### PR TITLE
feat: add floating header to overpay page

### DIFF
--- a/src/components/overpay/OverpayPage.tsx
+++ b/src/components/overpay/OverpayPage.tsx
@@ -7,45 +7,52 @@ import { OverpayComparisonChart } from "./OverpayComparisonChart";
 import { OverpayInputs } from "./OverpayInputs";
 import { OverpaySummaryCards } from "./OverpaySummaryCards";
 import { OverpayVerdict } from "./OverpayVerdict";
+import { FloatingHeader } from "@/components/FloatingHeader";
 import { useOverpayAnalysis } from "@/hooks";
 
 export function OverpayPage() {
   const analysis = useOverpayAnalysis();
 
   return (
-    <div className="mx-auto w-full max-w-4xl space-y-8 px-4 py-6 md:px-6 md:py-8">
-      <div className="space-y-4">
-        <Link
-          href="/"
-          className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
-          Back to Calculator
-        </Link>
+    <div className="flex min-h-screen flex-col">
+      <FloatingHeader />
+      <main
+        id="main-content"
+        className="mx-auto w-full max-w-4xl flex-1 space-y-8 px-4 py-6 md:px-6 md:py-8"
+      >
+        <div className="space-y-4">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+            Back to Calculator
+          </Link>
 
-        <div className="space-y-2">
-          <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
-            Should You Overpay?
-          </h1>
-          <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
-            Most graduates won&apos;t fully repay before write-off. See if
-            overpaying helps or if you&apos;d be better off investing.
-          </p>
+          <div className="space-y-2">
+            <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">
+              Should You Overpay?
+            </h2>
+            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+              Most graduates won&apos;t fully repay before write-off. See if
+              overpaying helps or if you&apos;d be better off investing.
+            </p>
+          </div>
         </div>
-      </div>
 
-      <div className="h-[300px] sm:h-[350px]">
-        <OverpayComparisonChart analysis={analysis} />
-      </div>
+        <div className="h-[300px] sm:h-[350px]">
+          <OverpayComparisonChart analysis={analysis} />
+        </div>
 
-      <OverpayInputs />
+        <OverpayInputs />
 
-      <OverpayVerdict
-        recommendation={analysis.recommendation}
-        reason={analysis.recommendationReason}
-      />
+        <OverpayVerdict
+          recommendation={analysis.recommendation}
+          reason={analysis.recommendationReason}
+        />
 
-      <OverpaySummaryCards analysis={analysis} />
+        <OverpaySummaryCards analysis={analysis} />
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The overpay page now includes the floating header component to align with the main calculator page's layout. Users can access loan settings and a summary of their loan information from the overpay analysis page, creating a more consistent experience across the application.

## Context

The floating header provides quick access to personalization settings and loan summary without taking up permanent page real estate. This was already available on the main page but missing from the overpay analysis page, creating an inconsistent user experience.