### PR TITLE
fix: show Y value in chart annotation instead of salary

### DIFF
--- a/src/components/ChartBase.tsx
+++ b/src/components/ChartBase.tsx
@@ -132,22 +132,24 @@ export function ChartBase({
             strokeWidth={2}
             activeDot={isTooltipActive}
           />
-          {annotationSalary !== undefined && !isTooltipActive && (
-            <ReferenceLine
-              x={annotationSalary}
-              stroke="rgba(255, 255, 255, 0.6)"
-              strokeWidth={1.5}
-              strokeDasharray="6 4"
-              label={{
-                value: xFormatter(annotationSalary),
-                position: "insideTop",
-                fill: "rgba(255, 255, 255, 0.9)",
-                fontSize: 11,
-                fontWeight: 500,
-                dx: getAnnotationLabelOffset(),
-              }}
-            />
-          )}
+          {annotationSalary !== undefined &&
+            annotationValue !== undefined &&
+            !isTooltipActive && (
+              <ReferenceLine
+                x={annotationSalary}
+                stroke="rgba(255, 255, 255, 0.6)"
+                strokeWidth={1.5}
+                strokeDasharray="6 4"
+                label={{
+                  value: yFormatter(annotationValue),
+                  position: "insideTop",
+                  fill: "rgba(255, 255, 255, 0.9)",
+                  fontSize: 11,
+                  fontWeight: 500,
+                  dx: getAnnotationLabelOffset(),
+                }}
+              />
+            )}
           {annotationSalary !== undefined &&
             annotationValue !== undefined &&
             !isTooltipActive && (


### PR DESCRIPTION
## Summary

The chart annotation label was displaying the selected salary, which is redundant since the salary slider already shows this value. Changed it to display the chart's Y value at the annotation point, giving users useful information they can't already see elsewhere.

## Context

When a user selects a salary via the slider, a vertical reference line appears on the chart. The label on this line now shows the actual chart value (e.g., total repayment amount) rather than echoing the salary.