### PR TITLE
fix: resolve layout overflow and add max-width constraint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ pnpm test          # Run tests in watch mode
 pnpm test:coverage # Run tests with coverage report
 ```
 
+Do not run `pnpm dev` unless otherwise told to, expect a dev server to be already running during development.
+
 Run a single test file:
 
 ```bash

--- a/src/components/ChartsGrid.tsx
+++ b/src/components/ChartsGrid.tsx
@@ -7,7 +7,7 @@ const TotalRepaymentChart = lazy(() => import("./TotalRepaymentChart"));
 
 export function ChartsGrid() {
   return (
-    <div className="grid gap-4 sm:grid-cols-[repeat(auto-fill,minmax(600px,1fr))] lg:grid-cols-[repeat(auto-fill,minmax(700px,1fr))] xl:grid-cols-[repeat(auto-fill,minmax(800px,1fr))]">
+    <div className="grid gap-4">
       <div className="flex flex-col p-4 lg:p-8">
         <div className="flex-grow">
           <h2 className="text-lg font-bold">How much do you repay in total?</h2>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -23,7 +23,7 @@ export function Header() {
       >
         Skip to main content
       </a>
-      <div className="container flex h-14 items-center px-4">
+      <div className="mx-auto flex h-14 max-w-screen-2xl items-center px-4 md:px-6">
         <h1 className="text-lg font-bold">UK Student Loan Study</h1>
       </div>
     </header>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,7 +5,7 @@ interface LayoutProps {
 
 export function Layout({ stickyPanel, content }: LayoutProps) {
   return (
-    <div className="grid gap-4 px-4 pb-4 md:grid-cols-[400px_1fr] md:px-6 md:pb-6">
+    <div className="mx-auto grid max-w-screen-2xl gap-4 px-4 pb-4 md:grid-cols-[400px_1fr] md:px-6 md:pb-6">
       <aside className="relative h-full" aria-label="Loan configuration panel">
         <div className="sticky top-14 max-h-[calc(100vh-3.5rem)] overflow-auto px-1 pb-1 pt-4">
           {stickyPanel}


### PR DESCRIPTION
## Summary

Fixes horizontal scrollbar appearing at narrow viewport widths (640-768px range) and adds a max-width constraint so content doesn't expand infinitely on wide screens.

## Context

The `container` class in Header caused max-width jumps at breakpoints that didn't match the main content layout. The ChartsGrid used `minmax(600px, 1fr)` which overflowed when viewport was 640-700px after accounting for padding. Neither Header nor Layout had max-width constraints for large screens.

Changes:
- Header: Replace `container` with explicit `max-w-screen-2xl mx-auto` and consistent padding
- Layout: Add `max-w-screen-2xl mx-auto` to match Header
- ChartsGrid: Simplify to single-column grid since max-width constraint means content area only fits one chart column anyway