### PR TITLE
fix: enable scrolling in settings panel on small screens

### DIFF
--- a/src/components/AssumptionsFooter.tsx
+++ b/src/components/AssumptionsFooter.tsx
@@ -33,8 +33,10 @@ export function AssumptionsFooter() {
     <div className="sticky bottom-0 z-40">
       {/* Expandable Panel */}
       <div
-        className={`bg-background/95 overflow-hidden border-t backdrop-blur-sm transition-all duration-300 ease-out ${
-          isOpen ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0"
+        className={`bg-background/95 border-t backdrop-blur-sm transition-all duration-300 ease-out ${
+          isOpen
+            ? "max-h-[calc((100dvh-6.5rem)*0.9)] overflow-y-auto opacity-100"
+            : "max-h-0 overflow-hidden opacity-0"
         }`}
       >
         <div className="mx-auto max-w-4xl px-4 py-6 md:px-6">


### PR DESCRIPTION
## Summary

On small screens, the settings panel had a fixed max-height of 500px with `overflow-hidden`, which prevented scrolling and made some input fields (like Postgraduate Rate) inaccessible.

This fix makes the panel scrollable when open by using `overflow-y-auto` and calculates the max-height dynamically based on viewport height (`90% of (100dvh - 6.5rem)`), accounting for the header and footer.

## Context

The 6.5rem offset accounts for the header (3rem) and footer bar (~3.5rem), ensuring the panel never overlaps these elements. Using `dvh` units handles mobile browsers where the viewport can change (e.g., address bar show/hide).