### PR TITLE
chore: remove duplicate robots.txt and sitemap.xml from public

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,0 @@
-User-agent: *
-Allow: /
-Sitemap: https://studentloanstudy.uk/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  <url>
-    <loc>https://studentloanstudy.uk</loc>
-  </url>
-</urlset>


### PR DESCRIPTION
## Summary

Remove static `robots.txt` and `sitemap.xml` from `public/` as they duplicate the App Router metadata API files (`src/app/robots.ts` and `src/app/sitemap.ts`).

## Context

Next.js App Router's metadata API takes precedence over static files in `public/`. The dynamic `.ts` versions are preferred because they can generate content at build/request time (e.g., `sitemap.ts` sets `lastModified: new Date()`). Keeping both is redundant and potentially confusing.