### PR TITLE
feat: add legal disclaimer footer

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,5 @@
 import { FloatingHeader } from "./FloatingHeader";
+import { Footer } from "./Footer";
 import { HeroSection } from "./HeroSection";
 import SecondaryCharts from "./SecondaryCharts";
 
@@ -14,6 +15,7 @@ function App() {
 
         <SecondaryCharts />
       </main>
+      <Footer />
     </div>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,14 @@
+export function Footer() {
+  return (
+    <footer className="border-t bg-muted/30">
+      <div className="mx-auto max-w-4xl px-4 py-6 md:px-6">
+        <p className="text-center text-xs text-muted-foreground sm:text-sm">
+          This calculator is for illustrative purposes only and does not
+          constitute financial advice. Calculations are based on current UK
+          student loan rules and may change. For personalised guidance, consult
+          a qualified financial adviser.
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/overpay/OverpayPage.tsx
+++ b/src/components/overpay/OverpayPage.tsx
@@ -8,6 +8,7 @@ import { OverpayInputs } from "./OverpayInputs";
 import { OverpaySummaryCards } from "./OverpaySummaryCards";
 import { OverpayVerdict } from "./OverpayVerdict";
 import { FloatingHeader } from "@/components/FloatingHeader";
+import { Footer } from "@/components/Footer";
 import { useOverpayAnalysis } from "@/hooks/useOverpayAnalysis";
 
 export function OverpayPage() {
@@ -53,6 +54,7 @@ export function OverpayPage() {
 
         <OverpaySummaryCards analysis={analysis} />
       </main>
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Added a footer component displaying a legal disclaimer across the site. The disclaimer clarifies that the calculator is for illustrative purposes only, does not constitute financial advice, and that UK student loan rules may change. Users are directed to consult a qualified financial adviser for personalized guidance.

## Context

The footer is displayed on both the home page (`/`) and overpay analysis page (`/overpay`). The styling matches the existing design system with subtle border, muted background, and responsive typography.