### PR TITLE
perf: convert page components to server components

### DIFF
--- a/src/app/overpay/page.tsx
+++ b/src/app/overpay/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { AppErrorBoundary } from "@/components/ErrorBoundary";
 import { OverpayPage } from "@/components/overpay";
 import { LoanProvider } from "@/context";

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import App from "@/components/App";
 import { AppErrorBoundary } from "@/components/ErrorBoundary";
 import { LoanProvider } from "@/context";

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { InsightCallout } from "./InsightCallout";
 import { QuickInputs } from "./QuickInputs";
 import TotalRepaymentChart from "./TotalRepaymentChart";

--- a/src/components/SecondaryCharts.tsx
+++ b/src/components/SecondaryCharts.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import InterestRateChart from "./InterestRateChart";
 import RepaymentYearsChart from "./RepaymentYearsChart";
 

--- a/src/components/overpay/OverpaySummaryCards.tsx
+++ b/src/components/overpay/OverpaySummaryCards.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { OverpayAnalysisResult } from "@/lib/loans";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { currencyFormatter } from "@/constants";

--- a/src/components/overpay/OverpayVerdict.tsx
+++ b/src/components/overpay/OverpayVerdict.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
   InformationCircleIcon,
   Alert02Icon,

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as React from "react";
 import { cn } from "@/lib/utils";
 


### PR DESCRIPTION
## Summary

Server components reduce JavaScript bundle size and improve initial page load performance. These changes remove unnecessary `"use client"` directives from page.tsx files and presentational components that don't require client-side interactivity. Interactive functionality remains unchanged.

## Context

Page components and composition wrappers can be rendered on the server while still importing and rendering client components. This optimization allows the app to leverage Next.js server components without requiring a new wrapper layer.