### PR TITLE
feat: set default salary to 40k with 4% growth

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 // Chart salary range
 export const MIN_SALARY = 25_000;
 export const MAX_SALARY = 150_000;
-export const DEFAULT_SALARY = 65_000;
+export const DEFAULT_SALARY = 40_000;
 export const SALARY_STEP = 5_000;
 
 // Overpay analysis constants

--- a/src/context/loanReducer.test.ts
+++ b/src/context/loanReducer.test.ts
@@ -12,7 +12,7 @@ describe("loanReducer", () => {
       expect(initialState.underGradPlanType).toBe("PLAN_2");
       expect(initialState.underGradBalance).toBe(45_000); // "2012-23 Grad" preset
       expect(initialState.postGradBalance).toBe(0);
-      expect(initialState.salary).toBe(65_000);
+      expect(initialState.salary).toBe(40_000);
     });
   });
 
@@ -80,7 +80,7 @@ describe("loanReducer", () => {
       expect(resetState.underGradBalance).toBe(45_000); // "2012-23 Grad" preset
       expect(resetState.postGradBalance).toBe(0);
       expect(resetState.underGradPlanType).toBe("PLAN_2");
-      expect(resetState.salary).toBe(65_000);
+      expect(resetState.salary).toBe(40_000);
     });
   });
 });

--- a/src/context/loanReducer.ts
+++ b/src/context/loanReducer.ts
@@ -10,7 +10,7 @@ export const initialState: LoanState = {
 
   // Overpay analysis defaults
   monthlyOverpayment: 0,
-  salaryGrowthRate: "none",
+  salaryGrowthRate: "moderate",
   thresholdGrowthRate: "none",
   lumpSumPayment: 10_000,
 };


### PR DESCRIPTION
Default salary increased from 65k to 40k and default salary growth changed from none to 4% (moderate rate).