### PR TITLE
docs: simplify CLAUDE.md to essential information

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,104 +1,30 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 ## Commands
 
 ```bash
-pnpm dev           # Start Next.js development server (http://localhost:3000)
+pnpm dev           # Start dev server (expect it to be already running)
 pnpm build         # Build for production
 pnpm lint          # Run ESLint
-pnpm format        # Format code with Prettier
-pnpm format:check  # Check formatting without modifying files
-pnpm test          # Run tests in watch mode
-pnpm test:coverage # Run tests with coverage report
-```
-
-Do not run `pnpm dev` unless otherwise told to, expect a dev server to be already running during development.
-
-Run a single test file:
-
-```bash
-pnpm test src/utils/__tests__/loan-calculations.test.ts
+pnpm format        # Format with Prettier
+pnpm test          # Run tests
 ```
 
 ## Architecture
 
-This is a UK student loan repayment calculator built with Next.js 16 (App Router), React 19, and TypeScript.
+UK student loan repayment calculator built with Next.js (App Router), React, and TypeScript.
 
-### Data Flow
+**Data flow**: React Context (`src/context/`) → loan simulation library (`src/lib/loans/`) → chart data hooks → chart components
 
-1. **Context** (`src/context/`): React Context with `useReducer` handles loan configuration state (`underGradPlanType`, `underGradBalance`, `postGradBalance`, `repaymentDate`, `salary`).
-   - `loanReducer.ts` - Pure reducer function, action creators, and initial state
-   - `LoanContext.tsx` - Context provider and `useLoanContext` hook
-   - `index.ts` - Barrel export
-
-2. **Store Selectors** (`src/hooks/useStoreSelectors.ts`): Builds `Loan[]` array from context state for calculations, plus current salary for annotations.
-
-3. **Loan Library** (`src/lib/loans/`): Core loan modeling logic:
-   - `plans.ts` - Configuration values for all UK loan plans (easy to update annually)
-   - `interest.ts` - Interest rate calculations per plan type
-   - `simulate.ts` - `simulateLoans()` runs repayment simulation
-   - `types.ts` - Type definitions (`PlanType`, `Loan`, `SimulationResult`, etc.)
-
-4. **Chart Utilities** (`src/utils/loan-calculations.ts`): Thin wrapper providing chart-specific functions:
-   - `generateSalaryDataSeries()` - Generates chart data by running simulations across salary range
-   - `calculateAnnualizedRate()` - Computes effective interest rate from simulation results
-
-5. **Chart Data Hooks** (`src/hooks/useChartData.ts`): Three hooks (`useTotalRepaymentData`, `useRepaymentYearsData`, `useInterestRateData`) each call `generateSalaryDataSeries` with appropriate mapper functions.
-
-6. **Insights** (`src/hooks/usePersonalizedInsight.ts`, `src/utils/insights.ts`): Generate personalized insights based on user's salary and loan configuration.
-
-7. **Chart Components**: `TotalRepaymentChart`, `RepaymentYearsChart`, `InterestRateChart` each use their corresponding hook and render via `ChartBase`.
-
-### Key Types (from `src/lib/loans/`)
-
-- `PlanType` - Union of all plan types: `"PLAN_1" | "PLAN_2" | "PLAN_4" | "PLAN_5" | "POSTGRADUATE"`
-- `Loan` - `{ planType, balance }` for a single loan
-- `SimulationResult` - Output with `loanResults[]`, `totalRepayment`, `totalMonths`
-- `LoanResult` - Per-loan result with `totalPaid`, `monthsToPayoff`, `remainingBalance`, `writtenOff`
-- `DataPoint` - `{ salary, value }` object for charts
-- `SimulationMapper` - Function extracting chart metric from `SimulationResult`
-
-### UI Structure
-
-- **App** - Main layout with Header, HeroSection, SecondaryCharts, and AssumptionsFooter
-- **HeroSection** - Primary content area with TotalRepaymentChart, QuickInputs, and InsightCallout
-- **SecondaryCharts** - Repayment years and interest rate charts
-- **QuickInputs** - Inline controls for salary, loan balance, and plan type
-- **InsightCallout** - Personalized insight based on user's inputs
-- **ChartBase** - Shared chart component using Recharts with Shadcn styling
-
-### Path Aliases
-
-`@/*` maps to `./src/*` (configured in tsconfig.json)
-
-### Loan Plan Differences
-
-All plan configurations are in `src/lib/loans/plans.ts` (update annually when GOV.UK announces changes):
-
-- **Plan 1** (pre-2012): 25-year write-off, min(RPI, BoE+1%) interest
-- **Plan 2** (2012-2023): 30-year write-off, sliding scale interest (RPI to RPI+3%)
-- **Plan 4** (Scotland): 30-year write-off, min(RPI, BoE+1%) interest
-- **Plan 5** (post-2023): 40-year write-off, RPI-only interest
-- **Postgraduate**: 30-year write-off, RPI+3% interest, 6% repayment rate, runs concurrently
+**Domain knowledge**: UK student loans have different plan types with varying thresholds, interest rates, and write-off periods. Plan configurations in `src/lib/loans/plans.ts` should be updated annually when GOV.UK announces changes.
 
 ## Code Quality Rules
 
-**NEVER use these - they hide real errors:**
+**Never use these:**
 
-- `eslint-disable` comments (any form)
+- `eslint-disable` comments
 - `any` type
 - `@ts-ignore` / `@ts-expect-error`
-- Type assertions that bypass safety (`as unknown as X`)
+- Unsafe type assertions (`as unknown as X`)
 
-If lint or TypeScript errors occur, fix the underlying issue properly. If genuinely stuck, stop and ask for guidance rather than suppressing the error.
-
-## Documentation Maintenance
-
-When making changes that affect architecture, dependencies, or UI structure:
-
-- Update this CLAUDE.md file to reflect those changes
-- Keep framework/library versions accurate
-- Document new components, hooks, or utilities
-- Remove references to deleted or deprecated code
+Fix underlying issues instead of suppressing errors.


### PR DESCRIPTION
## Summary

Reduces CLAUDE.md from 105 lines to 31 lines by removing detailed file paths, type definitions, and component listings that duplicate what's easily discoverable from the codebase.

## Context

Overly detailed documentation becomes a maintenance burden and quickly drifts out of sync with the code. The simplified version retains only what's genuinely useful: commands, high-level architecture, domain knowledge about annual updates, and code quality rules.