### PR TITLE
chore: set default salary to 65k

### DIFF
--- a/src/context/loanReducer.test.ts
+++ b/src/context/loanReducer.test.ts
@@ -12,7 +12,7 @@ describe("loanReducer", () => {
       expect(initialState.underGradPlanType).toBe("PLAN_2");
       expect(initialState.underGradBalance).toBe(45_000); // "2012-23 Grad" preset
       expect(initialState.postGradBalance).toBe(0);
-      expect(initialState.salary).toBe(70_000);
+      expect(initialState.salary).toBe(65_000);
     });
   });
 
@@ -80,7 +80,7 @@ describe("loanReducer", () => {
       expect(resetState.underGradBalance).toBe(45_000); // "2012-23 Grad" preset
       expect(resetState.postGradBalance).toBe(0);
       expect(resetState.underGradPlanType).toBe("PLAN_2");
-      expect(resetState.salary).toBe(70_000);
+      expect(resetState.salary).toBe(65_000);
     });
   });
 });

--- a/src/context/loanReducer.ts
+++ b/src/context/loanReducer.ts
@@ -5,7 +5,7 @@ export const initialState: LoanState = {
   underGradPlanType: DEFAULT_PRESET.underGradPlanType,
   underGradBalance: DEFAULT_PRESET.underGradBalance,
   postGradBalance: DEFAULT_PRESET.postGradBalance,
-  salary: 70_000,
+  salary: 65_000,
 
   // Overpay analysis defaults
   monthlyOverpayment: 200,


### PR DESCRIPTION
## Summary

Updates the default selected salary from 70k to 65k for new users accessing the calculator.

## Context

This adjusts the initial salary value that users see when they first load the application, providing a more appropriate baseline for salary assumptions.