### PR TITLE
refactor: remove lazy loading for SSG/SEO

### DIFF
--- a/src/components/AdvancedInputs.tsx
+++ b/src/components/AdvancedInputs.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import { lazy, Suspense } from "react";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
-import { Skeleton } from "@/components/ui/skeleton";
 import { useStore } from "@/store";
-
-const CurrencyInput = lazy(() => import("./CurrencyInput"));
-const PercentageInput = lazy(() => import("./PercentageInput"));
-const DateInput = lazy(() => import("./DateInput"));
+import CurrencyInput from "./CurrencyInput";
+import PercentageInput from "./PercentageInput";
+import DateInput from "./DateInput";
 
 export function AdvancedInputs() {
   const store = useStore();
@@ -19,23 +16,19 @@ export function AdvancedInputs() {
       <div className="space-y-4">
         <h4 className="text-sm font-medium">Loan Details</h4>
         <div className="grid gap-4 sm:grid-cols-2">
-          <Suspense fallback={<Skeleton className="h-14 w-full" />}>
-            <CurrencyInput
-              id="adv-postgrad-balance"
-              label="Postgraduate Loan Balance"
-              value={store.postGradBalance}
-              onChange={(value) => store.updateField("postGradBalance", value)}
-            />
-          </Suspense>
-          <Suspense fallback={<Skeleton className="h-14 w-full" />}>
-            <DateInput
-              id="adv-repayment-date"
-              label="Repayment Start Date"
-              helperText="Determines when your loan is written off."
-              value={store.repaymentDate}
-              onChange={(value) => store.updateField("repaymentDate", value)}
-            />
-          </Suspense>
+          <CurrencyInput
+            id="adv-postgrad-balance"
+            label="Postgraduate Loan Balance"
+            value={store.postGradBalance}
+            onChange={(value) => store.updateField("postGradBalance", value)}
+          />
+          <DateInput
+            id="adv-repayment-date"
+            label="Repayment Start Date"
+            helperText="Determines when your loan is written off."
+            value={store.repaymentDate}
+            onChange={(value) => store.updateField("repaymentDate", value)}
+          />
         </div>
         <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
           <div className="space-y-0.5">
@@ -61,42 +54,34 @@ export function AdvancedInputs() {
         <div className="grid gap-4 sm:grid-cols-2">
           {!store.isPost2023 && (
             <>
-              <Suspense fallback={<Skeleton className="h-14 w-full" />}>
-                <PercentageInput
-                  id="adv-plan2-lt-rate"
-                  label="Plan 2 Lower Threshold Rate"
-                  value={store.plan2LTRate}
-                  onChange={(value) => store.updateField("plan2LTRate", value)}
-                />
-              </Suspense>
-              <Suspense fallback={<Skeleton className="h-14 w-full" />}>
-                <PercentageInput
-                  id="adv-plan2-ut-rate"
-                  label="Plan 2 Upper Threshold Rate"
-                  value={store.plan2UTRate}
-                  onChange={(value) => store.updateField("plan2UTRate", value)}
-                />
-              </Suspense>
+              <PercentageInput
+                id="adv-plan2-lt-rate"
+                label="Plan 2 Lower Threshold Rate"
+                value={store.plan2LTRate}
+                onChange={(value) => store.updateField("plan2LTRate", value)}
+              />
+              <PercentageInput
+                id="adv-plan2-ut-rate"
+                label="Plan 2 Upper Threshold Rate"
+                value={store.plan2UTRate}
+                onChange={(value) => store.updateField("plan2UTRate", value)}
+              />
             </>
           )}
           {store.isPost2023 && (
-            <Suspense fallback={<Skeleton className="h-14 w-full" />}>
-              <PercentageInput
-                id="adv-plan5-rate"
-                label="Plan 5 Interest Rate (RPI)"
-                value={store.plan5Rate}
-                onChange={(value) => store.updateField("plan5Rate", value)}
-              />
-            </Suspense>
-          )}
-          <Suspense fallback={<Skeleton className="h-14 w-full" />}>
             <PercentageInput
-              id="adv-postgrad-rate"
-              label="Postgraduate Rate"
-              value={store.postGradRate}
-              onChange={(value) => store.updateField("postGradRate", value)}
+              id="adv-plan5-rate"
+              label="Plan 5 Interest Rate (RPI)"
+              value={store.plan5Rate}
+              onChange={(value) => store.updateField("plan5Rate", value)}
             />
-          </Suspense>
+          )}
+          <PercentageInput
+            id="adv-postgrad-rate"
+            label="Postgraduate Rate"
+            value={store.postGradRate}
+            onChange={(value) => store.updateField("postGradRate", value)}
+          />
         </div>
       </div>
     </div>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,10 +1,7 @@
-import { lazy, Suspense } from "react";
 import { Header } from "./Header";
 import { HeroSection } from "./HeroSection";
-import { Skeleton } from "./ui/skeleton";
-
-const SecondaryCharts = lazy(() => import("./SecondaryCharts"));
-const AssumptionsFooter = lazy(() => import("./AssumptionsFooter"));
+import SecondaryCharts from "./SecondaryCharts";
+import AssumptionsFooter from "./AssumptionsFooter";
 
 function App() {
   return (
@@ -16,13 +13,9 @@ function App() {
       >
         <HeroSection />
 
-        <Suspense fallback={<Skeleton className="h-96 w-full" />}>
-          <SecondaryCharts />
-        </Suspense>
+        <SecondaryCharts />
       </main>
-      <Suspense fallback={<Skeleton className="h-12 w-full" />}>
-        <AssumptionsFooter />
-      </Suspense>
+      <AssumptionsFooter />
     </div>
   );
 }

--- a/src/components/AssumptionsFooter.tsx
+++ b/src/components/AssumptionsFooter.tsx
@@ -1,16 +1,14 @@
 "use client";
 
-import { lazy, Suspense, useState } from "react";
+import { useState } from "react";
 import { useStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import { currencyFormatter } from "@/constants";
 import { PLAN2_LT, PLAN5_MONTHLY_THRESHOLD } from "@/constants";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Cancel01Icon, Settings02Icon } from "@hugeicons/core-free-icons";
-
-const AdvancedInputs = lazy(() => import("./AdvancedInputs"));
+import AdvancedInputs from "./AdvancedInputs";
 
 export function AssumptionsFooter() {
   const [isOpen, setIsOpen] = useState(false);
@@ -57,9 +55,7 @@ export function AssumptionsFooter() {
           </div>
 
           {/* Panel Content */}
-          <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-            <AdvancedInputs />
-          </Suspense>
+          <AdvancedInputs />
         </div>
       </div>
 

--- a/src/components/ChartsGrid.tsx
+++ b/src/components/ChartsGrid.tsx
@@ -1,9 +1,6 @@
-import { lazy, Suspense } from "react";
-import { Skeleton } from "@/components/ui/skeleton";
-
-const InterestRateChart = lazy(() => import("./InterestRateChart"));
-const RepaymentYearsChart = lazy(() => import("./RepaymentYearsChart"));
-const TotalRepaymentChart = lazy(() => import("./TotalRepaymentChart"));
+import InterestRateChart from "./InterestRateChart";
+import RepaymentYearsChart from "./RepaymentYearsChart";
+import TotalRepaymentChart from "./TotalRepaymentChart";
 
 export function ChartsGrid() {
   return (
@@ -24,9 +21,7 @@ export function ChartsGrid() {
           </p>
         </div>
         <div className="h-[300px] sm:h-[400px] lg:h-[450px] lg:p-4 xl:h-[600px]">
-          <Suspense fallback={<Skeleton className="h-full w-full" />}>
-            <TotalRepaymentChart />
-          </Suspense>
+          <TotalRepaymentChart />
         </div>
       </div>
       <div className="flex min-w-0 flex-col p-4 lg:p-8">
@@ -45,9 +40,7 @@ export function ChartsGrid() {
           </p>
         </div>
         <div className="h-[300px] sm:h-[400px] lg:h-[450px] lg:p-4 xl:h-[600px]">
-          <Suspense fallback={<Skeleton className="h-full w-full" />}>
-            <RepaymentYearsChart />
-          </Suspense>
+          <RepaymentYearsChart />
         </div>
       </div>
       <div className="flex min-w-0 flex-col p-4 lg:p-8">
@@ -67,9 +60,7 @@ export function ChartsGrid() {
           </p>
         </div>
         <div className="h-[300px] sm:h-[400px] lg:h-[450px] lg:p-4 xl:h-[600px]">
-          <Suspense fallback={<Skeleton className="h-full w-full" />}>
-            <InterestRateChart />
-          </Suspense>
+          <InterestRateChart />
         </div>
       </div>
     </div>

--- a/src/components/ConfigPanel.tsx
+++ b/src/components/ConfigPanel.tsx
@@ -1,4 +1,3 @@
-import { lazy, Suspense } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Accordion,
@@ -8,12 +7,10 @@ import {
 } from "@/components/ui/accordion";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
-import { Skeleton } from "@/components/ui/skeleton";
 import { useStore } from "../store";
-
-const CurrencyInput = lazy(() => import("./CurrencyInput"));
-const PercentageInput = lazy(() => import("./PercentageInput"));
-const DateInput = lazy(() => import("./DateInput"));
+import CurrencyInput from "./CurrencyInput";
+import PercentageInput from "./PercentageInput";
+import DateInput from "./DateInput";
 
 export function ConfigPanel() {
   const store = useStore();
@@ -25,31 +22,25 @@ export function ConfigPanel() {
           <CardTitle>Student Loan Balance</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <Suspense fallback={<Skeleton className="h-14 w-full" />}>
-            <CurrencyInput
-              id="undergrad-balance"
-              label="Undergraduate Loan Balance (plan 2 or plan 5)"
-              value={store.underGradBalance}
-              onChange={(value) => store.updateField("underGradBalance", value)}
-            />
-          </Suspense>
-          <Suspense fallback={<Skeleton className="h-14 w-full" />}>
-            <CurrencyInput
-              id="postgrad-balance"
-              label="Postgraduate Loan Balance"
-              value={store.postGradBalance}
-              onChange={(value) => store.updateField("postGradBalance", value)}
-            />
-          </Suspense>
-          <Suspense fallback={<Skeleton className="h-14 w-full" />}>
-            <DateInput
-              id="repayment-date"
-              label="Date Repayment Started"
-              helperText="This determines when your loan is written off."
-              value={store.repaymentDate}
-              onChange={(value) => store.updateField("repaymentDate", value)}
-            />
-          </Suspense>
+          <CurrencyInput
+            id="undergrad-balance"
+            label="Undergraduate Loan Balance (plan 2 or plan 5)"
+            value={store.underGradBalance}
+            onChange={(value) => store.updateField("underGradBalance", value)}
+          />
+          <CurrencyInput
+            id="postgrad-balance"
+            label="Postgraduate Loan Balance"
+            value={store.postGradBalance}
+            onChange={(value) => store.updateField("postGradBalance", value)}
+          />
+          <DateInput
+            id="repayment-date"
+            label="Date Repayment Started"
+            helperText="This determines when your loan is written off."
+            value={store.repaymentDate}
+            onChange={(value) => store.updateField("repaymentDate", value)}
+          />
           <div className="flex items-center justify-between gap-4">
             <div className="space-y-0.5">
               <Label htmlFor="post-2023">Post 2023</Label>
@@ -77,63 +68,49 @@ export function ConfigPanel() {
               <AccordionContent className="space-y-4">
                 {!store.isPost2023 && (
                   <>
-                    <Suspense fallback={<Skeleton className="h-14 w-full" />}>
-                      <PercentageInput
-                        id="plan2-lt-rate"
-                        label="Plan 2 Lower Threshold Rate"
-                        value={store.plan2LTRate}
-                        onChange={(value) =>
-                          store.updateField("plan2LTRate", value)
-                        }
-                      />
-                    </Suspense>
-                    <Suspense fallback={<Skeleton className="h-14 w-full" />}>
-                      <PercentageInput
-                        id="plan2-ut-rate"
-                        label="Plan 2 Upper Threshold Rate"
-                        value={store.plan2UTRate}
-                        onChange={(value) =>
-                          store.updateField("plan2UTRate", value)
-                        }
-                      />
-                    </Suspense>
+                    <PercentageInput
+                      id="plan2-lt-rate"
+                      label="Plan 2 Lower Threshold Rate"
+                      value={store.plan2LTRate}
+                      onChange={(value) =>
+                        store.updateField("plan2LTRate", value)
+                      }
+                    />
+                    <PercentageInput
+                      id="plan2-ut-rate"
+                      label="Plan 2 Upper Threshold Rate"
+                      value={store.plan2UTRate}
+                      onChange={(value) =>
+                        store.updateField("plan2UTRate", value)
+                      }
+                    />
                   </>
                 )}
                 {store.isPost2023 && (
-                  <Suspense fallback={<Skeleton className="h-14 w-full" />}>
-                    <PercentageInput
-                      id="plan5-rate"
-                      label="Plan 5 Interest Rate (RPI)"
-                      value={store.plan5Rate}
-                      onChange={(value) =>
-                        store.updateField("plan5Rate", value)
-                      }
-                    />
-                  </Suspense>
-                )}
-                <Suspense fallback={<Skeleton className="h-14 w-full" />}>
                   <PercentageInput
-                    id="postgrad-rate"
-                    label="Postgraduate Rate"
-                    value={store.postGradRate}
-                    onChange={(value) =>
-                      store.updateField("postGradRate", value)
-                    }
+                    id="plan5-rate"
+                    label="Plan 5 Interest Rate (RPI)"
+                    value={store.plan5Rate}
+                    onChange={(value) => store.updateField("plan5Rate", value)}
                   />
-                </Suspense>
+                )}
+                <PercentageInput
+                  id="postgrad-rate"
+                  label="Postgraduate Rate"
+                  value={store.postGradRate}
+                  onChange={(value) => store.updateField("postGradRate", value)}
+                />
               </AccordionContent>
             </AccordionItem>
             <AccordionItem value={1}>
               <AccordionTrigger>Earnings</AccordionTrigger>
               <AccordionContent className="space-y-4">
-                <Suspense fallback={<Skeleton className="h-14 w-full" />}>
-                  <CurrencyInput
-                    id="earning"
-                    label="Your current Pre-Tax Salary"
-                    value={store.salary}
-                    onChange={(value) => store.updateField("salary", value)}
-                  />
-                </Suspense>
+                <CurrencyInput
+                  id="earning"
+                  label="Your current Pre-Tax Salary"
+                  value={store.salary}
+                  onChange={(value) => store.updateField("salary", value)}
+                />
               </AccordionContent>
             </AccordionItem>
           </Accordion>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import { lazy, Suspense } from "react";
-import { Skeleton } from "@/components/ui/skeleton";
 import { QuickInputs } from "./QuickInputs";
 import { InsightCallout } from "./InsightCallout";
-
-const TotalRepaymentChart = lazy(() => import("./TotalRepaymentChart"));
+import TotalRepaymentChart from "./TotalRepaymentChart";
 
 export function HeroSection() {
   return (
@@ -22,9 +19,7 @@ export function HeroSection() {
       </div>
 
       <div className="h-[300px] sm:h-[400px] lg:h-[450px]">
-        <Suspense fallback={<Skeleton className="h-full w-full" />}>
-          <TotalRepaymentChart />
-        </Suspense>
+        <TotalRepaymentChart />
       </div>
 
       <QuickInputs />

--- a/src/components/QuickInputs.tsx
+++ b/src/components/QuickInputs.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { lazy, Suspense, useCallback } from "react";
+import { useCallback } from "react";
 import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
-import { Skeleton } from "@/components/ui/skeleton";
 import { useStore } from "@/store";
 import {
   MIN_SALARY,
@@ -11,8 +10,7 @@ import {
   SALARY_STEP,
   currencyFormatter,
 } from "@/constants";
-
-const CurrencyInput = lazy(() => import("./CurrencyInput"));
+import CurrencyInput from "./CurrencyInput";
 
 export function QuickInputs() {
   const salary = useStore((state) => state.salary);
@@ -59,14 +57,12 @@ export function QuickInputs() {
       </div>
 
       <div className="w-full sm:w-48">
-        <Suspense fallback={<Skeleton className="h-14 w-full" />}>
-          <CurrencyInput
-            id="quick-balance"
-            label="Loan Balance"
-            value={underGradBalance}
-            onChange={handleBalanceChange}
-          />
-        </Suspense>
+        <CurrencyInput
+          id="quick-balance"
+          label="Loan Balance"
+          value={underGradBalance}
+          onChange={handleBalanceChange}
+        />
       </div>
     </div>
   );

--- a/src/components/SecondaryCharts.tsx
+++ b/src/components/SecondaryCharts.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import { lazy, Suspense } from "react";
-import { Skeleton } from "@/components/ui/skeleton";
-
-const RepaymentYearsChart = lazy(() => import("./RepaymentYearsChart"));
-const InterestRateChart = lazy(() => import("./InterestRateChart"));
+import RepaymentYearsChart from "./RepaymentYearsChart";
+import InterestRateChart from "./InterestRateChart";
 
 export function SecondaryCharts() {
   return (
@@ -17,9 +14,7 @@ export function SecondaryCharts() {
           years of payments.
         </p>
         <div className="h-[300px] sm:h-[350px]">
-          <Suspense fallback={<Skeleton className="h-full w-full" />}>
-            <RepaymentYearsChart />
-          </Suspense>
+          <RepaymentYearsChart />
         </div>
       </section>
 
@@ -30,9 +25,7 @@ export function SecondaryCharts() {
           Lower earners often have negative effective rates due to write-off.
         </p>
         <div className="h-[300px] sm:h-[350px]">
-          <Suspense fallback={<Skeleton className="h-full w-full" />}>
-            <InterestRateChart />
-          </Suspense>
+          <InterestRateChart />
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary

React.lazy() is client-side only, which means lazy-loaded components render as skeleton placeholders during static site generation. This causes search engines to see empty content instead of the actual page markup. This PR replaces all lazy imports with static imports so components are fully server-rendered in the initial HTML.

## Context

The affected components (charts, input fields, footer) are small enough that the overhead of lazy loading (extra HTTP requests, skeleton flashes, code complexity) isn't worth the trade-off against SEO and initial render quality.