### PR TITLE
feat: add salary growth advanced config to home page

### DIFF
--- a/src/components/AdvancedConfigSection.tsx
+++ b/src/components/AdvancedConfigSection.tsx
@@ -1,12 +1,10 @@
 "use client";
 
+import { ArrowDown01Icon, ArrowUp01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useState } from "react";
 import type { SalaryGrowthRate } from "@/types/store";
 import { Button } from "@/components/ui/button";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
 import { useLoanContext } from "@/context/LoanContext";
 
 const salaryGrowthOptions: {
@@ -24,14 +22,45 @@ const salaryGrowthOptions: {
   },
 ];
 
-export function OverpaySecondaryInputs() {
+export function AdvancedConfigSection() {
+  const [isOpen, setIsOpen] = useState(false);
+  // Track animation completion to enable overflow only after expanding finishes.
+  // This matches the Header personalise panel animation pattern (CSS transitions)
+  // rather than shadcn Collapsible's accordion animation.
+  const [isFullyOpen, setIsFullyOpen] = useState(false);
   const { state, updateField } = useLoanContext();
 
   return (
-    <Collapsible defaultOpen={false}>
-      <CollapsibleTrigger>Advanced</CollapsibleTrigger>
-      <CollapsibleContent>
-        <div className="pt-4">
+    <div>
+      <button
+        type="button"
+        onClick={() => {
+          setIsOpen(!isOpen);
+        }}
+        className="flex w-full items-center justify-between rounded-lg py-2.5 text-left text-sm font-medium transition-all hover:underline focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
+        aria-expanded={isOpen}
+        aria-controls="advanced-config-content"
+      >
+        Advanced
+        <HugeiconsIcon
+          icon={isOpen ? ArrowUp01Icon : ArrowDown01Icon}
+          strokeWidth={2}
+          className="size-4 shrink-0 text-muted-foreground"
+        />
+      </button>
+
+      <div
+        id="advanced-config-content"
+        className={`transition-all duration-500 ease-in-out ${
+          isOpen ? "max-h-48 opacity-100" : "max-h-0 opacity-0"
+        } ${isOpen && isFullyOpen ? "overflow-visible" : "overflow-hidden"}`}
+        onTransitionEnd={(e) => {
+          if (e.propertyName === "max-height" && e.target === e.currentTarget) {
+            setIsFullyOpen(isOpen);
+          }
+        }}
+      >
+        <div className="pt-2 pb-2.5">
           <fieldset className="space-y-2">
             <legend className="text-sm font-medium">Salary Growth</legend>
             <div
@@ -67,7 +96,7 @@ export function OverpaySecondaryInputs() {
             </p>
           </fieldset>
         </div>
-      </CollapsibleContent>
-    </Collapsible>
+      </div>
+    </div>
   );
 }

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,3 +1,4 @@
+import { AdvancedConfigSection } from "./AdvancedConfigSection";
 import { InsightCallout } from "./InsightCallout";
 import { QuickInputs } from "./QuickInputs";
 import TotalRepaymentChart from "./TotalRepaymentChart";
@@ -21,6 +22,8 @@ export function HeroSection() {
       </div>
 
       <QuickInputs />
+
+      <AdvancedConfigSection />
 
       <InsightCallout />
     </section>

--- a/src/components/overpay/OverpayPage.tsx
+++ b/src/components/overpay/OverpayPage.tsx
@@ -6,9 +6,9 @@ import Link from "next/link";
 import { useState } from "react";
 import { OverpayComparisonChart } from "./OverpayComparisonChart";
 import { OverpayPrimaryInputs } from "./OverpayPrimaryInputs";
-import { OverpaySecondaryInputs } from "./OverpaySecondaryInputs";
 import { OverpaySummaryCards } from "./OverpaySummaryCards";
 import { OverpayVerdict } from "./OverpayVerdict";
+import { AdvancedConfigSection } from "@/components/AdvancedConfigSection";
 import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
 import { PlanFromQuery } from "@/components/PlanFromQuery";
@@ -71,7 +71,7 @@ export function OverpayPage() {
           onRepaymentDateChange={setRepaymentDate}
         />
 
-        <OverpaySecondaryInputs />
+        <AdvancedConfigSection />
       </main>
       <Footer />
     </div>

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -1,6 +1,10 @@
-import { useLoanConfig, useCurrentSalary } from "./useStoreSelectors";
+import {
+  useLoanConfig,
+  useCurrentSalary,
+  useSalaryGrowthRate,
+} from "./useStoreSelectors";
 import type { DataPoint, BalanceDataPoint } from "@/types/chart";
-import { MIN_SALARY, MAX_SALARY } from "@/constants";
+import { MIN_SALARY, MAX_SALARY, SALARY_GROWTH_RATES } from "@/constants";
 import {
   generateSalaryDataSeries,
   generateBalanceTimeSeries,
@@ -44,8 +48,15 @@ function useAnnotationData(
 export function useTotalRepaymentData() {
   const config = useLoanConfig();
   const salary = useCurrentSalary();
+  const salaryGrowthRate = useSalaryGrowthRate();
+  const annualGrowthRate = SALARY_GROWTH_RATES[salaryGrowthRate];
 
-  const data = generateSalaryDataSeries(config.loans, (r) => r.totalRepayment);
+  const data = generateSalaryDataSeries(
+    config.loans,
+    (r) => r.totalRepayment,
+    undefined,
+    annualGrowthRate,
+  );
 
   const { annotationSalary, annotationValue } = useAnnotationData(salary, data);
 
@@ -59,6 +70,13 @@ export function useBalanceOverTimeData(): {
 } {
   const config = useLoanConfig();
   const salary = useCurrentSalary();
+  const salaryGrowthRate = useSalaryGrowthRate();
+  const annualGrowthRate = SALARY_GROWTH_RATES[salaryGrowthRate];
 
-  return generateBalanceTimeSeries(config.loans, salary);
+  return generateBalanceTimeSeries(
+    config.loans,
+    salary,
+    undefined,
+    annualGrowthRate,
+  );
 }

--- a/src/hooks/useStoreSelectors.ts
+++ b/src/hooks/useStoreSelectors.ts
@@ -43,6 +43,12 @@ interface OverpayConfig {
   lumpSumPayment: number;
 }
 
+/** Select salary growth rate for charts */
+export function useSalaryGrowthRate(): SalaryGrowthRate {
+  const { state } = useLoanContext();
+  return state.salaryGrowthRate;
+}
+
 /** Select overpay analysis configuration */
 export function useOverpayConfig(): OverpayConfig {
   const { state } = useLoanContext();

--- a/src/utils/loan-calculations.ts
+++ b/src/utils/loan-calculations.ts
@@ -20,12 +20,14 @@ import { CURRENT_RATES } from "@/lib/loans/plans";
  * @param loans - Array of loans to simulate
  * @param mapper - Function to extract desired value from simulation result
  * @param rpiRate - Optional RPI rate override
+ * @param salaryGrowthRate - Annual salary growth rate (default 0)
  * @returns Array of [salary, value] data points
  */
 export function generateSalaryDataSeries(
   loans: Loan[],
   mapper: SimulationMapper,
   rpiRate = CURRENT_RATES.rpi,
+  salaryGrowthRate = 0,
 ): DataPoint[] {
   const data: DataPoint[] = [];
 
@@ -35,6 +37,7 @@ export function generateSalaryDataSeries(
       annualSalary: salary,
       monthsElapsed: 0, // Simulate from repayment start
       rpiRate,
+      salaryGrowthRate,
     });
 
     // Convert to SimulationResult for mapper compatibility
@@ -67,12 +70,14 @@ export interface BalanceTimeSeriesResult {
  * @param loans - Array of loans to simulate
  * @param annualSalary - The user's current annual salary
  * @param rpiRate - Optional RPI rate override
+ * @param salaryGrowthRate - Annual salary growth rate (default 0)
  * @returns Balance data points and write-off month if applicable
  */
 export function generateBalanceTimeSeries(
   loans: Loan[],
   annualSalary: number,
   rpiRate = CURRENT_RATES.rpi,
+  salaryGrowthRate = 0,
 ): BalanceTimeSeriesResult {
   if (loans.length === 0 || loans.every((loan) => loan.balance <= 0)) {
     return { data: [], writeOffMonth: null };
@@ -83,6 +88,7 @@ export function generateBalanceTimeSeries(
     annualSalary,
     monthsElapsed: 0,
     rpiRate,
+    salaryGrowthRate,
   });
 
   const data: BalanceDataPoint[] = [];


### PR DESCRIPTION
## Summary

Added salary growth rate selection to the home page, allowing users to see how different growth assumptions affect total repayment calculations. Consolidated salary growth UI into a single reusable component with smooth expand/collapse animation, used on both home and overpay pages.

## Context

The salary growth feature was previously only available on the overpay page. This change brings it to the home page to give users more control over their repayment projections. The component now uses a Header-style CSS transition animation (500ms ease-in-out) for consistent UX across the app. Code duplication was removed by consolidating the UI into a single component.