### PR TITLE
fix: adjust header and body padding layout

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -12,7 +12,7 @@ function App() {
       <Header />
       <main
         id="main-content"
-        className="mx-auto w-full max-w-4xl flex-1 space-y-8 px-4 py-6 md:px-6 md:py-8"
+        className="mx-auto w-full max-w-4xl flex-1 space-y-8 px-3 pt-36 pb-6 md:pb-8"
       >
         <HeroSection />
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 export function Footer() {
   return (
     <footer className="border-t bg-muted/30">
-      <div className="mx-auto max-w-4xl px-4 py-6 md:px-6">
+      <div className="mx-auto max-w-4xl px-3 py-6">
         <p className="text-center text-xs text-muted-foreground sm:text-sm">
           This calculator is for illustrative purposes only and does not
           constitute financial advice. Calculations are based on current UK

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -37,7 +37,7 @@ export function Header({ variant = "full", repaymentYear }: HeaderProps) {
 
 function SimpleHeaderContent() {
   return (
-    <div className="sticky top-0 z-50 px-4 pt-3">
+    <div className="sticky top-0 z-50 px-3 pt-3">
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:bg-background focus:p-2 focus:text-foreground"
@@ -151,7 +151,7 @@ function FullHeaderContent({ repaymentYear }: FullHeaderContentProps) {
   }, [isOpen]);
 
   return (
-    <div className="sticky top-0 z-50 px-4 pt-3">
+    <div className="sticky top-0 z-50 px-3 pt-3">
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:bg-background focus:p-2 focus:text-foreground"
@@ -159,8 +159,6 @@ function FullHeaderContent({ repaymentYear }: FullHeaderContentProps) {
         Skip to main content
       </a>
       <div className="relative mx-auto max-w-4xl">
-        <div className="h-24" aria-hidden="true" />
-
         <header
           ref={headerRef}
           className="absolute inset-x-0 top-0 max-h-[85dvh] overflow-hidden rounded-xl border bg-muted/50 shadow-lg backdrop-blur-sm"

--- a/src/components/overpay/OverpayPage.tsx
+++ b/src/components/overpay/OverpayPage.tsx
@@ -31,7 +31,7 @@ export function OverpayPage() {
       <Header repaymentYear={repaymentDate.getFullYear()} />
       <main
         id="main-content"
-        className="mx-auto w-full max-w-4xl flex-1 space-y-6 overflow-x-hidden px-4 py-6 md:px-6 md:py-8"
+        className="mx-auto w-full max-w-4xl flex-1 space-y-6 overflow-x-hidden px-3 pt-36 pb-6 md:pb-8"
       >
         <div className="space-y-4">
           <Link


### PR DESCRIPTION
## Summary

Fixed layout spacing by standardizing horizontal padding to px-3 across header and footer components and adjusting main content area padding to account for the sticky header positioning. This resolves spacing inconsistencies and improves the visual hierarchy of the page layout.

## Context

The sticky header required adjustment to how vertical space is allocated to content areas. The spacer div has been replaced with explicit top padding on main content, and horizontal padding is now consistently applied across all layout sections.