### PR TITLE
feat: add preset personas for common loan scenarios

### DIFF
--- a/src/components/FloatingHeader.tsx
+++ b/src/components/FloatingHeader.tsx
@@ -4,6 +4,7 @@ import { Cancel01Icon, Settings02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useState, useEffect, useRef } from "react";
 import AdvancedInputs from "./AdvancedInputs";
+import { PresetPills } from "./PresetPills";
 import ThemeToggle from "./ThemeToggle";
 import { Button } from "@/components/ui/button";
 import { currencyFormatter } from "@/constants";
@@ -118,8 +119,8 @@ export function FloatingHeader() {
     };
   }, [isOpen]);
 
-  // Height of summary bar (py-2 = 0.5rem*2, plus content ~2.5rem, plus border)
-  const SUMMARY_HEIGHT = "4.5rem";
+  // Height of header (py-2 = 0.5rem*2, title, preset pills row, summary line, plus border)
+  const SUMMARY_HEIGHT = "6rem";
 
   return (
     <div className="sticky top-0 z-50 px-4 pt-3">
@@ -138,38 +139,53 @@ export function FloatingHeader() {
           ref={headerRef}
           className="absolute inset-x-0 top-0 max-h-[85dvh] overflow-hidden rounded-xl border bg-muted/50 shadow-lg backdrop-blur-sm"
         >
-          {/* Title and Summary Bar */}
-          <div className="py-2 pr-2 pl-4">
-            <h1 className="text-base font-medium text-foreground">
-              UK Student Loan Calculator
-            </h1>
-            <div className="mt-1 flex items-center gap-3">
-              {/* Scrollable tags container - hidden scrollbar */}
-              <div
-                className="min-w-0 flex-1 overflow-x-auto [&::-webkit-scrollbar]:hidden"
-                style={{ scrollbarWidth: "none" }}
-              >
-                <p className="flex items-center gap-2 text-xs whitespace-nowrap text-muted-foreground sm:text-sm">
-                  {renderSummary()}
-                </p>
+          {/* Title and Controls Bar */}
+          <div className="py-2 pr-2 pl-3">
+            <div className="flex items-center justify-between gap-3">
+              <h1 className="text-base font-medium text-foreground">
+                UK Student Loan Calculator
+              </h1>
+              <div className="flex shrink-0 items-center gap-2">
+                <ThemeToggle />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setIsOpen(!isOpen);
+                  }}
+                  className="shrink-0 gap-1.5"
+                  aria-label={
+                    isOpen ? "Close settings" : "Personalise settings"
+                  }
+                >
+                  <HugeiconsIcon
+                    icon={isOpen ? Cancel01Icon : Settings02Icon}
+                    className="size-4"
+                    strokeWidth={2}
+                  />
+                  <span className="hidden sm:inline">
+                    {isOpen ? "Close" : "Personalise"}
+                  </span>
+                </Button>
               </div>
-              {/* Theme toggle and settings button */}
-              <ThemeToggle />
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  setIsOpen(!isOpen);
-                }}
-                className="shrink-0 gap-1.5"
-              >
-                <HugeiconsIcon
-                  icon={isOpen ? Cancel01Icon : Settings02Icon}
-                  className="size-4"
-                  strokeWidth={2}
-                />
-                {isOpen ? "Close" : "Personalise"}
-              </Button>
+            </div>
+
+            {/* Preset Pills Row */}
+            <div
+              className="mt-2 overflow-x-auto border-t pt-2 [&::-webkit-scrollbar]:hidden"
+              style={{ scrollbarWidth: "none" }}
+            >
+              <PresetPills />
+            </div>
+
+            {/* Summary Line */}
+            <div
+              className="mt-1.5 overflow-x-auto [&::-webkit-scrollbar]:hidden"
+              style={{ scrollbarWidth: "none" }}
+            >
+              <p className="flex items-center gap-2 text-xs whitespace-nowrap text-muted-foreground sm:text-sm">
+                {renderSummary()}
+              </p>
             </div>
           </div>
 

--- a/src/components/PresetPills.tsx
+++ b/src/components/PresetPills.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useLoanContext } from "@/context";
+import { PRESETS } from "@/lib/presets";
+
+export function PresetPills() {
+  const { state, applyPreset } = useLoanContext();
+
+  // Find matching preset (includes repayment year to avoid false matches)
+  const activePreset = PRESETS.find(
+    (p) =>
+      p.underGradBalance === state.underGradBalance &&
+      p.postGradBalance === state.postGradBalance &&
+      p.underGradPlanType === state.underGradPlanType &&
+      p.repaymentYear === state.repaymentDate?.getFullYear(),
+  );
+
+  return (
+    <div className="flex gap-1.5" role="group" aria-label="Preset profiles">
+      {PRESETS.map((preset) => (
+        <Button
+          key={preset.id}
+          variant={activePreset?.id === preset.id ? "default" : "outline"}
+          size="xs"
+          onClick={() => {
+            applyPreset(preset);
+          }}
+          aria-pressed={activePreset?.id === preset.id}
+        >
+          {preset.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/src/context/LoanContext.tsx
+++ b/src/context/LoanContext.tsx
@@ -6,13 +6,16 @@ import {
   initialState,
   updateFieldAction,
   resetAction,
+  applyPresetAction,
 } from "./loanReducer";
+import type { Preset } from "@/lib/presets";
 import type { LoanState } from "@/types/store";
 
 interface LoanContextValue {
   state: LoanState;
   updateField: <K extends keyof LoanState>(key: K, value: LoanState[K]) => void;
   reset: () => void;
+  applyPreset: (preset: Preset) => void;
 }
 
 const LoanContext = createContext<LoanContextValue | null>(null);
@@ -35,8 +38,12 @@ export function LoanProvider({ children }: LoanProviderProps) {
     dispatch(resetAction());
   };
 
+  const applyPreset = (preset: Preset) => {
+    dispatch(applyPresetAction(preset));
+  };
+
   return (
-    <LoanContext.Provider value={{ state, updateField, reset }}>
+    <LoanContext.Provider value={{ state, updateField, reset, applyPreset }}>
       {children}
     </LoanContext.Provider>
   );

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -4,5 +4,6 @@ export {
   initialState,
   updateFieldAction,
   resetAction,
+  applyPresetAction,
   type LoanAction,
 } from "./loanReducer";

--- a/src/context/loanReducer.test.ts
+++ b/src/context/loanReducer.test.ts
@@ -10,7 +10,7 @@ describe("loanReducer", () => {
   describe("initial state", () => {
     it("should have correct initial values", () => {
       expect(initialState.underGradPlanType).toBe("PLAN_2");
-      expect(initialState.underGradBalance).toBe(50_000);
+      expect(initialState.underGradBalance).toBe(45_000); // "2012-23 Grad" preset
       expect(initialState.postGradBalance).toBe(0);
       expect(initialState.salary).toBe(70_000);
       expect(initialState.repaymentDate).toBeInstanceOf(Date);
@@ -91,7 +91,7 @@ describe("loanReducer", () => {
       const resetState = loanReducer(state, resetAction());
 
       // Verify all fields are back to initial values
-      expect(resetState.underGradBalance).toBe(50_000);
+      expect(resetState.underGradBalance).toBe(45_000); // "2012-23 Grad" preset
       expect(resetState.postGradBalance).toBe(0);
       expect(resetState.underGradPlanType).toBe("PLAN_2");
       expect(resetState.salary).toBe(70_000);

--- a/src/context/loanReducer.ts
+++ b/src/context/loanReducer.ts
@@ -1,10 +1,19 @@
 import type { LoanState } from "@/types/store";
+import {
+  DEFAULT_PRESET,
+  REPAYMENT_START_MONTH,
+  type Preset,
+} from "@/lib/presets";
 
 export const initialState: LoanState = {
-  underGradPlanType: "PLAN_2",
-  underGradBalance: 50_000,
-  postGradBalance: 0,
-  repaymentDate: new Date(),
+  underGradPlanType: DEFAULT_PRESET.underGradPlanType,
+  underGradBalance: DEFAULT_PRESET.underGradBalance,
+  postGradBalance: DEFAULT_PRESET.postGradBalance,
+  repaymentDate: new Date(
+    DEFAULT_PRESET.repaymentYear,
+    REPAYMENT_START_MONTH,
+    1,
+  ),
   salary: 70_000,
 
   // Overpay analysis defaults
@@ -24,7 +33,12 @@ type ResetAction = {
   type: "RESET";
 };
 
-export type LoanAction = UpdateFieldAction | ResetAction;
+type ApplyPresetAction = {
+  type: "APPLY_PRESET";
+  preset: Preset;
+};
+
+export type LoanAction = UpdateFieldAction | ResetAction | ApplyPresetAction;
 
 // Action creators
 export function updateFieldAction<K extends keyof LoanState>(
@@ -38,13 +52,29 @@ export function resetAction(): ResetAction {
   return { type: "RESET" };
 }
 
+export function applyPresetAction(preset: Preset): ApplyPresetAction {
+  return { type: "APPLY_PRESET", preset };
+}
+
 // Reducer
 export function loanReducer(state: LoanState, action: LoanAction): LoanState {
   switch (action.type) {
     case "UPDATE_FIELD":
       return { ...state, [action.key]: action.value };
     case "RESET":
-      return { ...initialState, repaymentDate: new Date() };
+      return initialState;
+    case "APPLY_PRESET":
+      return {
+        ...state,
+        underGradBalance: action.preset.underGradBalance,
+        postGradBalance: action.preset.postGradBalance,
+        underGradPlanType: action.preset.underGradPlanType,
+        repaymentDate: new Date(
+          action.preset.repaymentYear,
+          REPAYMENT_START_MONTH,
+          1,
+        ),
+      };
     default:
       return state;
   }

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -1,0 +1,56 @@
+import type { UndergraduatePlanType } from "@/lib/loans";
+
+export interface Preset {
+  id: string;
+  label: string;
+  underGradBalance: number;
+  postGradBalance: number;
+  underGradPlanType: UndergraduatePlanType;
+  repaymentYear: number;
+}
+
+export const PRESETS: Preset[] = [
+  {
+    id: "plan2-grad",
+    label: "2012-23 Grad",
+    underGradBalance: 45_000,
+    postGradBalance: 0,
+    underGradPlanType: "PLAN_2",
+    repaymentYear: 2018,
+  },
+  {
+    id: "plan5-grad",
+    label: "2023+ Grad",
+    underGradBalance: 50_000,
+    postGradBalance: 0,
+    underGradPlanType: "PLAN_5",
+    repaymentYear: 2026,
+  },
+  {
+    id: "plan1-legacy",
+    label: "Pre-2012",
+    underGradBalance: 20_000,
+    postGradBalance: 0,
+    underGradPlanType: "PLAN_1",
+    repaymentYear: 2010,
+  },
+  {
+    id: "ug-pg-combo",
+    label: "UG+Masters",
+    underGradBalance: 45_000,
+    postGradBalance: 12_000,
+    underGradPlanType: "PLAN_2",
+    repaymentYear: 2018,
+  },
+];
+
+export const DEFAULT_PRESET_ID = "plan2-grad";
+
+/** April is when UK student loan repayments typically start (0-indexed month) */
+export const REPAYMENT_START_MONTH = 3;
+
+const defaultPreset = PRESETS.find((p) => p.id === DEFAULT_PRESET_ID);
+if (!defaultPreset) {
+  throw new Error(`Default preset "${DEFAULT_PRESET_ID}" not found in PRESETS`);
+}
+export const DEFAULT_PRESET: Preset = defaultPreset;


### PR DESCRIPTION
## Summary

Adds quick-select preset personas to help users explore different UK student loan repayment scenarios without manually adjusting all parameters. Users can now click between four common profiles: 2012-23 graduate, 2023+ graduate, pre-2012, and undergraduate with postgraduate loans.

## Context

Preset personas simplify the experience for new users and make it easy to compare scenarios. The feature resets only loan-related fields (balances, plan type, repayment date) while preserving other analysis settings like salary and overpay preferences.