### PR TITLE
fix: use writtenOff flag instead of comparing months for write-off check

### DIFF
--- a/src/utils/insights.ts
+++ b/src/utils/insights.ts
@@ -41,10 +41,8 @@ function getWriteOffYears(loans: Loan[]): number {
 /**
  * Determines if the loan will be written off based on simulation result.
  */
-function willBeWrittenOff(result: SimulationResult, loans: Loan[]): boolean {
-  const writeOffYears = getWriteOffYears(loans);
-  const writeOffMonths = writeOffYears * 12;
-  return result.totalMonths >= writeOffMonths;
+function willBeWrittenOff(result: SimulationResult): boolean {
+  return result.loanResults.some((loan) => loan.writtenOff);
 }
 
 /**
@@ -105,7 +103,7 @@ export function generateInsight(
   }
 
   // Low earner: loan will be written off
-  if (willBeWrittenOff(result, loans)) {
+  if (willBeWrittenOff(result)) {
     const remaining = result.loanResults.reduce(
       (sum, r) => sum + r.remainingBalance,
       0,


### PR DESCRIPTION
## Summary

The insight callout incorrectly shows "You'll pay off quickly" for low-earner scenarios with Plan 2. The bug was in `willBeWrittenOff()`, which compared simulation run time (remaining months since loan start) against the total write-off period. The fix uses the `writtenOff` flag that the simulation engine already computes, correctly detecting write-off scenarios.

## Verification

At £25,000 salary with Plan 2: Shows "Your loan will be written off" with £91,626 to be written off. At £150,000: Shows "You'll pay off quickly" as expected.