### PR TITLE
fix: prevent panel expansion from affecting page layout

### DIFF
--- a/src/components/FloatingHeader.tsx
+++ b/src/components/FloatingHeader.tsx
@@ -12,6 +12,7 @@ import ThemeToggle from "./ThemeToggle";
 
 export function FloatingHeader() {
   const [isOpen, setIsOpen] = useState(false);
+  const [isFullyOpen, setIsFullyOpen] = useState(false);
   const headerRef = useRef<HTMLDivElement>(null);
 
   const { state } = useLoanContext();
@@ -40,6 +41,9 @@ export function FloatingHeader() {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isOpen]);
 
+  // Height of summary bar (py-2 = 0.5rem*2, plus content ~2.5rem, plus border)
+  const SUMMARY_HEIGHT = "4.5rem";
+
   return (
     <div className="sticky top-0 z-50 px-4 pt-3">
       <a
@@ -48,62 +52,77 @@ export function FloatingHeader() {
       >
         Skip to main content
       </a>
-      <header
-        ref={headerRef}
-        className="mx-auto max-w-4xl overflow-hidden rounded-xl border bg-muted/50 shadow-lg backdrop-blur-sm"
-      >
-        {/* Title and Summary Bar */}
-        <div className="py-2 pl-4 pr-2">
-          <h1 className="text-foreground text-base font-medium">
-            UK Student Loan Calculator
-          </h1>
-          <div className="mt-1 flex items-center gap-3">
-            {/* Scrollable tags container - hidden scrollbar */}
-            <div
-              className="min-w-0 flex-1 overflow-x-auto [&::-webkit-scrollbar]:hidden"
-              style={{ scrollbarWidth: "none" }}
-            >
-              <p className="text-muted-foreground flex items-center gap-2 whitespace-nowrap text-xs sm:text-sm">
-                <span>{planName}</span>
-                <span className="text-muted-foreground/50">•</span>
-                <span>{balance}</span>
-                <span className="text-muted-foreground/50">•</span>
-                <span>{rate}% interest</span>
-                <span className="text-muted-foreground/50">•</span>
-                <span>{writeOff} write-off</span>
-              </p>
-            </div>
-            {/* Theme toggle and settings button */}
-            <ThemeToggle />
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setIsOpen(!isOpen)}
-              className="shrink-0 gap-1.5"
-            >
-              <HugeiconsIcon
-                icon={isOpen ? Cancel01Icon : Settings02Icon}
-                className="size-4"
-                strokeWidth={2}
-              />
-              {isOpen ? "Close" : "Edit"}
-            </Button>
-          </div>
-        </div>
+      <div className="relative mx-auto max-w-4xl">
+        {/* Spacer - reserves layout space for the summary bar only */}
+        <div style={{ height: SUMMARY_HEIGHT }} aria-hidden="true" />
 
-        {/* Expandable Panel */}
-        <div
-          className={`overflow-hidden border-t transition-all duration-300 ease-out ${
-            isOpen
-              ? "max-h-[calc((100dvh-6rem)*0.85)] overflow-y-auto opacity-100"
-              : "max-h-0 border-t-transparent opacity-0"
-          }`}
+        {/* Absolutely positioned card - expands without affecting page layout */}
+        <header
+          ref={headerRef}
+          className="absolute inset-x-0 top-0 overflow-hidden rounded-xl border bg-muted/50 shadow-lg backdrop-blur-sm"
         >
-          <div className="px-4 py-6">
-            <AdvancedInputs />
+          {/* Title and Summary Bar */}
+          <div className="py-2 pl-4 pr-2">
+            <h1 className="text-foreground text-base font-medium">
+              UK Student Loan Calculator
+            </h1>
+            <div className="mt-1 flex items-center gap-3">
+              {/* Scrollable tags container - hidden scrollbar */}
+              <div
+                className="min-w-0 flex-1 overflow-x-auto [&::-webkit-scrollbar]:hidden"
+                style={{ scrollbarWidth: "none" }}
+              >
+                <p className="text-muted-foreground flex items-center gap-2 whitespace-nowrap text-xs sm:text-sm">
+                  <span>{planName}</span>
+                  <span className="text-muted-foreground/50">•</span>
+                  <span>{balance}</span>
+                  <span className="text-muted-foreground/50">•</span>
+                  <span>{rate}% interest</span>
+                  <span className="text-muted-foreground/50">•</span>
+                  <span>{writeOff} write-off</span>
+                </p>
+              </div>
+              {/* Theme toggle and settings button */}
+              <ThemeToggle />
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setIsOpen(!isOpen)}
+                className="shrink-0 gap-1.5"
+              >
+                <HugeiconsIcon
+                  icon={isOpen ? Cancel01Icon : Settings02Icon}
+                  className="size-4"
+                  strokeWidth={2}
+                />
+                {isOpen ? "Close" : "Edit"}
+              </Button>
+            </div>
           </div>
-        </div>
-      </header>
+
+          {/* Expandable Panel - inside the card for unified expand animation */}
+          <div
+            className={`border-t transition-all duration-500 ease-in-out ${
+              isOpen
+                ? "max-h-[calc((100dvh-6rem)*0.85)] max-h-[calc-size(auto,size)] opacity-100"
+                : "max-h-0 border-t-transparent opacity-0"
+            } ${isOpen && isFullyOpen ? "overflow-y-auto" : "overflow-hidden"}`}
+            onTransitionEnd={(e) => {
+              // Only react to max-height transitions on this element
+              if (
+                e.propertyName === "max-height" &&
+                e.target === e.currentTarget
+              ) {
+                setIsFullyOpen(isOpen);
+              }
+            }}
+          >
+            <div className="px-4 py-6">
+              <AdvancedInputs />
+            </div>
+          </div>
+        </header>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The expandable advanced configuration panel now overlays page content instead of pushing it down. The panel uses absolute positioning with a spacer div that reserves layout space only for the summary bar, preventing layout shifts when expanding.

## Context

Previously, clicking Edit would expand the panel inline within the header, causing the entire header to grow taller and push the chart content down. This violated the intended behavior of having the panel float over the content. The fix restructures the component to use absolute positioning while preserving smooth animations with `calc-size(auto)` support for modern browsers.