### PR TITLE
feat: add shareable results with path-aware URL encoding

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 const manrope = Manrope({ subsets: ["latin"], variable: "--font-sans" });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://studentloanstudy.uk"),
   title: "UK Student Loan Study - Student Loan Repayment Calculator",
   description:
     "Interactive calculator to understand UK student loan repayment. Compare Plan 2 and Plan 5, visualize total repayments, and see effective interest rates based on your salary.",

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,140 @@
+import { ImageResponse } from "next/og";
+import { parseMetadataParams } from "@/lib/metadata";
+
+export const runtime = "edge";
+export const alt = "UK Student Loan Projection";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+interface Props {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function Image({ searchParams }: Props) {
+  const params = await searchParams;
+  const meta = parseMetadataParams(params);
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+        background:
+          "linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)",
+        fontFamily: "system-ui, sans-serif",
+        color: "white",
+        padding: "60px",
+      }}
+    >
+      {/* Title */}
+      <div
+        style={{
+          fontSize: "42px",
+          fontWeight: 600,
+          marginBottom: "40px",
+          color: "#94a3b8",
+        }}
+      >
+        UK Student Loan Study
+      </div>
+
+      {/* Plan Type */}
+      <div
+        style={{
+          fontSize: "64px",
+          fontWeight: 700,
+          marginBottom: "24px",
+          background: "linear-gradient(90deg, #60a5fa, #a78bfa)",
+          backgroundClip: "text",
+          color: "transparent",
+        }}
+      >
+        {meta.planName}
+      </div>
+
+      {/* Stats Row */}
+      <div
+        style={{
+          display: "flex",
+          gap: "80px",
+          marginTop: "20px",
+        }}
+      >
+        {/* Balance */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+        >
+          <div
+            style={{
+              fontSize: "56px",
+              fontWeight: 700,
+              color: "#f1f5f9",
+            }}
+          >
+            {meta.formattedBalance}
+          </div>
+          <div
+            style={{
+              fontSize: "24px",
+              color: "#94a3b8",
+              marginTop: "8px",
+            }}
+          >
+            {meta.pgBalance > 0 ? "Total Balance" : "Balance"}
+          </div>
+        </div>
+
+        {/* Salary */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+        >
+          <div
+            style={{
+              fontSize: "56px",
+              fontWeight: 700,
+              color: "#f1f5f9",
+            }}
+          >
+            {meta.formattedSalary}
+          </div>
+          <div
+            style={{
+              fontSize: "24px",
+              color: "#94a3b8",
+              marginTop: "8px",
+            }}
+          >
+            Salary
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div
+        style={{
+          position: "absolute",
+          bottom: "40px",
+          fontSize: "24px",
+          color: "#64748b",
+        }}
+      >
+        studentloanstudy.uk
+      </div>
+    </div>,
+    {
+      ...size,
+    },
+  );
+}

--- a/src/app/overpay/opengraph-image.tsx
+++ b/src/app/overpay/opengraph-image.tsx
@@ -1,0 +1,168 @@
+import { ImageResponse } from "next/og";
+import { parseMetadataParams } from "@/lib/metadata";
+
+export const runtime = "edge";
+export const alt = "Should You Overpay Your UK Student Loan?";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+interface Props {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function Image({ searchParams }: Props) {
+  const params = await searchParams;
+  const meta = parseMetadataParams(params);
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+        background:
+          "linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)",
+        fontFamily: "system-ui, sans-serif",
+        color: "white",
+        padding: "60px",
+      }}
+    >
+      {/* Title */}
+      <div
+        style={{
+          fontSize: "42px",
+          fontWeight: 600,
+          marginBottom: "40px",
+          color: "#94a3b8",
+        }}
+      >
+        UK Student Loan Study
+      </div>
+
+      {/* Main Question */}
+      <div
+        style={{
+          fontSize: "64px",
+          fontWeight: 700,
+          marginBottom: "24px",
+          background: "linear-gradient(90deg, #60a5fa, #a78bfa)",
+          backgroundClip: "text",
+          color: "transparent",
+        }}
+      >
+        Should You Overpay?
+      </div>
+
+      {/* Stats Row */}
+      <div
+        style={{
+          display: "flex",
+          gap: "60px",
+          marginTop: "20px",
+        }}
+      >
+        {/* Plan */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+        >
+          <div
+            style={{
+              fontSize: "48px",
+              fontWeight: 700,
+              color: "#f1f5f9",
+            }}
+          >
+            {meta.planName}
+          </div>
+          <div
+            style={{
+              fontSize: "24px",
+              color: "#94a3b8",
+              marginTop: "8px",
+            }}
+          >
+            Loan Type
+          </div>
+        </div>
+
+        {/* Balance */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+        >
+          <div
+            style={{
+              fontSize: "48px",
+              fontWeight: 700,
+              color: "#f1f5f9",
+            }}
+          >
+            {meta.formattedBalance}
+          </div>
+          <div
+            style={{
+              fontSize: "24px",
+              color: "#94a3b8",
+              marginTop: "8px",
+            }}
+          >
+            {meta.pgBalance > 0 ? "Total Balance" : "Balance"}
+          </div>
+        </div>
+
+        {/* Salary */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+        >
+          <div
+            style={{
+              fontSize: "48px",
+              fontWeight: 700,
+              color: "#f1f5f9",
+            }}
+          >
+            {meta.formattedSalary}
+          </div>
+          <div
+            style={{
+              fontSize: "24px",
+              color: "#94a3b8",
+              marginTop: "8px",
+            }}
+          >
+            Salary
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div
+        style={{
+          position: "absolute",
+          bottom: "40px",
+          fontSize: "24px",
+          color: "#64748b",
+        }}
+      >
+        studentloanstudy.uk
+      </div>
+    </div>,
+    {
+      ...size,
+    },
+  );
+}

--- a/src/app/overpay/page.tsx
+++ b/src/app/overpay/page.tsx
@@ -1,5 +1,43 @@
+import type { Metadata } from "next";
 import { AppErrorBoundary } from "@/components/ErrorBoundary";
 import { OverpayPage } from "@/components/overpay/OverpayPage";
+import { parseMetadataParams } from "@/lib/metadata";
+
+interface Props {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export async function generateMetadata({
+  searchParams,
+}: Props): Promise<Metadata> {
+  const params = await searchParams;
+  const meta = parseMetadataParams(params);
+
+  // If no share params, use defaults
+  if (!meta.hasShareParams) {
+    return {
+      title: "Should You Overpay? | UK Student Loan Study",
+      description:
+        "Find out if overpaying your UK student loan makes financial sense, or if you'd be better off investing instead.",
+    };
+  }
+
+  const title = `Should you overpay a ${meta.planName} loan of ${meta.formattedBalance}?`;
+  const description = `See if overpaying a ${meta.planName} UK student loan with ${meta.formattedBalance} balance at ${meta.formattedSalary} salary makes sense, or if investing is better.`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+    },
+    twitter: {
+      title,
+      description,
+    },
+  };
+}
 
 export default function OverpayRoute() {
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,39 @@
+import type { Metadata } from "next";
 import App from "@/components/App";
 import { AppErrorBoundary } from "@/components/ErrorBoundary";
+import { parseMetadataParams } from "@/lib/metadata";
+
+interface Props {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export async function generateMetadata({
+  searchParams,
+}: Props): Promise<Metadata> {
+  const params = await searchParams;
+  const meta = parseMetadataParams(params);
+
+  // If no share params, use defaults from layout.tsx
+  if (!meta.hasShareParams) {
+    return {};
+  }
+
+  const title = `${meta.planName} loan of ${meta.formattedBalance} at ${meta.formattedSalary} salary`;
+  const description = `See the repayment projection for a ${meta.planName} UK student loan with ${meta.formattedBalance} balance and ${meta.formattedSalary} annual salary.`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+    },
+    twitter: {
+      title,
+      description,
+    },
+  };
+}
 
 export default function Home() {
   return (

--- a/src/components/FloatingHeader.tsx
+++ b/src/components/FloatingHeader.tsx
@@ -5,6 +5,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { useState, useEffect, useRef } from "react";
 import AdvancedInputs from "./AdvancedInputs";
 import { PresetPills } from "./PresetPills";
+import { ShareButton } from "./ShareButton";
 import ThemeToggle from "./ThemeToggle";
 import { Button } from "@/components/ui/button";
 import { currencyFormatter } from "@/constants";
@@ -20,7 +21,11 @@ import {
 // This matches data-slot="popover-content" set by our own @/components/ui/popover.tsx wrapper.
 const POPOVER_CONTENT_SELECTOR = '[data-slot="popover-content"]';
 
-export function FloatingHeader() {
+interface FloatingHeaderProps {
+  repaymentYear?: number;
+}
+
+export function FloatingHeader({ repaymentYear }: FloatingHeaderProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isFullyOpen, setIsFullyOpen] = useState(false);
   const headerRef = useRef<HTMLDivElement>(null);
@@ -147,6 +152,7 @@ export function FloatingHeader() {
               </h1>
               <div className="flex shrink-0 items-center gap-2">
                 <ThemeToggle />
+                <ShareButton repaymentYear={repaymentYear} />
                 <Button
                   variant="outline"
                   size="sm"

--- a/src/components/PlanFromQuery.tsx
+++ b/src/components/PlanFromQuery.tsx
@@ -1,39 +1,62 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
-import { Suspense, useEffect } from "react";
-import type { UndergraduatePlanType } from "@/lib/loans/types";
+import { Suspense, useEffect, useRef } from "react";
 import { useLoanContext } from "@/context/LoanContext";
+import { decodeParamsToState } from "@/lib/shareUrl";
 
-const VALID_PLANS: UndergraduatePlanType[] = [
-  "PLAN_1",
-  "PLAN_2",
-  "PLAN_4",
-  "PLAN_5",
-];
-
-function isValidPlan(plan: string): plan is UndergraduatePlanType {
-  return VALID_PLANS.includes(plan as UndergraduatePlanType);
+interface PlanFromQueryProps {
+  onRepaymentYearChange?: (year: number) => void;
 }
 
-function PlanFromQueryInner() {
+function PlanFromQueryInner({ onRepaymentYearChange }: PlanFromQueryProps) {
   const searchParams = useSearchParams();
   const { updateField } = useLoanContext();
+  const lastAppliedParams = useRef<string>("");
 
   useEffect(() => {
-    const planParam = searchParams.get("plan");
-    if (planParam && isValidPlan(planParam)) {
-      updateField("underGradPlanType", planParam);
+    // Skip if we've already applied these exact params
+    const paramsString = searchParams.toString();
+    if (paramsString === lastAppliedParams.current) return;
+    lastAppliedParams.current = paramsString;
+
+    const decoded = decodeParamsToState(searchParams);
+
+    if (decoded.underGradPlanType !== undefined) {
+      updateField("underGradPlanType", decoded.underGradPlanType);
     }
-  }, [searchParams, updateField]);
+    if (decoded.underGradBalance !== undefined) {
+      updateField("underGradBalance", decoded.underGradBalance);
+    }
+    if (decoded.postGradBalance !== undefined) {
+      updateField("postGradBalance", decoded.postGradBalance);
+    }
+    if (decoded.salary !== undefined) {
+      updateField("salary", decoded.salary);
+    }
+
+    // Overpay-specific fields
+    if (decoded.monthlyOverpayment !== undefined) {
+      updateField("monthlyOverpayment", decoded.monthlyOverpayment);
+    }
+    if (decoded.salaryGrowthRate !== undefined) {
+      updateField("salaryGrowthRate", decoded.salaryGrowthRate);
+    }
+    if (decoded.lumpSumPayment !== undefined) {
+      updateField("lumpSumPayment", decoded.lumpSumPayment);
+    }
+    if (decoded.repaymentYear !== undefined && onRepaymentYearChange) {
+      onRepaymentYearChange(decoded.repaymentYear);
+    }
+  }, [searchParams, updateField, onRepaymentYearChange]);
 
   return null;
 }
 
-export function PlanFromQuery() {
+export function PlanFromQuery({ onRepaymentYearChange }: PlanFromQueryProps) {
   return (
     <Suspense fallback={null}>
-      <PlanFromQueryInner />
+      <PlanFromQueryInner onRepaymentYearChange={onRepaymentYearChange} />
     </Suspense>
   );
 }

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Share01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useLoanContext } from "@/context/LoanContext";
+import { generateShareUrl, generateShareText } from "@/lib/shareUrl";
+
+interface ShareButtonProps {
+  repaymentYear?: number;
+}
+
+export function ShareButton({ repaymentYear }: ShareButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const { state } = useLoanContext();
+
+  const handleShare = () => {
+    const options = { repaymentYear };
+    const shareText = generateShareText(state, options);
+    const shareUrl = generateShareUrl(state, options);
+
+    const copyToClipboard = async () => {
+      try {
+        await navigator.clipboard.writeText(shareText);
+        setCopied(true);
+        setTimeout(() => {
+          setCopied(false);
+        }, 2000);
+      } catch {
+        // Intentional silent failure: clipboard access may be blocked in
+        // some browsers/contexts. The button remains functional but without
+        // feedback, which is acceptable UX for a non-critical feature.
+      }
+    };
+
+    // Try native share API first (mobile)
+    if (typeof navigator.share === "function") {
+      navigator
+        .share({
+          title: "UK Student Loan Projection",
+          text: shareText,
+          url: shareUrl,
+        })
+        .catch((err: unknown) => {
+          // Only fall back to clipboard if share actually failed,
+          // not if user cancelled
+          if (err instanceof DOMException && err.name === "AbortError") {
+            return;
+          }
+          void copyToClipboard();
+        });
+      return;
+    }
+
+    // Fall back to clipboard
+    void copyToClipboard();
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={handleShare}
+      aria-label={copied ? "Link copied" : "Share results"}
+      className="shrink-0"
+    >
+      <HugeiconsIcon
+        icon={copied ? Tick02Icon : Share01Icon}
+        className="size-4"
+        strokeWidth={2}
+      />
+    </Button>
+  );
+}

--- a/src/components/overpay/OverpayPage.tsx
+++ b/src/components/overpay/OverpayPage.tsx
@@ -11,6 +11,7 @@ import { OverpaySummaryCards } from "./OverpaySummaryCards";
 import { OverpayVerdict } from "./OverpayVerdict";
 import { FloatingHeader } from "@/components/FloatingHeader";
 import { Footer } from "@/components/Footer";
+import { PlanFromQuery } from "@/components/PlanFromQuery";
 import { useOverpayAnalysis } from "@/hooks/useOverpayAnalysis";
 import { REPAYMENT_START_MONTH } from "@/lib/presets";
 
@@ -20,9 +21,14 @@ export function OverpayPage() {
   );
   const analysis = useOverpayAnalysis(repaymentDate);
 
+  const handleRepaymentYearChange = (year: number) => {
+    setRepaymentDate(new Date(year, REPAYMENT_START_MONTH, 1));
+  };
+
   return (
     <div className="flex min-h-screen flex-col">
-      <FloatingHeader />
+      <PlanFromQuery onRepaymentYearChange={handleRepaymentYearChange} />
+      <FloatingHeader repaymentYear={repaymentDate.getFullYear()} />
       <main
         id="main-content"
         className="mx-auto w-full max-w-4xl flex-1 space-y-6 overflow-x-hidden px-4 py-6 md:px-6 md:py-8"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 // Chart salary range
 export const MIN_SALARY = 25_000;
 export const MAX_SALARY = 150_000;
+export const DEFAULT_SALARY = 65_000;
 export const SALARY_STEP = 5_000;
 
 // Overpay analysis constants

--- a/src/context/loanReducer.ts
+++ b/src/context/loanReducer.ts
@@ -1,11 +1,12 @@
 import type { LoanState } from "@/types/store";
+import { DEFAULT_SALARY } from "@/constants";
 import { DEFAULT_PRESET, type Preset } from "@/lib/presets";
 
 export const initialState: LoanState = {
   underGradPlanType: DEFAULT_PRESET.underGradPlanType,
   underGradBalance: DEFAULT_PRESET.underGradBalance,
   postGradBalance: DEFAULT_PRESET.postGradBalance,
-  salary: 65_000,
+  salary: DEFAULT_SALARY,
 
   // Overpay analysis defaults
   monthlyOverpayment: 0,

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,0 +1,61 @@
+import { currencyFormatter, DEFAULT_SALARY } from "@/constants";
+import { PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
+import { DEFAULT_PRESET } from "@/lib/presets";
+import { decodeParamsToState } from "@/lib/shareUrl";
+
+/**
+ * Default values derived from DEFAULT_PRESET to stay in sync.
+ */
+const DEFAULTS = {
+  planType: DEFAULT_PRESET.underGradPlanType,
+  balance: DEFAULT_PRESET.underGradBalance,
+  pgBalance: DEFAULT_PRESET.postGradBalance,
+  salary: DEFAULT_SALARY,
+};
+
+export interface DecodedMetadataParams {
+  planName: string;
+  balance: number;
+  pgBalance: number;
+  totalBalance: number;
+  salary: number;
+  formattedBalance: string;
+  formattedSalary: string;
+  hasShareParams: boolean;
+}
+
+/**
+ * Parses URL search params into metadata-ready values.
+ * Used by generateMetadata and opengraph-image files.
+ */
+export function parseMetadataParams(
+  searchParams: Record<string, string | string[] | undefined>,
+): DecodedMetadataParams {
+  const urlParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (typeof value === "string") {
+      urlParams.set(key, value);
+    }
+  }
+
+  const decoded = decodeParamsToState(urlParams);
+  const hasShareParams = Object.keys(decoded).length > 0;
+
+  const planType = decoded.underGradPlanType ?? DEFAULTS.planType;
+  const planName = PLAN_DISPLAY_INFO[planType].name;
+  const balance = decoded.underGradBalance ?? DEFAULTS.balance;
+  const pgBalance = decoded.postGradBalance ?? DEFAULTS.pgBalance;
+  const salary = decoded.salary ?? DEFAULTS.salary;
+  const totalBalance = balance + pgBalance;
+
+  return {
+    planName,
+    balance,
+    pgBalance,
+    totalBalance,
+    salary,
+    formattedBalance: currencyFormatter.format(totalBalance),
+    formattedSalary: currencyFormatter.format(salary),
+    hasShareParams,
+  };
+}

--- a/src/lib/shareUrl.test.ts
+++ b/src/lib/shareUrl.test.ts
@@ -1,0 +1,422 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  encodeStateToParams,
+  decodeParamsToState,
+  generateShareUrl,
+  generateShareText,
+} from "./shareUrl";
+import type { LoanState } from "@/types/store";
+import { MIN_SALARY, MAX_SALARY } from "@/constants";
+
+const mockState: LoanState = {
+  underGradPlanType: "PLAN_2",
+  underGradBalance: 45000,
+  postGradBalance: 12000,
+  salary: 65000,
+  monthlyOverpayment: 200,
+  salaryGrowthRate: "moderate",
+  lumpSumPayment: 10000,
+};
+
+describe("encodeStateToParams", () => {
+  it("encodes all shareable fields", () => {
+    const params = encodeStateToParams(mockState);
+
+    expect(params.get("plan")).toBe("PLAN_2");
+    expect(params.get("ug")).toBe("45000");
+    expect(params.get("pg")).toBe("12000");
+    expect(params.get("sal")).toBe("65000");
+  });
+
+  it("handles zero balances", () => {
+    const state: LoanState = {
+      ...mockState,
+      underGradBalance: 0,
+      postGradBalance: 0,
+    };
+    const params = encodeStateToParams(state);
+
+    expect(params.get("ug")).toBe("0");
+    expect(params.get("pg")).toBe("0");
+  });
+
+  it("handles all plan types", () => {
+    const plans = ["PLAN_1", "PLAN_2", "PLAN_4", "PLAN_5"] as const;
+    for (const plan of plans) {
+      const state: LoanState = { ...mockState, underGradPlanType: plan };
+      const params = encodeStateToParams(state);
+      expect(params.get("plan")).toBe(plan);
+    }
+  });
+
+  it("excludes overpay fields by default", () => {
+    const params = encodeStateToParams(mockState);
+
+    expect(params.get("ovp")).toBeNull();
+    expect(params.get("sgr")).toBeNull();
+    expect(params.get("lsp")).toBeNull();
+    expect(params.get("repy")).toBeNull();
+  });
+
+  it("includes overpay fields when includeOverpayFields is true", () => {
+    const params = encodeStateToParams(mockState, {
+      includeOverpayFields: true,
+      repaymentYear: 2018,
+    });
+
+    expect(params.get("ovp")).toBe("200");
+    expect(params.get("sgr")).toBe("moderate");
+    expect(params.get("lsp")).toBe("10000");
+    expect(params.get("repy")).toBe("2018");
+  });
+
+  it("omits repaymentYear if not provided", () => {
+    const params = encodeStateToParams(mockState, {
+      includeOverpayFields: true,
+    });
+
+    expect(params.get("ovp")).toBe("200");
+    expect(params.get("sgr")).toBe("moderate");
+    expect(params.get("lsp")).toBe("10000");
+    expect(params.get("repy")).toBeNull();
+  });
+});
+
+describe("decodeParamsToState", () => {
+  it("decodes all valid params", () => {
+    const params = new URLSearchParams(
+      "plan=PLAN_2&ug=45000&pg=12000&sal=65000",
+    );
+    const state = decodeParamsToState(params);
+
+    expect(state.underGradPlanType).toBe("PLAN_2");
+    expect(state.underGradBalance).toBe(45000);
+    expect(state.postGradBalance).toBe(12000);
+    expect(state.salary).toBe(65000);
+  });
+
+  it("ignores invalid plan types", () => {
+    const params = new URLSearchParams("plan=INVALID_PLAN");
+    const state = decodeParamsToState(params);
+
+    expect(state.underGradPlanType).toBeUndefined();
+  });
+
+  it("ignores non-numeric balance values", () => {
+    const params = new URLSearchParams("ug=abc&pg=xyz");
+    const state = decodeParamsToState(params);
+
+    expect(state.underGradBalance).toBeUndefined();
+    expect(state.postGradBalance).toBeUndefined();
+  });
+
+  it("ignores non-numeric salary values", () => {
+    const params = new URLSearchParams("sal=not-a-number");
+    const state = decodeParamsToState(params);
+
+    expect(state.salary).toBeUndefined();
+  });
+
+  it("clamps negative balances to 0", () => {
+    const params = new URLSearchParams("ug=-5000&pg=-1000");
+    const state = decodeParamsToState(params);
+
+    expect(state.underGradBalance).toBe(0);
+    expect(state.postGradBalance).toBe(0);
+  });
+
+  it("clamps excessively high balances", () => {
+    const params = new URLSearchParams("ug=500000&pg=300000");
+    const state = decodeParamsToState(params);
+
+    expect(state.underGradBalance).toBe(200000);
+    expect(state.postGradBalance).toBe(200000);
+  });
+
+  it("clamps salary below minimum", () => {
+    const params = new URLSearchParams("sal=10000");
+    const state = decodeParamsToState(params);
+
+    expect(state.salary).toBe(MIN_SALARY);
+  });
+
+  it("clamps salary above maximum", () => {
+    const params = new URLSearchParams("sal=500000");
+    const state = decodeParamsToState(params);
+
+    expect(state.salary).toBe(MAX_SALARY);
+  });
+
+  it("returns empty object for empty params", () => {
+    const params = new URLSearchParams();
+    const state = decodeParamsToState(params);
+
+    expect(state).toEqual({});
+  });
+
+  it("handles partial params", () => {
+    const params = new URLSearchParams("plan=PLAN_5&sal=80000");
+    const state = decodeParamsToState(params);
+
+    expect(state.underGradPlanType).toBe("PLAN_5");
+    expect(state.salary).toBe(80000);
+    expect(state.underGradBalance).toBeUndefined();
+    expect(state.postGradBalance).toBeUndefined();
+  });
+
+  it("decodes overpay fields", () => {
+    const params = new URLSearchParams(
+      "ovp=300&sgr=aggressive&lsp=15000&repy=2020",
+    );
+    const state = decodeParamsToState(params);
+
+    expect(state.monthlyOverpayment).toBe(300);
+    expect(state.salaryGrowthRate).toBe("aggressive");
+    expect(state.lumpSumPayment).toBe(15000);
+    expect(state.repaymentYear).toBe(2020);
+  });
+
+  it("ignores invalid salaryGrowthRate values", () => {
+    const params = new URLSearchParams("sgr=invalid");
+    const state = decodeParamsToState(params);
+
+    expect(state.salaryGrowthRate).toBeUndefined();
+  });
+
+  it("validates salaryGrowthRate values", () => {
+    const validRates = [
+      "none",
+      "conservative",
+      "moderate",
+      "aggressive",
+    ] as const;
+    for (const rate of validRates) {
+      const params = new URLSearchParams(`sgr=${rate}`);
+      const state = decodeParamsToState(params);
+      expect(state.salaryGrowthRate).toBe(rate);
+    }
+  });
+
+  it("clamps overpayment below minimum to 0", () => {
+    const params = new URLSearchParams("ovp=-100");
+    const state = decodeParamsToState(params);
+
+    expect(state.monthlyOverpayment).toBe(0);
+  });
+
+  it("clamps overpayment above maximum to 500", () => {
+    const params = new URLSearchParams("ovp=1000");
+    const state = decodeParamsToState(params);
+
+    expect(state.monthlyOverpayment).toBe(500);
+  });
+
+  it("clamps lumpSumPayment to valid range", () => {
+    // Below minimum
+    const paramsLow = new URLSearchParams("lsp=-5000");
+    expect(decodeParamsToState(paramsLow).lumpSumPayment).toBe(0);
+
+    // Above maximum
+    const paramsHigh = new URLSearchParams("lsp=200000");
+    expect(decodeParamsToState(paramsHigh).lumpSumPayment).toBe(100000);
+  });
+
+  it("clamps repaymentYear to valid range", () => {
+    // Below minimum
+    const paramsLow = new URLSearchParams("repy=1990");
+    expect(decodeParamsToState(paramsLow).repaymentYear).toBe(2000);
+
+    // Above maximum
+    const paramsHigh = new URLSearchParams("repy=2100");
+    expect(decodeParamsToState(paramsHigh).repaymentYear).toBe(2050);
+  });
+
+  it("ignores non-numeric overpay values", () => {
+    const params = new URLSearchParams("ovp=abc&lsp=xyz&repy=foo");
+    const state = decodeParamsToState(params);
+
+    expect(state.monthlyOverpayment).toBeUndefined();
+    expect(state.lumpSumPayment).toBeUndefined();
+    expect(state.repaymentYear).toBeUndefined();
+  });
+});
+
+describe("round-trip encoding/decoding", () => {
+  it("preserves all values through encode/decode", () => {
+    const params = encodeStateToParams(mockState);
+    const decoded = decodeParamsToState(params);
+
+    expect(decoded.underGradPlanType).toBe(mockState.underGradPlanType);
+    expect(decoded.underGradBalance).toBe(mockState.underGradBalance);
+    expect(decoded.postGradBalance).toBe(mockState.postGradBalance);
+    expect(decoded.salary).toBe(mockState.salary);
+  });
+
+  it("round-trips for all plan types", () => {
+    const plans = ["PLAN_1", "PLAN_2", "PLAN_4", "PLAN_5"] as const;
+    for (const plan of plans) {
+      const state: LoanState = { ...mockState, underGradPlanType: plan };
+      const params = encodeStateToParams(state);
+      const decoded = decodeParamsToState(params);
+      expect(decoded.underGradPlanType).toBe(plan);
+    }
+  });
+
+  it("round-trips edge case values", () => {
+    const state: LoanState = {
+      ...mockState,
+      underGradBalance: 0,
+      postGradBalance: 200000,
+      salary: MIN_SALARY,
+    };
+    const params = encodeStateToParams(state);
+    const decoded = decodeParamsToState(params);
+
+    expect(decoded.underGradBalance).toBe(0);
+    expect(decoded.postGradBalance).toBe(200000);
+    expect(decoded.salary).toBe(MIN_SALARY);
+  });
+
+  it("round-trips overpay fields with includeOverpayFields", () => {
+    const params = encodeStateToParams(mockState, {
+      includeOverpayFields: true,
+      repaymentYear: 2018,
+    });
+    const decoded = decodeParamsToState(params);
+
+    expect(decoded.monthlyOverpayment).toBe(mockState.monthlyOverpayment);
+    expect(decoded.salaryGrowthRate).toBe(mockState.salaryGrowthRate);
+    expect(decoded.lumpSumPayment).toBe(mockState.lumpSumPayment);
+    expect(decoded.repaymentYear).toBe(2018);
+  });
+
+  it("round-trips for all salary growth rates", () => {
+    const rates = ["none", "conservative", "moderate", "aggressive"] as const;
+    for (const rate of rates) {
+      const state: LoanState = { ...mockState, salaryGrowthRate: rate };
+      const params = encodeStateToParams(state, { includeOverpayFields: true });
+      const decoded = decodeParamsToState(params);
+      expect(decoded.salaryGrowthRate).toBe(rate);
+    }
+  });
+});
+
+describe("generateShareUrl", () => {
+  it("generates URL with encoded params", () => {
+    const url = generateShareUrl(mockState, { baseUrl: "https://example.com" });
+
+    expect(url).toContain("https://example.com/");
+    expect(url).toContain("plan=PLAN_2");
+    expect(url).toContain("ug=45000");
+    expect(url).toContain("pg=12000");
+    expect(url).toContain("sal=65000");
+  });
+
+  it("generates valid URL without explicit base", () => {
+    const url = generateShareUrl(mockState);
+    // Should use window.location.origin in browser or fallback
+    expect(url).toMatch(/^https?:\/\//);
+    expect(url).toContain("plan=PLAN_2");
+    expect(url).toContain("ug=45000");
+  });
+
+  it("preserves current pathname in generated URL", () => {
+    // Mock window.location using vi.stubGlobal
+    const mockLocation = {
+      pathname: "/overpay",
+      origin: "https://example.com",
+      href: "https://example.com/overpay",
+      search: "",
+      hash: "",
+      host: "example.com",
+      hostname: "example.com",
+      port: "",
+      protocol: "https:",
+    };
+    vi.stubGlobal("location", mockLocation);
+
+    const url = generateShareUrl(mockState);
+    expect(url).toContain("/overpay?");
+    expect(url).not.toContain("/?");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("uses root path when on home page", () => {
+    const mockLocation = {
+      pathname: "/",
+      origin: "https://example.com",
+      href: "https://example.com/",
+      search: "",
+      hash: "",
+      host: "example.com",
+      hostname: "example.com",
+      port: "",
+      protocol: "https:",
+    };
+    vi.stubGlobal("location", mockLocation);
+
+    const url = generateShareUrl(mockState);
+    expect(url).toContain("/?");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("includes overpay fields when on /overpay path", () => {
+    const mockLocation = {
+      pathname: "/overpay",
+      origin: "https://example.com",
+      href: "https://example.com/overpay",
+      search: "",
+      hash: "",
+      host: "example.com",
+      hostname: "example.com",
+      port: "",
+      protocol: "https:",
+    };
+    vi.stubGlobal("location", mockLocation);
+
+    const url = generateShareUrl(mockState, { repaymentYear: 2018 });
+
+    expect(url).toContain("ovp=200");
+    expect(url).toContain("sgr=moderate");
+    expect(url).toContain("lsp=10000");
+    expect(url).toContain("repy=2018");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("excludes overpay fields when on root path", () => {
+    const mockLocation = {
+      pathname: "/",
+      origin: "https://example.com",
+      href: "https://example.com/",
+      search: "",
+      hash: "",
+      host: "example.com",
+      hostname: "example.com",
+      port: "",
+      protocol: "https:",
+    };
+    vi.stubGlobal("location", mockLocation);
+
+    const url = generateShareUrl(mockState, { repaymentYear: 2018 });
+
+    expect(url).not.toContain("ovp=");
+    expect(url).not.toContain("sgr=");
+    expect(url).not.toContain("lsp=");
+    expect(url).not.toContain("repy=");
+
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("generateShareText", () => {
+  it("generates share text with URL", () => {
+    const text = generateShareText(mockState);
+
+    expect(text).toContain("Check out my UK student loan projection:");
+    expect(text).toContain("plan=PLAN_2");
+    expect(text).toContain("ug=45000");
+  });
+});

--- a/src/lib/shareUrl.ts
+++ b/src/lib/shareUrl.ts
@@ -1,0 +1,210 @@
+import type { UndergraduatePlanType } from "@/lib/loans/types";
+import type { LoanState, SalaryGrowthRate } from "@/types/store";
+import {
+  MIN_SALARY,
+  MAX_SALARY,
+  MIN_MONTHLY_OVERPAYMENT,
+  MAX_MONTHLY_OVERPAYMENT,
+} from "@/constants";
+
+// URL param keys
+const PARAM_PLAN = "plan";
+const PARAM_UG = "ug";
+const PARAM_PG = "pg";
+const PARAM_SAL = "sal";
+
+// Overpay-specific param keys
+const PARAM_OVP = "ovp";
+const PARAM_SGR = "sgr";
+const PARAM_LSP = "lsp";
+const PARAM_REPY = "repy";
+
+// Balance bounds
+const MIN_BALANCE = 0;
+const MAX_BALANCE = 200_000;
+
+// Lump sum payment bounds (URL validation only)
+const MIN_LUMP_SUM = 0;
+const MAX_LUMP_SUM = 100_000;
+
+// Repayment year bounds (URL validation only)
+const MIN_REPAYMENT_YEAR = 2000;
+const MAX_REPAYMENT_YEAR = 2050;
+
+const VALID_PLANS: UndergraduatePlanType[] = [
+  "PLAN_1",
+  "PLAN_2",
+  "PLAN_4",
+  "PLAN_5",
+];
+
+const VALID_SALARY_GROWTH_RATES: SalaryGrowthRate[] = [
+  "none",
+  "conservative",
+  "moderate",
+  "aggressive",
+];
+
+function isValidPlan(plan: string): plan is UndergraduatePlanType {
+  return VALID_PLANS.includes(plan as UndergraduatePlanType);
+}
+
+function isValidSalaryGrowthRate(rate: string): rate is SalaryGrowthRate {
+  return VALID_SALARY_GROWTH_RATES.includes(rate as SalaryGrowthRate);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export interface EncodeOptions {
+  includeOverpayFields?: boolean;
+  repaymentYear?: number;
+}
+
+/**
+ * Encodes shareable loan state fields to URL search params.
+ */
+export function encodeStateToParams(
+  state: LoanState,
+  options: EncodeOptions = {},
+): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set(PARAM_PLAN, state.underGradPlanType);
+  params.set(PARAM_UG, String(state.underGradBalance));
+  params.set(PARAM_PG, String(state.postGradBalance));
+  params.set(PARAM_SAL, String(state.salary));
+
+  if (options.includeOverpayFields) {
+    params.set(PARAM_OVP, String(state.monthlyOverpayment));
+    params.set(PARAM_SGR, state.salaryGrowthRate);
+    params.set(PARAM_LSP, String(state.lumpSumPayment));
+    if (options.repaymentYear !== undefined) {
+      params.set(PARAM_REPY, String(options.repaymentYear));
+    }
+  }
+
+  return params;
+}
+
+export interface DecodedState extends Partial<LoanState> {
+  repaymentYear?: number;
+}
+
+/**
+ * Decodes URL search params to partial loan state.
+ * Invalid values are ignored, out-of-range values are clamped.
+ */
+export function decodeParamsToState(params: URLSearchParams): DecodedState {
+  const result: DecodedState = {};
+
+  const planParam = params.get(PARAM_PLAN);
+  if (planParam && isValidPlan(planParam)) {
+    result.underGradPlanType = planParam;
+  }
+
+  const ugParam = params.get(PARAM_UG);
+  if (ugParam !== null) {
+    const value = parseInt(ugParam, 10);
+    if (!isNaN(value)) {
+      result.underGradBalance = clamp(value, MIN_BALANCE, MAX_BALANCE);
+    }
+  }
+
+  const pgParam = params.get(PARAM_PG);
+  if (pgParam !== null) {
+    const value = parseInt(pgParam, 10);
+    if (!isNaN(value)) {
+      result.postGradBalance = clamp(value, MIN_BALANCE, MAX_BALANCE);
+    }
+  }
+
+  const salParam = params.get(PARAM_SAL);
+  if (salParam !== null) {
+    const value = parseInt(salParam, 10);
+    if (!isNaN(value)) {
+      result.salary = clamp(value, MIN_SALARY, MAX_SALARY);
+    }
+  }
+
+  // Overpay-specific fields
+  const ovpParam = params.get(PARAM_OVP);
+  if (ovpParam !== null) {
+    const value = parseInt(ovpParam, 10);
+    if (!isNaN(value)) {
+      result.monthlyOverpayment = clamp(
+        value,
+        MIN_MONTHLY_OVERPAYMENT,
+        MAX_MONTHLY_OVERPAYMENT,
+      );
+    }
+  }
+
+  const sgrParam = params.get(PARAM_SGR);
+  if (sgrParam !== null && isValidSalaryGrowthRate(sgrParam)) {
+    result.salaryGrowthRate = sgrParam;
+  }
+
+  const lspParam = params.get(PARAM_LSP);
+  if (lspParam !== null) {
+    const value = parseInt(lspParam, 10);
+    if (!isNaN(value)) {
+      result.lumpSumPayment = clamp(value, MIN_LUMP_SUM, MAX_LUMP_SUM);
+    }
+  }
+
+  const repyParam = params.get(PARAM_REPY);
+  if (repyParam !== null) {
+    const value = parseInt(repyParam, 10);
+    if (!isNaN(value)) {
+      result.repaymentYear = clamp(
+        value,
+        MIN_REPAYMENT_YEAR,
+        MAX_REPAYMENT_YEAR,
+      );
+    }
+  }
+
+  return result;
+}
+
+export interface ShareUrlOptions {
+  baseUrl?: string;
+  repaymentYear?: number;
+}
+
+/**
+ * Generates a shareable URL with loan state encoded in query params.
+ * Preserves the current pathname (e.g., /overpay) when generating URLs.
+ * When on /overpay, includes overpay-specific fields in the URL.
+ */
+export function generateShareUrl(
+  state: LoanState,
+  options: ShareUrlOptions = {},
+): string {
+  const base =
+    options.baseUrl ??
+    (typeof window !== "undefined"
+      ? window.location.origin
+      : "https://studentloanstudy.uk");
+  const path = typeof window !== "undefined" ? window.location.pathname : "/";
+
+  const isOverpayPage = path.startsWith("/overpay");
+  const params = encodeStateToParams(state, {
+    includeOverpayFields: isOverpayPage,
+    repaymentYear: options.repaymentYear,
+  });
+
+  return `${base}${path}?${params.toString()}`;
+}
+
+/**
+ * Generates share text with a human-readable message and URL.
+ */
+export function generateShareText(
+  state: LoanState,
+  options: ShareUrlOptions = {},
+): string {
+  const url = generateShareUrl(state, options);
+  return `Check out my UK student loan projection: ${url}`;
+}


### PR DESCRIPTION
## Summary

Add shareable URLs that encode loan calculation state as query parameters. Users can now generate links to share their loan scenarios with others, and the URL includes overpay-specific fields (monthly overpayment, salary growth rate, savings rate, repayment year) only when sharing from the `/overpay` page.

## Context

The feature includes a new URL encoding/decoding library with validation and bounds checking, a ShareButton component with native Web Share API support and clipboard fallback, dynamic OpenGraph image generation for rich previews, and integration across the home and overpay pages. The `PlanFromQuery` component now decodes all shareable state fields from URLs, and both pages generate personalized metadata when share parameters are present.