### PR TITLE
refactor: move loan balance input to advanced settings

### DIFF
--- a/src/components/AdvancedInputs.tsx
+++ b/src/components/AdvancedInputs.tsx
@@ -17,6 +17,12 @@ export function AdvancedInputs() {
         <h4 className="text-sm font-medium">Loan Details</h4>
         <div className="grid gap-4 sm:grid-cols-2">
           <CurrencyInput
+            id="adv-undergrad-balance"
+            label="Undergraduate Loan Balance"
+            value={store.underGradBalance}
+            onChange={(value) => store.updateField("underGradBalance", value)}
+          />
+          <CurrencyInput
             id="adv-postgrad-balance"
             label="Postgraduate Loan Balance"
             value={store.postGradBalance}

--- a/src/components/AssumptionsFooter.tsx
+++ b/src/components/AssumptionsFooter.tsx
@@ -13,11 +13,12 @@ import AdvancedInputs from "./AdvancedInputs";
 export function AssumptionsFooter() {
   const [isOpen, setIsOpen] = useState(false);
 
-  const { isPost2023, plan2UTRate, plan5Rate } = useStore(
+  const { isPost2023, plan2UTRate, plan5Rate, underGradBalance } = useStore(
     useShallow((state) => ({
       isPost2023: state.isPost2023,
       plan2UTRate: state.plan2UTRate,
       plan5Rate: state.plan5Rate,
+      underGradBalance: state.underGradBalance,
     })),
   );
 
@@ -26,6 +27,7 @@ export function AssumptionsFooter() {
     ? currencyFormatter.format(PLAN5_MONTHLY_THRESHOLD * 12)
     : currencyFormatter.format(PLAN2_LT);
   const rate = isPost2023 ? plan5Rate : plan2UTRate;
+  const balance = currencyFormatter.format(underGradBalance);
 
   return (
     <div className="sticky bottom-0 z-40">
@@ -66,6 +68,8 @@ export function AssumptionsFooter() {
         <div className="mx-auto flex max-w-4xl items-center justify-between gap-4 px-4 py-3 md:px-6">
           <p className="text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1 text-xs sm:text-sm">
             <span className="text-foreground font-medium">{planName}</span>
+            <span className="text-muted-foreground/50">•</span>
+            <span>{balance}</span>
             <span className="text-muted-foreground/50">•</span>
             <span>9% above {threshold}</span>
             <span className="text-muted-foreground/50">•</span>

--- a/src/components/QuickInputs.tsx
+++ b/src/components/QuickInputs.tsx
@@ -10,11 +10,9 @@ import {
   SALARY_STEP,
   currencyFormatter,
 } from "@/constants";
-import CurrencyInput from "./CurrencyInput";
 
 export function QuickInputs() {
   const salary = useStore((state) => state.salary);
-  const underGradBalance = useStore((state) => state.underGradBalance);
   const updateField = useStore((state) => state.updateField);
 
   const handleSalaryChange = useCallback(
@@ -25,44 +23,26 @@ export function QuickInputs() {
     [updateField],
   );
 
-  const handleBalanceChange = useCallback(
-    (value: number) => {
-      updateField("underGradBalance", value);
-    },
-    [updateField],
-  );
-
   return (
-    <div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:gap-8">
-      <div className="flex-1 space-y-2">
-        <div className="flex items-center justify-between">
-          <Label htmlFor="salary-slider">Your Salary</Label>
-          <span className="text-sm font-medium tabular-nums">
-            {currencyFormatter.format(salary)}
-          </span>
-        </div>
-        <Slider
-          id="salary-slider"
-          value={[salary]}
-          onValueChange={handleSalaryChange}
-          min={MIN_SALARY}
-          max={MAX_SALARY}
-          step={SALARY_STEP}
-          aria-label="Adjust your annual salary"
-        />
-        <div className="text-muted-foreground flex justify-between text-xs">
-          <span>{currencyFormatter.format(MIN_SALARY)}</span>
-          <span>{currencyFormatter.format(MAX_SALARY)}</span>
-        </div>
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <Label htmlFor="salary-slider">Your Salary</Label>
+        <span className="text-sm font-medium tabular-nums">
+          {currencyFormatter.format(salary)}
+        </span>
       </div>
-
-      <div className="w-full sm:w-48">
-        <CurrencyInput
-          id="quick-balance"
-          label="Loan Balance"
-          value={underGradBalance}
-          onChange={handleBalanceChange}
-        />
+      <Slider
+        id="salary-slider"
+        value={[salary]}
+        onValueChange={handleSalaryChange}
+        min={MIN_SALARY}
+        max={MAX_SALARY}
+        step={SALARY_STEP}
+        aria-label="Adjust your annual salary"
+      />
+      <div className="text-muted-foreground flex justify-between text-xs">
+        <span>{currencyFormatter.format(MIN_SALARY)}</span>
+        <span>{currencyFormatter.format(MAX_SALARY)}</span>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Moves the undergraduate loan balance input from the main QuickInputs area to the advanced settings panel, reducing upfront complexity for users. The loan balance is now displayed in the footer alongside plan type and interest rate for visibility without requiring the settings panel to be open.

## Context

The QuickInputs component is simplified to only contain the salary slider, making the primary interaction more focused. Users who need to adjust their loan balance can do so via the "Customize" settings panel.