### PR TITLE
fix: show "Your Salary" annotation at salary boundaries

### DIFF
--- a/src/hooks/useChartData.test.tsx
+++ b/src/hooks/useChartData.test.tsx
@@ -177,6 +177,24 @@ describe("useChartData hooks", () => {
       expect(result.current.annotationSalary).toBeUndefined();
     });
 
+    it("returns annotationSalary at exactly MIN_SALARY boundary", () => {
+      const { result } = renderHook(() => useTotalRepaymentData(), {
+        wrapper: createWrapper({ salary: MIN_SALARY }),
+      });
+
+      expect(result.current.annotationSalary).toBe(MIN_SALARY);
+      expect(result.current.annotationValue).toBeDefined();
+    });
+
+    it("returns annotationSalary at exactly MAX_SALARY boundary", () => {
+      const { result } = renderHook(() => useTotalRepaymentData(), {
+        wrapper: createWrapper({ salary: MAX_SALARY }),
+      });
+
+      expect(result.current.annotationSalary).toBe(MAX_SALARY);
+      expect(result.current.annotationValue).toBeDefined();
+    });
+
     it("calculates higher repayment for higher earners who pay off loan", () => {
       const { result } = renderHook(() => useTotalRepaymentData(), {
         wrapper: createWrapper(),
@@ -282,6 +300,30 @@ describe("useChartData hooks", () => {
       });
 
       expect(result.current.annotationSalary).toBeDefined();
+    });
+
+    it("returns annotationSalary at exactly MIN_SALARY boundary", () => {
+      const { result } = renderHook(() => useInterestRateData(), {
+        wrapper: createWrapper({
+          salary: MIN_SALARY,
+          underGradBalance: 50_000,
+        }),
+      });
+
+      expect(result.current.annotationSalary).toBe(MIN_SALARY);
+      expect(result.current.annotationValue).toBeDefined();
+    });
+
+    it("returns annotationSalary at exactly MAX_SALARY boundary", () => {
+      const { result } = renderHook(() => useInterestRateData(), {
+        wrapper: createWrapper({
+          salary: MAX_SALARY,
+          underGradBalance: 50_000,
+        }),
+      });
+
+      expect(result.current.annotationSalary).toBe(MAX_SALARY);
+      expect(result.current.annotationValue).toBeDefined();
     });
 
     it("handles zero balance gracefully", () => {

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -22,8 +22,8 @@ function useAnnotationData(
 ): AnnotationData {
   if (
     data.length > 0 &&
-    salary > MIN_SALARY &&
-    salary < MAX_SALARY - maxSalaryOffset
+    salary >= MIN_SALARY &&
+    salary <= MAX_SALARY - maxSalaryOffset
   ) {
     // Find the data point closest to the annotation salary
     const closestPoint = data.reduce((closest, point) => {


### PR DESCRIPTION
## Summary

Fixed a bug where the "Your Salary" annotation was not appearing on charts when the salary slider was set to the exact minimum (£25,000) or maximum (£150,000) values. The annotation check used strict inequalities (> and <) instead of inclusive inequalities (>= and <=), causing these edge cases to be missed.

## Context

The annotation visibility logic in `useAnnotationData` now correctly includes the boundary values, allowing users to see their repayment information across the full salary range. Added comprehensive test coverage for these boundary conditions.