### PR TITLE
refactor: remove write-off annotation from balance chart

### DIFF
--- a/src/components/BalanceOverTimeChart.tsx
+++ b/src/components/BalanceOverTimeChart.tsx
@@ -18,7 +18,7 @@ function formatYear(month: number): string {
 }
 
 export function BalanceOverTimeChart() {
-  const { data, writeOffMonth } = useBalanceOverTimeData();
+  const { data } = useBalanceOverTimeData();
 
   if (data.length === 0) {
     return (
@@ -27,19 +27,6 @@ export function BalanceOverTimeChart() {
       </div>
     );
   }
-
-  const maxMonth = data[data.length - 1].month;
-  const annotations =
-    writeOffMonth !== null
-      ? [
-          {
-            x: writeOffMonth,
-            label: "Write-off",
-            color: "var(--chart-3)",
-            labelPosition: "insideTopLeft" as const,
-          },
-        ]
-      : [];
 
   return (
     <ChartBase
@@ -53,8 +40,6 @@ export function BalanceOverTimeChart() {
       ariaLabel="Chart showing your loan balance decreasing over time. The balance starts at your total loan amount and decreases as you make repayments."
       chartConfig={chartConfig}
       series={[{ dataKey: "balance" }]}
-      annotations={annotations}
-      xDomain={[0, maxMonth]}
     />
   );
 }


### PR DESCRIPTION
## Summary

Removes the write-off annotation from the balance over time chart for a cleaner visualization of loan balance progression.

## Context

The chart previously displayed a vertical dashed line at the write-off date with a "Write-off" label. This annotation has been removed to simplify the chart display and improve visual clarity.