### PR TITLE
fix: improve chart annotation and tooltip UX

### DIFF
--- a/src/components/ChartBase.tsx
+++ b/src/components/ChartBase.tsx
@@ -55,6 +55,8 @@ export function ChartBase({
       role="img"
       aria-label={ariaLabel || `Chart showing ${yAxisLabel} by ${xAxisLabel}`}
       className="h-full w-full overflow-hidden select-none touch-pinch-zoom"
+      onMouseEnter={() => setIsTooltipActive(true)}
+      onMouseLeave={() => setIsTooltipActive(false)}
       onTouchStart={() => setIsTooltipActive(true)}
       onTouchEnd={() => setIsTooltipActive(false)}
     >
@@ -63,10 +65,6 @@ export function ChartBase({
           data={data}
           accessibilityLayer
           margin={{ top: 5, right: 5, bottom: 25, left: 25 }}
-          onMouseMove={(state) => {
-            setIsTooltipActive(state?.activePayload != null);
-          }}
-          onMouseLeave={() => setIsTooltipActive(false)}
         >
           <defs>
             <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">


### PR DESCRIPTION
## Summary

Fixes three chart UX issues: annotation labels getting cut off at chart edges, visual confusion from annotation and tooltip appearing simultaneously, and page scrolling when interacting with charts on mobile.

## Context

- Annotation labels now dynamically offset away from edges (left 25% pushes right, right 75% pushes left)
- Annotations (line and dot) hide when tooltip is active, preventing visual clutter
- Mobile touch events now properly control tooltip state, and `touch-pinch-zoom` allows zooming while preventing scroll interference
- Annotation dot styling simplified to match the chart's active dot