### PR TITLE
feat: adjust salary range to 25k-150k

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 // Chart salary range
-export const MIN_SALARY = 30_000;
-export const MAX_SALARY = 200_000;
+export const MIN_SALARY = 25_000;
+export const MAX_SALARY = 150_000;
 export const SALARY_STEP = 5_000;
 
 // Overpay analysis constants

--- a/src/hooks/useChartData.test.tsx
+++ b/src/hooks/useChartData.test.tsx
@@ -258,9 +258,10 @@ describe("useChartData hooks", () => {
       });
 
       // Rates should be decimals (e.g., 0.05 for 5%, not 5)
+      // -1 means 100% written off (nothing paid back), which is valid for low salaries
       result.current.data.forEach(({ value: rate }) => {
         expect(isFinite(rate)).toBe(true);
-        expect(rate).toBeGreaterThan(-1);
+        expect(rate).toBeGreaterThanOrEqual(-1);
         expect(rate).toBeLessThan(1);
       });
     });


### PR DESCRIPTION
## Summary

Updated the home page salary range from £30,000-£200,000 to £25,000-£150,000 to better reflect common income scenarios. The changes automatically propagate across all salary sliders and chart domains throughout the application.

## Context

Also fixed a test assertion that was too strict for low-salary scenarios. At salaries below most loan repayment thresholds (e.g., £25,000 for Plan 2), the annualized interest rate correctly calculates to exactly -1 (representing 100% writeoff), which is now allowed by the updated test.