### PR TITLE
style: use linear interpolation for chart lines and areas

### DIFF
--- a/src/components/charts/ChartBase.tsx
+++ b/src/components/charts/ChartBase.tsx
@@ -189,7 +189,7 @@ export function ChartBase({
               <Area
                 key={s.dataKey}
                 dataKey={s.dataKey}
-                type="natural"
+                type="linear"
                 fill={`url(#${gradientId}-${s.dataKey})`}
                 stroke={`var(--color-${s.dataKey})`}
                 strokeWidth={2}
@@ -202,7 +202,7 @@ export function ChartBase({
               <Line
                 key={s.dataKey}
                 dataKey={s.dataKey}
-                type="monotone"
+                type="linear"
                 stroke={`var(--color-${s.dataKey})`}
                 strokeWidth={2}
                 dot={false}


### PR DESCRIPTION
## Summary

Changed chart line interpolation from smooth splines (natural/monotone curves) to linear (straight line segments) to create sharper, more pointed chart lines.

## Context

This makes the chart visualization more angular and responsive to data point changes, improving visual clarity of the underlying data trends.