### PR TITLE
feat: move personalise button to preset pills row

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -18,6 +18,7 @@ import {
   PLAN_DISPLAY_INFO,
   POSTGRADUATE_DISPLAY_INFO,
 } from "@/lib/loans/plans";
+import { PRESETS } from "@/lib/presets";
 
 // Selector for popover content rendered in portals.
 const POPOVER_CONTENT_SELECTOR = '[data-slot="popover-content"]';
@@ -86,6 +87,13 @@ function FullHeaderContent({ repaymentYear }: FullHeaderContentProps) {
     salary,
     CURRENT_RATES.rpi,
     CURRENT_RATES.boeBaseRate,
+  );
+
+  const isCustomConfig = !PRESETS.some(
+    (p) =>
+      p.underGradBalance === underGradBalance &&
+      p.postGradBalance === postGradBalance &&
+      p.underGradPlanType === underGradPlanType,
   );
 
   function renderSummary() {
@@ -181,7 +189,7 @@ function FullHeaderContent({ repaymentYear }: FullHeaderContentProps) {
                 <PresetPills />
               </div>
               <Button
-                variant="outline"
+                variant={isCustomConfig ? "default" : "outline"}
                 size="xs"
                 onClick={() => {
                   setIsOpen(!isOpen);


### PR DESCRIPTION
## Summary

Moved the Personalise button to the same row as the preset pills for better layout efficiency. The button now stays sticky to the right while preset pills can scroll horizontally on narrow screens. The button text remains constant as "Personalise" while only the icon changes when expanded.

## Context

This improves the header layout by reducing vertical space and providing a more compact, cohesive control area. On mobile, the preset pills can scroll independently while the Personalise button remains accessible on the right edge.