### PR TITLE
refactor: remove manual memoization (React Compiler enabled)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,5 +26,6 @@ UK student loan repayment calculator built with Next.js (App Router), React, and
 - `any` type
 - `@ts-ignore` / `@ts-expect-error`
 - Unsafe type assertions (`as unknown as X`)
+- Manual memoization (`useMemo`, `useCallback`, `React.memo`) — React Compiler handles this automatically. Exception: auto-generated shadcn/ui components.
 
 Fix underlying issues instead of suppressing errors.

--- a/src/components/QuickInputs.tsx
+++ b/src/components/QuickInputs.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useCallback } from "react";
 import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
 import { useLoanContext } from "@/context";
@@ -15,13 +14,10 @@ export function QuickInputs() {
   const { state, updateField } = useLoanContext();
   const salary = state.salary;
 
-  const handleSalaryChange = useCallback(
-    (value: number | readonly number[]) => {
-      const newSalary = Array.isArray(value) ? value[0] : value;
-      updateField("salary", newSalary);
-    },
-    [updateField],
-  );
+  const handleSalaryChange = (value: number | readonly number[]) => {
+    const newSalary = Array.isArray(value) ? value[0] : value;
+    updateField("salary", newSalary);
+  };
 
   return (
     <div className="space-y-2">

--- a/src/context/LoanContext.tsx
+++ b/src/context/LoanContext.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  createContext,
-  useContext,
-  useReducer,
-  useMemo,
-  type ReactNode,
-} from "react";
+import { createContext, useContext, useReducer, type ReactNode } from "react";
 import type { LoanState } from "@/types/store";
 import {
   loanReducer,
@@ -30,21 +24,21 @@ interface LoanProviderProps {
 export function LoanProvider({ children }: LoanProviderProps) {
   const [state, dispatch] = useReducer(loanReducer, initialState);
 
-  const contextValue = useMemo<LoanContextValue>(
-    () => ({
-      state,
-      updateField: <K extends keyof LoanState>(key: K, value: LoanState[K]) => {
-        dispatch(updateFieldAction(key, value));
-      },
-      reset: () => {
-        dispatch(resetAction());
-      },
-    }),
-    [state],
-  );
+  const updateField = <K extends keyof LoanState>(
+    key: K,
+    value: LoanState[K],
+  ) => {
+    dispatch(updateFieldAction(key, value));
+  };
+
+  const reset = () => {
+    dispatch(resetAction());
+  };
 
   return (
-    <LoanContext.Provider value={contextValue}>{children}</LoanContext.Provider>
+    <LoanContext.Provider value={{ state, updateField, reset }}>
+      {children}
+    </LoanContext.Provider>
   );
 }
 

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -4,8 +4,6 @@ import {
   createContext,
   useContext,
   useEffect,
-  useCallback,
-  useMemo,
   useSyncExternalStore,
 } from "react";
 
@@ -91,18 +89,15 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     root.classList.add(resolvedTheme);
   }, [resolvedTheme]);
 
-  const setTheme = useCallback((newTheme: Theme) => {
+  const setTheme = (newTheme: Theme) => {
     localStorage.setItem(STORAGE_KEY, newTheme);
     notifyThemeListeners();
-  }, []);
-
-  const value = useMemo(
-    () => ({ theme, resolvedTheme, setTheme }),
-    [theme, resolvedTheme, setTheme],
-  );
+  };
 
   return (
-    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
   );
 }
 

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { useLoanConfig, useCurrentSalary } from "./useStoreSelectors";
 import {
   generateSalaryDataSeries,
@@ -20,29 +19,25 @@ function useAnnotationData(
   data: DataPoint[],
   maxSalaryOffset = 0,
 ): AnnotationData {
-  return useMemo(() => {
-    if (
-      data.length > 0 &&
-      salary > MIN_SALARY &&
-      salary < MAX_SALARY - maxSalaryOffset
-    ) {
-      // Find the data point closest to the annotation salary
-      const closestPoint = data.reduce((closest, point) => {
-        if (
-          Math.abs(point.salary - salary) < Math.abs(closest.salary - salary)
-        ) {
-          return point;
-        }
-        return closest;
-      }, data[0]);
+  if (
+    data.length > 0 &&
+    salary > MIN_SALARY &&
+    salary < MAX_SALARY - maxSalaryOffset
+  ) {
+    // Find the data point closest to the annotation salary
+    const closestPoint = data.reduce((closest, point) => {
+      if (Math.abs(point.salary - salary) < Math.abs(closest.salary - salary)) {
+        return point;
+      }
+      return closest;
+    }, data[0]);
 
-      return {
-        annotationSalary: salary,
-        annotationValue: closestPoint.value,
-      };
-    }
-    return { annotationSalary: undefined, annotationValue: undefined };
-  }, [salary, data, maxSalaryOffset]);
+    return {
+      annotationSalary: salary,
+      annotationValue: closestPoint.value,
+    };
+  }
+  return { annotationSalary: undefined, annotationValue: undefined };
 }
 
 /** Hook for total repayment chart data */
@@ -50,14 +45,10 @@ export function useTotalRepaymentData() {
   const config = useLoanConfig();
   const salary = useCurrentSalary();
 
-  const data = useMemo(
-    () =>
-      generateSalaryDataSeries(
-        config.loans,
-        config.repaymentStartDate,
-        (r) => r.totalRepayment,
-      ),
-    [config],
+  const data = generateSalaryDataSeries(
+    config.loans,
+    config.repaymentStartDate,
+    (r) => r.totalRepayment,
   );
 
   const { annotationSalary, annotationValue } = useAnnotationData(salary, data);
@@ -70,14 +61,10 @@ export function useRepaymentYearsData() {
   const config = useLoanConfig();
   const salary = useCurrentSalary();
 
-  const data = useMemo(
-    () =>
-      generateSalaryDataSeries(
-        config.loans,
-        config.repaymentStartDate,
-        (r) => r.totalMonths / 12,
-      ),
-    [config],
+  const data = generateSalaryDataSeries(
+    config.loans,
+    config.repaymentStartDate,
+    (r) => r.totalMonths / 12,
   );
 
   // RepaymentYearsChart uses a 5000 offset to avoid annotation at chart edge
@@ -97,12 +84,10 @@ export function useInterestRateData() {
   const { underGradBalance, postGradBalance } = config;
   const totalPrincipal = underGradBalance + postGradBalance;
 
-  const data = useMemo(
-    () =>
-      generateSalaryDataSeries(config.loans, config.repaymentStartDate, (r) =>
-        calculateAnnualizedRate(r, totalPrincipal),
-      ),
-    [config, totalPrincipal],
+  const data = generateSalaryDataSeries(
+    config.loans,
+    config.repaymentStartDate,
+    (r) => calculateAnnualizedRate(r, totalPrincipal),
   );
 
   const { annotationSalary, annotationValue } = useAnnotationData(salary, data);

--- a/src/hooks/usePersonalizedInsight.ts
+++ b/src/hooks/usePersonalizedInsight.ts
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { useLoanConfig, useCurrentSalary } from "./useStoreSelectors";
 import { generateInsight, type Insight } from "@/utils/insights";
 
@@ -9,7 +8,5 @@ export function usePersonalizedInsight(): Insight | null {
   const config = useLoanConfig();
   const salary = useCurrentSalary();
 
-  return useMemo(() => {
-    return generateInsight(salary, config);
-  }, [salary, config]);
+  return generateInsight(salary, config);
 }

--- a/src/hooks/useStoreSelectors.ts
+++ b/src/hooks/useStoreSelectors.ts
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { useLoanContext } from "@/context";
 import type { Loan } from "@/lib/loans";
 
@@ -13,26 +12,24 @@ interface LoanConfig {
 export function useLoanConfig(): LoanConfig {
   const { state } = useLoanContext();
 
-  return useMemo(() => {
-    const loans: Loan[] = [];
+  const loans: Loan[] = [];
 
-    if (state.underGradBalance > 0) {
-      loans.push({
-        planType: state.underGradPlanType,
-        balance: state.underGradBalance,
-      });
-    }
-    if (state.postGradBalance > 0) {
-      loans.push({ planType: "POSTGRADUATE", balance: state.postGradBalance });
-    }
+  if (state.underGradBalance > 0) {
+    loans.push({
+      planType: state.underGradPlanType,
+      balance: state.underGradBalance,
+    });
+  }
+  if (state.postGradBalance > 0) {
+    loans.push({ planType: "POSTGRADUATE", balance: state.postGradBalance });
+  }
 
-    return {
-      loans,
-      repaymentStartDate: state.repaymentDate ?? new Date(),
-      underGradBalance: state.underGradBalance,
-      postGradBalance: state.postGradBalance,
-    };
-  }, [state]);
+  return {
+    loans,
+    repaymentStartDate: state.repaymentDate ?? new Date(),
+    underGradBalance: state.underGradBalance,
+    postGradBalance: state.postGradBalance,
+  };
 }
 
 /** Select current salary for chart annotation */


### PR DESCRIPTION
## Summary

React Compiler automatically optimizes component performance, making manual memoization with `useMemo`, `useCallback`, and `React.memo` redundant. This PR removes these unnecessary hooks to simplify the codebase while maintaining identical behavior.

## Context

With React Compiler enabled, the build process now handles all memoization automatically. Removing manual memoization reduces cognitive load and eliminates the risk of incorrect dependency arrays.