### PR TITLE
fix: make charts responsive to window resize

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@react-spring/web": "^10.0.3",
     "@vercel/analytics": "^1.6.1",
     "@visx/pattern": "4.0.1-alpha.0",
+    "@visx/responsive": "4.0.1-alpha.0",
     "@visx/xychart": "4.0.1-alpha.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@visx/pattern':
         specifier: 4.0.1-alpha.0
         version: 4.0.1-alpha.0(react@19.2.4)
+      '@visx/responsive':
+        specifier: 4.0.1-alpha.0
+        version: 4.0.1-alpha.0(react@19.2.4)
       '@visx/xychart':
         specifier: 4.0.1-alpha.0
         version: 4.0.1-alpha.0(@react-spring/web@10.0.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/src/components/ChartBase.tsx
+++ b/src/components/ChartBase.tsx
@@ -1,4 +1,5 @@
 import { PatternLines } from "@visx/pattern";
+import { ParentSize } from "@visx/responsive";
 import {
   AnimatedAnnotation,
   AnimatedAreaSeries,
@@ -30,55 +31,63 @@ export function ChartBase({
     <div
       role="img"
       aria-label={ariaLabel || `Chart showing ${yAxisLabel} by ${xAxisLabel}`}
-      className="h-full w-full"
+      className="h-full w-full overflow-hidden"
     >
-      <XYChart
-        theme={chartTheme}
-        xScale={{ type: "band" }}
-        yScale={{ type: "linear" }}
-        margin={{ top: 20, right: 20, bottom: 50, left: 80 }}
-        accessibilityLabel={ariaLabel || `${yAxisLabel} by ${xAxisLabel}`}
-      >
-        <CustomChartBackground />
-        <AnimatedAxis
-          orientation="left"
-          label={yAxisLabel}
-          labelOffset={40}
-          numTicks={3}
-          tickFormat={yFormatter}
-        />
-        <CustomBottomAxis label={xAxisLabel} tickFormat={xFormatter} />
-        <AnimatedAreaSeries
-          dataKey="default"
-          data={data}
-          xAccessor={xAccessor}
-          yAccessor={yAccessor}
-          strokeWidth={2}
-          fillOpacity={0.4}
-        />
-        <Tooltip<DataPoint>
-          snapTooltipToDatumX
-          snapTooltipToDatumY
-          showVerticalCrosshair
-          renderTooltip={({ tooltipData }) =>
-            tooltipData?.nearestDatum && (
-              <>
-                <div>
-                  {xAxisLabel}: {xFormatter(tooltipData.nearestDatum.datum[0])}
-                </div>
-                <div>
-                  {yAxisLabel}: {yFormatter(tooltipData.nearestDatum.datum[1])}
-                </div>
-              </>
-            )
-          }
-        />
-        {annotateDataPoint && (
-          <AnimatedAnnotation dataKey="default" datum={annotateDataPoint}>
-            <AnnotationLineSubject orientation="vertical" />
-          </AnimatedAnnotation>
+      <ParentSize>
+        {({ width, height }) => (
+          <XYChart
+            theme={chartTheme}
+            width={width}
+            height={height}
+            xScale={{ type: "band" }}
+            yScale={{ type: "linear" }}
+            margin={{ top: 20, right: 20, bottom: 50, left: 80 }}
+            accessibilityLabel={ariaLabel || `${yAxisLabel} by ${xAxisLabel}`}
+          >
+            <CustomChartBackground />
+            <AnimatedAxis
+              orientation="left"
+              label={yAxisLabel}
+              labelOffset={40}
+              numTicks={3}
+              tickFormat={yFormatter}
+            />
+            <CustomBottomAxis label={xAxisLabel} tickFormat={xFormatter} />
+            <AnimatedAreaSeries
+              dataKey="default"
+              data={data}
+              xAccessor={xAccessor}
+              yAccessor={yAccessor}
+              strokeWidth={2}
+              fillOpacity={0.4}
+            />
+            <Tooltip<DataPoint>
+              snapTooltipToDatumX
+              snapTooltipToDatumY
+              showVerticalCrosshair
+              renderTooltip={({ tooltipData }) =>
+                tooltipData?.nearestDatum && (
+                  <>
+                    <div>
+                      {xAxisLabel}:{" "}
+                      {xFormatter(tooltipData.nearestDatum.datum[0])}
+                    </div>
+                    <div>
+                      {yAxisLabel}:{" "}
+                      {yFormatter(tooltipData.nearestDatum.datum[1])}
+                    </div>
+                  </>
+                )
+              }
+            />
+            {annotateDataPoint && (
+              <AnimatedAnnotation dataKey="default" datum={annotateDataPoint}>
+                <AnnotationLineSubject orientation="vertical" />
+              </AnimatedAnnotation>
+            )}
+          </XYChart>
         )}
-      </XYChart>
+      </ParentSize>
     </div>
   );
 }

--- a/src/components/ChartsGrid.tsx
+++ b/src/components/ChartsGrid.tsx
@@ -7,8 +7,8 @@ const TotalRepaymentChart = lazy(() => import("./TotalRepaymentChart"));
 
 export function ChartsGrid() {
   return (
-    <div className="grid gap-4">
-      <div className="flex flex-col p-4 lg:p-8">
+    <div className="grid min-w-0 gap-4">
+      <div className="flex min-w-0 flex-col p-4 lg:p-8">
         <div className="flex-grow">
           <h2 className="text-lg font-bold">How much do you repay in total?</h2>
           <p className="text-muted-foreground">
@@ -29,7 +29,7 @@ export function ChartsGrid() {
           </Suspense>
         </div>
       </div>
-      <div className="flex flex-col p-4 lg:p-8">
+      <div className="flex min-w-0 flex-col p-4 lg:p-8">
         <div className="flex-grow">
           <h2 className="text-lg font-bold">
             How long does it take to pay off your student loan?
@@ -50,7 +50,7 @@ export function ChartsGrid() {
           </Suspense>
         </div>
       </div>
-      <div className="flex flex-col p-4 lg:p-8">
+      <div className="flex min-w-0 flex-col p-4 lg:p-8">
         <div className="flex-grow">
           <h2 className="text-lg font-bold">
             Is it worth paying off student loan early?

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -11,8 +11,8 @@ export function Layout({ stickyPanel, content }: LayoutProps) {
           {stickyPanel}
         </div>
       </aside>
-      <main id="main-content" className="pt-4">
-        <div className="rounded-lg border bg-card p-4">{content}</div>
+      <main id="main-content" className="min-w-0 pt-4">
+        <div className="min-w-0 rounded-lg border bg-card p-4">{content}</div>
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary

Charts were not shrinking when the browser window was resized to a smaller width. This was caused by visx's XYChart relying on implicit sizing combined with CSS Grid/Flexbox's default `min-width: auto` behavior allowing content to overflow containers.

## Context

The fix has two parts:
1. Wrap XYChart with `ParentSize` from `@visx/responsive` to provide explicit width/height based on the container size
2. Add `min-w-0` throughout the container hierarchy (Layout, ChartsGrid) to override the default min-width behavior and allow elements to shrink below their content size