### PR TITLE
feat: add baseline scenario to overpay chart and improve color contrast

### DIFF
--- a/src/components/overpay/OverpayComparisonChart.tsx
+++ b/src/components/overpay/OverpayComparisonChart.tsx
@@ -6,13 +6,17 @@ import type { OverpayAnalysisResult } from "@/lib/loans/overpay-types";
 import { currencyFormatter } from "@/constants";
 
 const chartConfig = {
+  baselineNetWorth: {
+    label: "Do nothing",
+    color: "oklch(0.7 0.15 50)", // Orange
+  },
   overpayNetWorth: {
     label: "Overpay",
-    color: "var(--chart-1)",
+    color: "var(--chart-1)", // Theme color
   },
   investNetWorth: {
     label: "Invest",
-    color: "var(--chart-2)",
+    color: "oklch(0.6 0.15 250)", // Blue
   },
 } satisfies ChartConfig;
 
@@ -72,7 +76,11 @@ export function OverpayComparisonChart({
       yFormatter={(v) => currencyFormatter.format(v)}
       ariaLabel="Net worth comparison chart showing overpay vs invest scenarios over time"
       chartConfig={chartConfig}
-      series={[{ dataKey: "overpayNetWorth" }, { dataKey: "investNetWorth" }]}
+      series={[
+        { dataKey: "baselineNetWorth" },
+        { dataKey: "overpayNetWorth" },
+        { dataKey: "investNetWorth" },
+      ]}
       annotations={annotations}
       showLegend
       xDomain={[0, maxMonth]}

--- a/src/lib/loans/overpay-simulate.ts
+++ b/src/lib/loans/overpay-simulate.ts
@@ -271,14 +271,17 @@ function generateNetWorthSeries(params: NetWorthParams): NetWorthDataPoint[] {
   for (let month = 0; month <= maxMonths; month++) {
     // Calculate net worth at this point in time
     // Net worth = assets - liabilities
+    // Baseline path: just the remaining debt (no overpayment, no portfolio)
     // Overpay path: no portfolio, just reduced/eliminated debt
     // Invest path: portfolio value minus remaining debt
+    const baselineNetWorth = -Math.max(0, investBalance);
     const overpayNetWorth = -Math.max(0, overpayBalance);
     const investNetWorth = portfolioValue - Math.max(0, investBalance);
 
     series.push({
       month,
       year: Math.floor(month / 12),
+      baselineNetWorth,
       overpayNetWorth,
       investNetWorth,
     });

--- a/src/lib/loans/overpay-types.ts
+++ b/src/lib/loans/overpay-types.ts
@@ -50,6 +50,8 @@ export type RecommendationType =
 export interface NetWorthDataPoint {
   month: number;
   year: number;
+  /** Net worth with just baseline payments (no overpay, no invest) */
+  baselineNetWorth: number;
   /** Net worth if overpaying (negative loan balance offset by no debt) */
   overpayNetWorth: number;
   /** Net worth if investing (portfolio value minus remaining loan) */


### PR DESCRIPTION
## Summary

Add a third line to the overpay comparison chart showing what happens if you neither overpay nor invest (the "do nothing" baseline). Improve chart readability with more visually distinct colors: overpay uses the theme color, invest uses blue, and baseline uses orange.

## Context

Previously, the chart only showed two scenarios: overpaying the loan or investing the overpayment amount. Users now see how both strategies compare against simply making minimum payments, providing better context for the decision.