### PR TITLE
fix: add explicit dimensions to chart wrapper for proper rendering

### DIFF
--- a/src/components/ChartBase.tsx
+++ b/src/components/ChartBase.tsx
@@ -30,6 +30,7 @@ export function ChartBase({
     <div
       role="img"
       aria-label={ariaLabel || `Chart showing ${yAxisLabel} by ${xAxisLabel}`}
+      className="h-full w-full"
     >
       <XYChart
         theme={chartTheme}


### PR DESCRIPTION
## Summary

Fixes blank charts issue where all three charts (TotalRepaymentChart, RepaymentYearsChart, InterestRateChart) were rendering with 0 height.

## Changes

- Added `h-full w-full` Tailwind classes to the accessibility wrapper div in `ChartBase.tsx`

## Key Details

The accessibility wrapper `<div role="img">` added in commit 7fe766f had no explicit dimensions. Since `XYChart` from visx depends on its parent's dimensions to render, the chart collapsed to 0 height. Adding `h-full w-full` ensures the wrapper inherits dimensions from its parent container.

## Test Plan

1. Run `yarn dev`
2. Verify all three charts display correctly with data
3. Verify tooltips work on hover
4. Verify current salary annotation line appears