### PR TITLE
refactor: reorganize overpay config layout

### DIFF
--- a/src/components/AdvancedConfigSection.tsx
+++ b/src/components/AdvancedConfigSection.tsx
@@ -3,24 +3,9 @@
 import { ArrowDown01Icon, ArrowUp01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useState } from "react";
-import type { SalaryGrowthRate, ThresholdGrowthRate } from "@/types/store";
+import type { ThresholdGrowthRate } from "@/types/store";
 import { Button } from "@/components/ui/button";
 import { useLoanContext } from "@/context/LoanContext";
-
-const salaryGrowthOptions: {
-  value: SalaryGrowthRate;
-  label: string;
-  description: string;
-}[] = [
-  { value: "none", label: "0%", description: "No salary growth" },
-  { value: "conservative", label: "2%", description: "Matches inflation only" },
-  { value: "moderate", label: "4%", description: "Typical career progression" },
-  {
-    value: "aggressive",
-    label: "6%",
-    description: "Fast-track careers (tech, finance)",
-  },
-];
 
 const thresholdGrowthOptions: {
   value: ThresholdGrowthRate;
@@ -76,41 +61,6 @@ export function AdvancedConfigSection() {
         }}
       >
         <div className="space-y-4 pt-2 pb-2.5">
-          <fieldset className="space-y-2">
-            <legend className="text-sm font-medium">Salary Growth</legend>
-            <div
-              role="group"
-              aria-label="Salary growth rate options"
-              className="flex gap-1"
-            >
-              {salaryGrowthOptions.map((option) => (
-                <Button
-                  key={option.value}
-                  variant={
-                    state.salaryGrowthRate === option.value
-                      ? "default"
-                      : "outline"
-                  }
-                  size="sm"
-                  onClick={() => {
-                    updateField("salaryGrowthRate", option.value);
-                  }}
-                  aria-pressed={state.salaryGrowthRate === option.value}
-                  className="flex-1"
-                >
-                  {option.label}
-                </Button>
-              ))}
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {
-                salaryGrowthOptions.find(
-                  (o) => o.value === state.salaryGrowthRate,
-                )?.description
-              }
-            </p>
-          </fieldset>
-
           <fieldset className="space-y-2">
             <legend className="text-sm font-medium">
               Simulate threshold rising

--- a/src/components/QuickInputs.tsx
+++ b/src/components/QuickInputs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { SalaryGrowthPicker } from "@/components/SalaryGrowthPicker";
 import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
 import {
@@ -20,26 +21,30 @@ export function QuickInputs() {
   };
 
   return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <Label htmlFor="salary-slider">Your Salary</Label>
-        <span className="text-sm font-medium tabular-nums">
-          {currencyFormatter.format(salary)}
-        </span>
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label htmlFor="salary-slider">Your Salary</Label>
+          <span className="text-sm font-medium tabular-nums">
+            {currencyFormatter.format(salary)}
+          </span>
+        </div>
+        <Slider
+          id="salary-slider"
+          value={[salary]}
+          onValueChange={handleSalaryChange}
+          min={MIN_SALARY}
+          max={MAX_SALARY}
+          step={SALARY_STEP}
+          aria-label="Adjust your annual salary"
+        />
+        <div className="flex justify-between text-xs text-muted-foreground">
+          <span>{currencyFormatter.format(MIN_SALARY)}</span>
+          <span>{currencyFormatter.format(MAX_SALARY)}</span>
+        </div>
       </div>
-      <Slider
-        id="salary-slider"
-        value={[salary]}
-        onValueChange={handleSalaryChange}
-        min={MIN_SALARY}
-        max={MAX_SALARY}
-        step={SALARY_STEP}
-        aria-label="Adjust your annual salary"
-      />
-      <div className="flex justify-between text-xs text-muted-foreground">
-        <span>{currencyFormatter.format(MIN_SALARY)}</span>
-        <span>{currencyFormatter.format(MAX_SALARY)}</span>
-      </div>
+
+      <SalaryGrowthPicker />
     </div>
   );
 }

--- a/src/components/SalaryGrowthPicker.tsx
+++ b/src/components/SalaryGrowthPicker.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { SALARY_GROWTH_OPTIONS } from "@/constants";
+import { useLoanContext } from "@/context/LoanContext";
+
+export function SalaryGrowthPicker() {
+  const { state, updateField } = useLoanContext();
+
+  return (
+    <fieldset className="space-y-2">
+      <legend className="text-sm font-medium">Salary Growth</legend>
+      <div
+        role="group"
+        aria-label="Salary growth rate options"
+        className="flex gap-1"
+      >
+        {SALARY_GROWTH_OPTIONS.map((option) => (
+          <Button
+            key={option.value}
+            variant={
+              state.salaryGrowthRate === option.value ? "default" : "outline"
+            }
+            size="sm"
+            onClick={() => {
+              updateField("salaryGrowthRate", option.value);
+            }}
+            aria-pressed={state.salaryGrowthRate === option.value}
+            className="flex-1"
+          >
+            {option.label}
+          </Button>
+        ))}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {
+          SALARY_GROWTH_OPTIONS.find((o) => o.value === state.salaryGrowthRate)
+            ?.description
+        }
+      </p>
+    </fieldset>
+  );
+}

--- a/src/components/overpay/OverpayPrimaryInputs.tsx
+++ b/src/components/overpay/OverpayPrimaryInputs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { SalaryGrowthPicker } from "@/components/SalaryGrowthPicker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
@@ -47,95 +48,101 @@ export function OverpayPrimaryInputs({
   };
 
   return (
-    <div className="grid grid-cols-2 gap-6 lg:grid-cols-4">
-      <div className="space-y-2">
-        <Label htmlFor="lump-sum-input">Lump Sum Payment</Label>
-        {totalBalance > 0 ? (
-          <>
-            <div className="relative">
-              <span className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-muted-foreground">
-                £
-              </span>
-              <Input
-                id="lump-sum-input"
-                type="text"
-                inputMode="numeric"
-                value={
-                  state.lumpSumPayment === 0
-                    ? ""
-                    : state.lumpSumPayment.toLocaleString("en-GB")
-                }
-                onChange={handleLumpSumChange}
-                placeholder="0"
-                className="pl-6"
-                aria-label="Enter one-off lump sum payment"
-              />
-            </div>
-            <p className="text-xs text-muted-foreground">
-              Max: {currencyFormatter.format(totalBalance)}
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="lump-sum-input">Lump Sum Payment</Label>
+          {totalBalance > 0 ? (
+            <>
+              <div className="relative">
+                <span className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-muted-foreground">
+                  £
+                </span>
+                <Input
+                  id="lump-sum-input"
+                  type="text"
+                  inputMode="numeric"
+                  value={
+                    state.lumpSumPayment === 0
+                      ? ""
+                      : state.lumpSumPayment.toLocaleString("en-GB")
+                  }
+                  onChange={handleLumpSumChange}
+                  placeholder="0"
+                  className="pl-6"
+                  aria-label="Enter one-off lump sum payment"
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Max: {currencyFormatter.format(totalBalance)}
+              </p>
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Configure your loan balance first
             </p>
-          </>
-        ) : (
-          <p className="text-sm text-muted-foreground">
-            Configure your loan balance first
-          </p>
-        )}
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="overpayment-slider">Monthly Overpayment</Label>
+            <span className="text-sm font-medium tabular-nums">
+              {currencyFormatter.format(state.monthlyOverpayment)}
+            </span>
+          </div>
+          <Slider
+            id="overpayment-slider"
+            value={[state.monthlyOverpayment]}
+            onValueChange={handleOverpaymentChange}
+            min={MIN_MONTHLY_OVERPAYMENT}
+            max={MAX_MONTHLY_OVERPAYMENT}
+            step={OVERPAYMENT_STEP}
+            aria-label="Adjust monthly overpayment amount"
+          />
+          <div className="flex justify-between text-xs text-muted-foreground">
+            <span>{currencyFormatter.format(MIN_MONTHLY_OVERPAYMENT)}</span>
+            <span>{currencyFormatter.format(MAX_MONTHLY_OVERPAYMENT)}</span>
+          </div>
+        </div>
       </div>
 
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <Label htmlFor="overpayment-slider">Monthly Overpayment</Label>
-          <span className="text-sm font-medium tabular-nums">
-            {currencyFormatter.format(state.monthlyOverpayment)}
-          </span>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="salary-slider">Current Salary</Label>
+            <span className="text-sm font-medium tabular-nums">
+              {currencyFormatter.format(state.salary)}
+            </span>
+          </div>
+          <Slider
+            id="salary-slider"
+            value={[state.salary]}
+            onValueChange={handleSalaryChange}
+            min={MIN_SALARY}
+            max={MAX_SALARY}
+            step={SALARY_STEP}
+            aria-label="Adjust your annual salary"
+          />
+          <div className="flex justify-between text-xs text-muted-foreground">
+            <span>{currencyFormatter.format(MIN_SALARY)}</span>
+            <span>{currencyFormatter.format(MAX_SALARY)}</span>
+          </div>
         </div>
-        <Slider
-          id="overpayment-slider"
-          value={[state.monthlyOverpayment]}
-          onValueChange={handleOverpaymentChange}
-          min={MIN_MONTHLY_OVERPAYMENT}
-          max={MAX_MONTHLY_OVERPAYMENT}
-          step={OVERPAYMENT_STEP}
-          aria-label="Adjust monthly overpayment amount"
+
+        <SalaryGrowthPicker />
+
+        <YearSelector
+          id="overpay-repayment-year"
+          label="Repayment Start Year"
+          value={repaymentDate}
+          onChange={(value) => {
+            if (value) {
+              onRepaymentDateChange(value);
+            }
+          }}
         />
-        <div className="flex justify-between text-xs text-muted-foreground">
-          <span>{currencyFormatter.format(MIN_MONTHLY_OVERPAYMENT)}</span>
-          <span>{currencyFormatter.format(MAX_MONTHLY_OVERPAYMENT)}</span>
-        </div>
       </div>
-
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <Label htmlFor="salary-slider">Your Current Salary</Label>
-          <span className="text-sm font-medium tabular-nums">
-            {currencyFormatter.format(state.salary)}
-          </span>
-        </div>
-        <Slider
-          id="salary-slider"
-          value={[state.salary]}
-          onValueChange={handleSalaryChange}
-          min={MIN_SALARY}
-          max={MAX_SALARY}
-          step={SALARY_STEP}
-          aria-label="Adjust your annual salary"
-        />
-        <div className="flex justify-between text-xs text-muted-foreground">
-          <span>{currencyFormatter.format(MIN_SALARY)}</span>
-          <span>{currencyFormatter.format(MAX_SALARY)}</span>
-        </div>
-      </div>
-
-      <YearSelector
-        id="overpay-repayment-year"
-        label="Repayment Start Year"
-        value={repaymentDate}
-        onChange={(value) => {
-          if (value) {
-            onRepaymentDateChange(value);
-          }
-        }}
-      />
     </div>
   );
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import type { SalaryGrowthRate } from "@/types/store";
+
 // Chart salary range
 export const MIN_SALARY = 25_000;
 export const MAX_SALARY = 150_000;
@@ -27,6 +29,22 @@ export const THRESHOLD_GROWTH_RATES = {
   moderate: 0.03, // 3% - typical RPI-linked growth
   aggressive: 0.04, // 4% - above-inflation growth
 } as const;
+
+/** Salary growth rate option labels for toggle buttons */
+export const SALARY_GROWTH_OPTIONS: {
+  value: SalaryGrowthRate;
+  label: string;
+  description: string;
+}[] = [
+  { value: "none", label: "0%", description: "No salary growth" },
+  { value: "conservative", label: "2%", description: "Matches inflation only" },
+  { value: "moderate", label: "4%", description: "Typical career progression" },
+  {
+    value: "aggressive",
+    label: "6%",
+    description: "Fast-track careers (tech, finance)",
+  },
+];
 
 // Formatters for chart display
 export const currencyFormatter = new Intl.NumberFormat("en-GB", {


### PR DESCRIPTION
## Summary

Reorganized the overpay page configuration section into two rows with improved visual hierarchy, moved Salary Growth controls inline with the salary slider on both pages, and extracted a shared `SalaryGrowthPicker` component to eliminate duplication. The Advanced section now only contains Simulate Threshold Rising, making salary growth controls more discoverable and the configuration layout cleaner.

## Context

The previous layout had controls with mismatched visual heights that made the Repayment Start Year field appear out of place. Grouping similar-weight components (tall payment controls in row 1, compact controls in row 2) improves scannability. Moving Salary Growth inline with the salary slider makes the relationship clearer and reduces unnecessary abstraction in the Advanced section.