### PR TITLE
refactor: use shadcn Alert component in InsightCallout

### DIFF
--- a/src/components/InsightCallout.tsx
+++ b/src/components/InsightCallout.tsx
@@ -6,27 +6,30 @@ import {
   Alert02Icon,
   Tick02Icon,
 } from "@hugeicons/core-free-icons";
-import { cn } from "@/lib/utils";
+import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
 import { usePersonalizedInsight } from "@/hooks/usePersonalizedInsight";
 import type { InsightType } from "@/utils/insights";
 
-const insightStyles: Record<
+const insightConfig: Record<
   InsightType,
-  { bg: string; border: string; icon: typeof InformationCircleIcon }
+  {
+    className: string;
+    icon: typeof InformationCircleIcon;
+  }
 > = {
   "low-earner": {
-    bg: "bg-blue-50 dark:bg-blue-950/30",
-    border: "border-blue-200 dark:border-blue-800",
+    className:
+      "bg-blue-50 dark:bg-blue-950/30 border-blue-200 dark:border-blue-800",
     icon: InformationCircleIcon,
   },
   "middle-earner": {
-    bg: "bg-amber-50 dark:bg-amber-950/30",
-    border: "border-amber-200 dark:border-amber-800",
+    className:
+      "bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-800",
     icon: Alert02Icon,
   },
   "high-earner": {
-    bg: "bg-green-50 dark:bg-green-950/30",
-    border: "border-green-200 dark:border-green-800",
+    className:
+      "bg-emerald-50 dark:bg-emerald-950/20 border-emerald-200 dark:border-emerald-800",
     icon: Tick02Icon,
   },
 };
@@ -38,28 +41,18 @@ export function InsightCallout() {
     return null;
   }
 
-  const styles = insightStyles[insight.type];
+  const config = insightConfig[insight.type];
 
   return (
-    <div
-      className={cn(
-        "flex gap-3 rounded-lg border p-4",
-        styles.bg,
-        styles.border,
-      )}
-      role="status"
-      aria-live="polite"
-    >
+    <Alert className={config.className} role="status" aria-live="polite">
       <HugeiconsIcon
-        icon={styles.icon}
-        className="text-foreground/70 mt-0.5 size-5 shrink-0"
+        icon={config.icon}
+        className="text-foreground/70 size-5"
         strokeWidth={2}
       />
-      <div className="space-y-1">
-        <p className="text-sm font-medium">{insight.title}</p>
-        <p className="text-muted-foreground text-sm">{insight.description}</p>
-      </div>
-    </div>
+      <AlertTitle>{insight.title}</AlertTitle>
+      <AlertDescription>{insight.description}</AlertDescription>
+    </Alert>
   );
 }
 

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const alertVariants = cva(
+  "grid gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4 w-full relative group/alert",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "text-destructive bg-card *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-muted-foreground text-sm text-balance md:text-pretty [&_p:not(:last-child)]:mb-4 [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-action"
+      className={cn("absolute top-2 right-2", className)}
+      {...props}
+    />
+  );
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertAction };


### PR DESCRIPTION
## Summary

Refactors InsightCallout to use the shadcn Alert component instead of custom div-based styling, improving consistency with the project's UI component library. Also updates the color variants: middle-earner insights now use red (more urgent) and high-earner insights use a lighter emerald green.

## Context

The custom styling was moved to InsightCallout's `insightConfig` rather than extending the base Alert component with custom variants, keeping the Alert component minimal and domain-agnostic until reuse is needed elsewhere.