### PR TITLE
feat: simplify quiz with region-first flow

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -178,3 +178,61 @@ html.dark::view-transition-new(theme-icon) {
 ::view-transition-old(theme-icon) {
   animation: icon-exit 300ms ease-out;
 }
+
+/* Quiz step animations */
+@keyframes quiz-slide-in {
+  from {
+    transform: translateX(30px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes quiz-slide-in-reverse {
+  from {
+    transform: translateX(-30px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes quiz-result-enter {
+  from {
+    transform: scale(0.95);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@utility animate-quiz-slide-in {
+  animation: quiz-slide-in 200ms ease-out;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+@utility animate-quiz-slide-in-reverse {
+  animation: quiz-slide-in-reverse 200ms ease-out;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+@utility animate-quiz-result-enter {
+  animation: quiz-result-enter 300ms ease-out;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}

--- a/src/app/which-plan/layout.tsx
+++ b/src/app/which-plan/layout.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "What Student Loan Plan Am I On? | UK Student Loan Study",
+  description:
+    "Find out which UK student loan plan you're on with our quick 3-question quiz. Covers Plan 1, 2, 4, 5, and Postgraduate loans.",
+  openGraph: {
+    title: "What Student Loan Plan Am I On?",
+    description:
+      "Not sure which UK student loan plan you're on? Find out in 30 seconds.",
+    url: "https://studentloanstudy.uk/which-plan",
+    siteName: "UK Student Loan Study",
+    type: "website",
+    locale: "en_GB",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "What Student Loan Plan Am I On?",
+    description:
+      "Not sure which UK student loan plan you're on? Find out in 30 seconds.",
+  },
+};
+
+export default function WhichPlanLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/which-plan/page.tsx
+++ b/src/app/which-plan/page.tsx
@@ -1,0 +1,5 @@
+import { QuizContainer } from "@/components/quiz/QuizContainer";
+
+export default function WhichPlanPage() {
+  return <QuizContainer />;
+}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,10 +1,12 @@
 import { FloatingHeader } from "./FloatingHeader";
 import { HeroSection } from "./HeroSection";
+import { PlanFromQuery } from "./PlanFromQuery";
 import SecondaryCharts from "./SecondaryCharts";
 
 function App() {
   return (
     <div className="flex min-h-screen flex-col">
+      <PlanFromQuery />
       <FloatingHeader />
       <main
         id="main-content"

--- a/src/components/PlanFromQuery.tsx
+++ b/src/components/PlanFromQuery.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { Suspense, useEffect } from "react";
+import type { UndergraduatePlanType } from "@/lib/loans/types";
+import { useLoanContext } from "@/context/LoanContext";
+
+const VALID_PLANS: UndergraduatePlanType[] = [
+  "PLAN_1",
+  "PLAN_2",
+  "PLAN_4",
+  "PLAN_5",
+];
+
+function isValidPlan(plan: string): plan is UndergraduatePlanType {
+  return VALID_PLANS.includes(plan as UndergraduatePlanType);
+}
+
+function PlanFromQueryInner() {
+  const searchParams = useSearchParams();
+  const { updateField } = useLoanContext();
+
+  useEffect(() => {
+    const planParam = searchParams.get("plan");
+    if (planParam && isValidPlan(planParam)) {
+      updateField("underGradPlanType", planParam);
+    }
+  }, [searchParams, updateField]);
+
+  return null;
+}
+
+export function PlanFromQuery() {
+  return (
+    <Suspense fallback={null}>
+      <PlanFromQueryInner />
+    </Suspense>
+  );
+}

--- a/src/components/PlanSelector.tsx
+++ b/src/components/PlanSelector.tsx
@@ -2,6 +2,7 @@
 
 import { InformationCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
 import type { UndergraduatePlanType } from "@/lib/loans/types";
 import { Button } from "@/components/ui/button";
 import {
@@ -110,6 +111,13 @@ export function PlanSelector() {
             </div>
           </PopoverContent>
         </Popover>
+        <span className="text-muted-foreground/50">•</span>
+        <Link
+          href="/which-plan"
+          className="text-primary underline-offset-4 hover:underline"
+        >
+          Not sure?
+        </Link>
       </div>
     </div>
   );

--- a/src/components/quiz/OptionCard.tsx
+++ b/src/components/quiz/OptionCard.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface OptionCardProps {
+  label: string;
+  sublabel?: string;
+  icon?: ReactNode;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+export function OptionCard({
+  label,
+  sublabel,
+  icon,
+  isSelected,
+  onClick,
+}: OptionCardProps) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={isSelected}
+      onClick={onClick}
+      className={cn(
+        "group relative flex min-h-[72px] w-full items-center gap-4 rounded-xl border-2 px-5 py-4 text-left transition-all duration-150",
+        "hover:border-primary/50 hover:bg-accent/50",
+        "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none",
+        "active:scale-[0.98]",
+        isSelected
+          ? "border-primary bg-primary/5 ring-2 ring-primary/20"
+          : "border-border bg-card",
+      )}
+    >
+      {icon && (
+        <div
+          className={cn(
+            "flex size-10 shrink-0 items-center justify-center rounded-lg text-lg",
+            isSelected
+              ? "bg-primary/10 text-primary"
+              : "bg-muted text-muted-foreground",
+          )}
+        >
+          {icon}
+        </div>
+      )}
+
+      <div className="flex-1">
+        <span
+          className={cn(
+            "block font-medium",
+            isSelected ? "text-primary" : "text-foreground",
+          )}
+        >
+          {label}
+        </span>
+        {sublabel && (
+          <span className="mt-0.5 block text-sm text-muted-foreground">
+            {sublabel}
+          </span>
+        )}
+      </div>
+
+      <div
+        className={cn(
+          "size-5 shrink-0 rounded-full border-2 transition-colors",
+          isSelected ? "border-primary bg-primary" : "border-muted-foreground",
+        )}
+      >
+        {isSelected && (
+          <svg
+            className="size-full text-primary-foreground"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path
+              fillRule="evenodd"
+              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+              clipRule="evenodd"
+            />
+          </svg>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/src/components/quiz/QuestionStep.tsx
+++ b/src/components/quiz/QuestionStep.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+interface QuestionStepProps {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+  direction: "forward" | "backward";
+}
+
+export function QuestionStep({
+  title,
+  subtitle,
+  children,
+  direction,
+}: QuestionStepProps) {
+  return (
+    <div
+      className={
+        direction === "backward"
+          ? "animate-quiz-slide-in-reverse"
+          : "animate-quiz-slide-in"
+      }
+      aria-live="polite"
+    >
+      <div className="mb-8 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground md:text-3xl">
+          {title}
+        </h1>
+        {subtitle && (
+          <p className="mt-2 text-sm text-muted-foreground md:text-base">
+            {subtitle}
+          </p>
+        )}
+      </div>
+
+      {children}
+    </div>
+  );
+}

--- a/src/components/quiz/QuizContainer.tsx
+++ b/src/components/quiz/QuizContainer.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useReducer } from "react";
+import { QuizProgress } from "./QuizProgress";
+import { RegionQuestion } from "./RegionQuestion";
+import { ResultScreen } from "./ResultScreen";
+import { StartYearQuestion } from "./StartYearQuestion";
+import type { StartYearGroup, Region } from "@/lib/quiz/determinePlan";
+import { determinePlan, canSkipStartYear } from "@/lib/quiz/determinePlan";
+
+type QuizStep = "region" | "start-year" | "result";
+
+interface QuizState {
+  currentStep: QuizStep;
+  region: Region | null;
+  startYearGroup: StartYearGroup | null;
+  direction: "forward" | "backward";
+}
+
+type QuizAction =
+  | { type: "SET_REGION"; payload: Region }
+  | { type: "SET_START_YEAR"; payload: StartYearGroup }
+  | { type: "GO_BACK" }
+  | { type: "RESTART" };
+
+const initialState: QuizState = {
+  currentStep: "region",
+  region: null,
+  startYearGroup: null,
+  direction: "forward",
+};
+
+function quizReducer(state: QuizState, action: QuizAction): QuizState {
+  switch (action.type) {
+    case "SET_REGION": {
+      const region = action.payload;
+      // Scotland/NI → go directly to result, England/Wales → go to start-year
+      const nextStep = canSkipStartYear(region) ? "result" : "start-year";
+      return {
+        ...state,
+        region,
+        currentStep: nextStep,
+        direction: "forward",
+      };
+    }
+    case "SET_START_YEAR":
+      return {
+        ...state,
+        startYearGroup: action.payload,
+        currentStep: "result",
+        direction: "forward",
+      };
+    case "GO_BACK": {
+      if (state.currentStep === "start-year") {
+        return {
+          ...state,
+          currentStep: "region",
+          direction: "backward",
+        };
+      }
+      if (state.currentStep === "result") {
+        // If region doesn't need start year, go back to region; otherwise go to start-year
+        const previousStep =
+          state.region && canSkipStartYear(state.region)
+            ? "region"
+            : "start-year";
+        return {
+          ...state,
+          currentStep: previousStep,
+          direction: "backward",
+        };
+      }
+      return state;
+    }
+    case "RESTART":
+      return initialState;
+    default:
+      return state;
+  }
+}
+
+function getTotalSteps(region: Region | null): number {
+  // Scotland/NI: 1 question, England/Wales: 2 questions
+  if (region && canSkipStartYear(region)) {
+    return 1;
+  }
+  return 2;
+}
+
+function getCurrentStepIndex(step: QuizStep, region: Region | null): number {
+  if (step === "region") return 0;
+  if (step === "start-year") return 1;
+  // Result step - return the total steps (not shown in progress)
+  return getTotalSteps(region);
+}
+
+export function QuizContainer() {
+  const [state, dispatch] = useReducer(quizReducer, initialState);
+
+  const handleRegionSelect = (region: Region) => {
+    dispatch({ type: "SET_REGION", payload: region });
+  };
+
+  const handleStartYearSelect = (yearGroup: StartYearGroup) => {
+    dispatch({ type: "SET_START_YEAR", payload: yearGroup });
+  };
+
+  const handleBack = () => {
+    dispatch({ type: "GO_BACK" });
+  };
+
+  const handleRestart = () => {
+    dispatch({ type: "RESTART" });
+  };
+
+  const totalSteps = getTotalSteps(state.region);
+  const currentStepIndex = getCurrentStepIndex(state.currentStep, state.region);
+  const showProgress = state.currentStep !== "result";
+  const canGoBack = state.currentStep !== "region";
+
+  return (
+    <div className="flex min-h-dvh flex-col bg-background">
+      {showProgress && (
+        <QuizProgress
+          currentStep={currentStepIndex}
+          totalSteps={totalSteps}
+          onBack={canGoBack ? handleBack : undefined}
+        />
+      )}
+
+      <main className="flex flex-1 flex-col items-center justify-center px-4 py-8">
+        <div className="w-full max-w-lg">
+          {state.currentStep === "region" && (
+            <RegionQuestion
+              onSelect={handleRegionSelect}
+              selectedValue={state.region}
+              direction={state.direction}
+            />
+          )}
+
+          {state.currentStep === "start-year" && (
+            <StartYearQuestion
+              onSelect={handleStartYearSelect}
+              selectedValue={state.startYearGroup}
+              direction={state.direction}
+            />
+          )}
+
+          {state.currentStep === "result" && state.region && (
+            <ResultScreen
+              planType={determinePlan({
+                region: state.region,
+                startYearGroup: state.startYearGroup ?? undefined,
+              })}
+              onRestart={handleRestart}
+              direction={state.direction}
+            />
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/components/quiz/QuizProgress.tsx
+++ b/src/components/quiz/QuizProgress.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Button } from "@/components/ui/button";
+
+interface QuizProgressProps {
+  currentStep: number;
+  totalSteps: number;
+  onBack?: () => void;
+}
+
+export function QuizProgress({
+  currentStep,
+  totalSteps,
+  onBack,
+}: QuizProgressProps) {
+  return (
+    <header className="sticky top-0 z-10 border-b border-border/50 bg-background/80 backdrop-blur-sm">
+      <div className="mx-auto flex max-w-lg items-center justify-between px-4 py-3">
+        <div className="w-10">
+          {onBack && (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={onBack}
+              aria-label="Go back"
+            >
+              <HugeiconsIcon icon={ArrowLeft01Icon} className="size-5" />
+            </Button>
+          )}
+        </div>
+
+        <div
+          className="flex gap-2"
+          role="progressbar"
+          aria-valuenow={currentStep + 1}
+          aria-valuemin={1}
+          aria-valuemax={totalSteps}
+          aria-label={`Step ${String(currentStep + 1)} of ${String(totalSteps)}`}
+        >
+          {Array.from({ length: totalSteps }, (_, i) => (
+            <div
+              key={i}
+              className={`h-1.5 w-8 rounded-full transition-colors duration-200 ${
+                i <= currentStep ? "bg-primary" : "bg-muted"
+              }`}
+            />
+          ))}
+        </div>
+
+        <div className="w-10" />
+      </div>
+    </header>
+  );
+}

--- a/src/components/quiz/RegionQuestion.tsx
+++ b/src/components/quiz/RegionQuestion.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { OptionCard } from "./OptionCard";
+import { QuestionStep } from "./QuestionStep";
+import type { Region } from "@/lib/quiz/determinePlan";
+
+interface RegionQuestionProps {
+  onSelect: (region: Region) => void;
+  selectedValue: Region | null;
+  direction: "forward" | "backward";
+}
+
+const REGION_OPTIONS: Array<{
+  value: Region;
+  label: string;
+  icon: string;
+}> = [
+  {
+    value: "england",
+    label: "England",
+    icon: "🏴󠁧󠁢󠁥󠁮󠁧󠁿",
+  },
+  {
+    value: "wales",
+    label: "Wales",
+    icon: "🏴󠁧󠁢󠁷󠁬󠁳󠁿",
+  },
+  {
+    value: "scotland",
+    label: "Scotland",
+    icon: "🏴󠁧󠁢󠁳󠁣󠁴󠁿",
+  },
+  {
+    value: "northern-ireland",
+    label: "Northern Ireland",
+    icon: "☘️",
+  },
+];
+
+export function RegionQuestion({
+  onSelect,
+  selectedValue,
+  direction,
+}: RegionQuestionProps) {
+  return (
+    <QuestionStep
+      title="Where did you study?"
+      subtitle="The UK nation where your university was located"
+      direction={direction}
+    >
+      <div
+        className="grid grid-cols-2 gap-3"
+        role="radiogroup"
+        aria-label="Select where you studied"
+      >
+        {REGION_OPTIONS.map((option) => (
+          <OptionCard
+            key={option.value}
+            label={option.label}
+            icon={<span className="text-xl">{option.icon}</span>}
+            isSelected={selectedValue === option.value}
+            onClick={() => {
+              onSelect(option.value);
+            }}
+          />
+        ))}
+      </div>
+    </QuestionStep>
+  );
+}

--- a/src/components/quiz/ResultScreen.tsx
+++ b/src/components/quiz/ResultScreen.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import Link from "next/link";
+import type { UndergraduatePlanType } from "@/lib/loans/types";
+import { Button } from "@/components/ui/button";
+import { currencyFormatter } from "@/constants";
+import { PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
+
+interface ResultScreenProps {
+  planType: UndergraduatePlanType;
+  onRestart: () => void;
+  direction: "forward" | "backward";
+}
+
+export function ResultScreen({
+  planType,
+  onRestart,
+  direction,
+}: ResultScreenProps) {
+  const planInfo = PLAN_DISPLAY_INFO[planType];
+  const calculatorUrl = `/?plan=${planType}`;
+
+  return (
+    <div
+      className={
+        direction === "backward"
+          ? "animate-quiz-slide-in-reverse"
+          : "animate-quiz-result-enter"
+      }
+      aria-live="polite"
+    >
+      <div className="text-center">
+        <p className="mb-3 text-sm font-medium tracking-wide text-muted-foreground uppercase">
+          Your plan type
+        </p>
+
+        <h1 className="mb-2 text-4xl font-bold tracking-tight text-foreground md:text-5xl">
+          {planInfo.name}
+        </h1>
+
+        <p className="text-muted-foreground">{planInfo.description}</p>
+      </div>
+
+      <div className="mt-8 rounded-2xl border border-border bg-card p-6">
+        <dl className="space-y-4">
+          <div className="flex items-center justify-between">
+            <dt className="text-muted-foreground">Repayment threshold</dt>
+            <dd className="font-semibold">
+              {currencyFormatter.format(planInfo.yearlyThreshold)}/year
+            </dd>
+          </div>
+
+          <div className="h-px bg-border" />
+
+          <div className="flex items-center justify-between">
+            <dt className="text-muted-foreground">Repayment rate</dt>
+            <dd className="font-semibold">
+              {String(planInfo.repaymentRate * 100)}% of income above threshold
+            </dd>
+          </div>
+
+          <div className="h-px bg-border" />
+
+          <div className="flex items-center justify-between">
+            <dt className="text-muted-foreground">Write-off period</dt>
+            <dd className="font-semibold">{planInfo.writeOffYears} years</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div className="mt-8 space-y-3">
+        <Button
+          size="lg"
+          className="w-full"
+          render={<Link href={calculatorUrl} />}
+          nativeButton={false}
+        >
+          Calculate your repayments →
+        </Button>
+
+        <button
+          type="button"
+          onClick={onRestart}
+          className="w-full py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          Not sure? Take the quiz again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/quiz/StartYearQuestion.tsx
+++ b/src/components/quiz/StartYearQuestion.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { OptionCard } from "./OptionCard";
+import { QuestionStep } from "./QuestionStep";
+import type { StartYearGroup } from "@/lib/quiz/determinePlan";
+
+interface StartYearQuestionProps {
+  onSelect: (yearGroup: StartYearGroup) => void;
+  selectedValue: StartYearGroup | null;
+  direction: "forward" | "backward";
+}
+
+const YEAR_OPTIONS: Array<{
+  value: StartYearGroup;
+  label: string;
+  sublabel: string;
+}> = [
+  {
+    value: "before-2012",
+    label: "Before 2012",
+    sublabel: "Started before September 2012",
+  },
+  {
+    value: "2012-2022",
+    label: "2012 – 2022",
+    sublabel: "September 2012 to July 2023",
+  },
+  {
+    value: "2023-or-later",
+    label: "2023 or later",
+    sublabel: "Started August 2023 onwards",
+  },
+];
+
+export function StartYearQuestion({
+  onSelect,
+  selectedValue,
+  direction,
+}: StartYearQuestionProps) {
+  return (
+    <QuestionStep
+      title="When did you start your course?"
+      subtitle="The academic year you began, not graduated"
+      direction={direction}
+    >
+      <div
+        className="flex flex-col gap-3"
+        role="radiogroup"
+        aria-label="Select when you started your course"
+      >
+        {YEAR_OPTIONS.map((option) => (
+          <OptionCard
+            key={option.value}
+            label={option.label}
+            sublabel={option.sublabel}
+            isSelected={selectedValue === option.value}
+            onClick={() => {
+              onSelect(option.value);
+            }}
+          />
+        ))}
+      </div>
+    </QuestionStep>
+  );
+}

--- a/src/lib/quiz/determinePlan.test.ts
+++ b/src/lib/quiz/determinePlan.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  determinePlan,
+  canSkipStartYear,
+  type QuizAnswers,
+} from "./determinePlan";
+
+describe("determinePlan", () => {
+  describe("Scotland", () => {
+    it("returns PLAN_4 regardless of start year", () => {
+      // Scotland doesn't need startYearGroup
+      expect(determinePlan({ region: "scotland" })).toBe("PLAN_4");
+
+      // Even with startYearGroup provided, still returns PLAN_4
+      const testCases: QuizAnswers[] = [
+        { region: "scotland", startYearGroup: "before-2012" },
+        { region: "scotland", startYearGroup: "2012-2022" },
+        { region: "scotland", startYearGroup: "2023-or-later" },
+      ];
+
+      for (const answers of testCases) {
+        expect(determinePlan(answers)).toBe("PLAN_4");
+      }
+    });
+  });
+
+  describe("Northern Ireland", () => {
+    it("returns PLAN_1 regardless of start year", () => {
+      // Northern Ireland doesn't need startYearGroup
+      expect(determinePlan({ region: "northern-ireland" })).toBe("PLAN_1");
+
+      // Even with startYearGroup provided, still returns PLAN_1
+      const testCases: QuizAnswers[] = [
+        { region: "northern-ireland", startYearGroup: "before-2012" },
+        { region: "northern-ireland", startYearGroup: "2012-2022" },
+        { region: "northern-ireland", startYearGroup: "2023-or-later" },
+      ];
+
+      for (const answers of testCases) {
+        expect(determinePlan(answers)).toBe("PLAN_1");
+      }
+    });
+  });
+
+  describe("England", () => {
+    it("returns PLAN_1 for before 2012", () => {
+      expect(
+        determinePlan({
+          region: "england",
+          startYearGroup: "before-2012",
+        }),
+      ).toBe("PLAN_1");
+    });
+
+    it("returns PLAN_2 for 2012-2022", () => {
+      expect(
+        determinePlan({
+          region: "england",
+          startYearGroup: "2012-2022",
+        }),
+      ).toBe("PLAN_2");
+    });
+
+    it("returns PLAN_5 for 2023 or later", () => {
+      expect(
+        determinePlan({
+          region: "england",
+          startYearGroup: "2023-or-later",
+        }),
+      ).toBe("PLAN_5");
+    });
+  });
+
+  describe("Wales", () => {
+    it("returns PLAN_1 for before 2012", () => {
+      expect(
+        determinePlan({
+          region: "wales",
+          startYearGroup: "before-2012",
+        }),
+      ).toBe("PLAN_1");
+    });
+
+    it("returns PLAN_2 for 2012-2022", () => {
+      expect(
+        determinePlan({
+          region: "wales",
+          startYearGroup: "2012-2022",
+        }),
+      ).toBe("PLAN_2");
+    });
+
+    it("returns PLAN_5 for 2023 or later", () => {
+      expect(
+        determinePlan({
+          region: "wales",
+          startYearGroup: "2023-or-later",
+        }),
+      ).toBe("PLAN_5");
+    });
+  });
+});
+
+describe("canSkipStartYear", () => {
+  it("returns true for Scotland", () => {
+    expect(canSkipStartYear("scotland")).toBe(true);
+  });
+
+  it("returns true for Northern Ireland", () => {
+    expect(canSkipStartYear("northern-ireland")).toBe(true);
+  });
+
+  it("returns false for England", () => {
+    expect(canSkipStartYear("england")).toBe(false);
+  });
+
+  it("returns false for Wales", () => {
+    expect(canSkipStartYear("wales")).toBe(false);
+  });
+});

--- a/src/lib/quiz/determinePlan.ts
+++ b/src/lib/quiz/determinePlan.ts
@@ -1,0 +1,65 @@
+import type { UndergraduatePlanType } from "@/lib/loans/types";
+
+/**
+ * Start year groups for quiz selection.
+ */
+export type StartYearGroup = "before-2012" | "2012-2022" | "2023-or-later";
+
+/**
+ * UK regions for quiz selection.
+ */
+export type Region = "england" | "wales" | "scotland" | "northern-ireland";
+
+/**
+ * User's answers to the quiz questions.
+ * startYearGroup is optional - only needed for England/Wales.
+ */
+export interface QuizAnswers {
+  region: Region;
+  startYearGroup?: StartYearGroup;
+}
+
+/**
+ * Determines the undergraduate loan plan type based on quiz answers.
+ *
+ * Logic:
+ * - Scotland → PLAN_4 (regardless of year)
+ * - Northern Ireland → PLAN_1 (regardless of year)
+ * - England/Wales before 2012 → PLAN_1
+ * - England/Wales 2012-2022 → PLAN_2
+ * - England/Wales 2023+ → PLAN_5
+ */
+export function determinePlan(answers: QuizAnswers): UndergraduatePlanType {
+  const { region, startYearGroup } = answers;
+
+  // Scottish students are always Plan 4
+  if (region === "scotland") {
+    return "PLAN_4";
+  }
+
+  // Northern Irish students are always Plan 1
+  if (region === "northern-ireland") {
+    return "PLAN_1";
+  }
+
+  // England or Wales - depends on start year
+  switch (startYearGroup) {
+    case "before-2012":
+      return "PLAN_1";
+    case "2012-2022":
+      return "PLAN_2";
+    case "2023-or-later":
+      return "PLAN_5";
+    default:
+      // Default to PLAN_2 if somehow called without startYearGroup for England/Wales
+      return "PLAN_2";
+  }
+}
+
+/**
+ * Checks if we can skip the start year question based on region.
+ * Scotland and Northern Ireland don't need start year for determination.
+ */
+export function canSkipStartYear(region: Region): boolean {
+  return region === "scotland" || region === "northern-ireland";
+}


### PR DESCRIPTION
## Summary

Removes postgraduate loan support and optimizes the quiz to determine undergraduate plans in 1-2 questions instead of 3. Asks region first (Scotland/NI users get instant results), then conditionally asks start year only for England/Wales users. Includes quiz animations and navigation from the main calculator.

## Context

The original quiz required 3 questions (loan type, region, start year) even though postgraduate support wasn't needed. The simplified flow respects regional requirements: Scotland and Northern Ireland have no start year ambiguity, so users see results immediately after selecting their region.