### PR TITLE
feat: include overpayment input summary in verdict reason strings

### DIFF
--- a/src/components/overpay/OverpayPage.tsx
+++ b/src/components/overpay/OverpayPage.tsx
@@ -55,6 +55,7 @@ export function OverpayPage() {
         <OverpayVerdict
           recommendation={analysis.recommendation}
           reason={analysis.recommendationReason}
+          showDisclaimer={analysis.overpaymentContributions > 0}
         />
 
         <div className="grid gap-6 md:grid-cols-[1fr_260px]">

--- a/src/components/overpay/OverpayVerdict.tsx
+++ b/src/components/overpay/OverpayVerdict.tsx
@@ -16,19 +16,19 @@ const verdictConfig: Record<
   }
 > = {
   "dont-overpay": {
-    title: "Don't Overpay",
+    title: "Overpaying Costs More",
     className:
       "bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-800",
     icon: Cancel01Icon,
   },
   overpay: {
-    title: "Overpay Your Loan",
+    title: "Overpaying Saves Money",
     className:
       "bg-emerald-50 dark:bg-emerald-950/20 border-emerald-200 dark:border-emerald-800",
     icon: Tick02Icon,
   },
   marginal: {
-    title: "Personal Preference",
+    title: "Marginal Difference",
     className:
       "bg-amber-50 dark:bg-amber-950/30 border-amber-200 dark:border-amber-800",
     icon: Alert02Icon,
@@ -38,11 +38,13 @@ const verdictConfig: Record<
 interface OverpayVerdictProps {
   recommendation: RecommendationType;
   reason: string;
+  showDisclaimer: boolean;
 }
 
 export function OverpayVerdict({
   recommendation,
   reason,
+  showDisclaimer,
 }: OverpayVerdictProps) {
   const config = verdictConfig[recommendation];
 
@@ -55,6 +57,12 @@ export function OverpayVerdict({
       />
       <AlertTitle>{config.title}</AlertTitle>
       <AlertDescription>{reason}</AlertDescription>
+      {showDisclaimer && (
+        <p className="col-span-full mt-2 text-xs text-muted-foreground">
+          This is an estimate, not financial advice. Consider speaking to a
+          financial adviser.
+        </p>
+      )}
     </Alert>
   );
 }

--- a/src/lib/loans/overpay-simulate.test.ts
+++ b/src/lib/loans/overpay-simulate.test.ts
@@ -86,7 +86,7 @@ describe("simulateOverpayScenarios", () => {
 
       // High salary pays off quickly, overpaying saves significant interest
       if (result.recommendation === "overpay") {
-        expect(result.recommendationReason).toContain("saves");
+        expect(result.recommendationReason).toContain("could save");
       }
     });
 

--- a/src/lib/loans/overpay-simulate.ts
+++ b/src/lib/loans/overpay-simulate.ts
@@ -143,7 +143,13 @@ export function simulateOverpayScenarios(
   // Determine recommendation
   const hasOverpayment = monthlyOverpayment > 0 || lumpSumPayment > 0;
   const { recommendation, reason } = hasOverpayment
-    ? determineRecommendation(baseline, overpay, paymentDifference)
+    ? determineRecommendation(
+        baseline,
+        overpay,
+        paymentDifference,
+        monthlyOverpayment,
+        lumpSumPayment,
+      )
     : {
         recommendation: "marginal" as RecommendationType,
         reason: "Enter an overpayment amount to compare scenarios.",
@@ -228,13 +234,36 @@ function generateBalanceSeries(
 }
 
 /**
+ * Builds a human-readable summary of the overpayment inputs.
+ */
+function formatOverpaymentSummary(
+  monthlyOverpayment: number,
+  lumpSumPayment: number,
+): string {
+  const hasMonthly = monthlyOverpayment > 0;
+  const hasLumpSum = lumpSumPayment > 0;
+
+  if (hasLumpSum && hasMonthly) {
+    return `A lump sum of ${formatCurrency(lumpSumPayment)} and ${formatCurrency(monthlyOverpayment)}/month overpayment`;
+  }
+  if (hasLumpSum) {
+    return `A lump sum of ${formatCurrency(lumpSumPayment)}`;
+  }
+  return `Overpaying ${formatCurrency(monthlyOverpayment)}/month`;
+}
+
+/**
  * Determines the recommendation based on simulation results.
  */
 function determineRecommendation(
   baseline: ScenarioResult,
   overpay: ScenarioResult,
   paymentDifference: number,
+  monthlyOverpayment: number,
+  lumpSumPayment: number,
 ): { recommendation: RecommendationType; reason: string } {
+  const summary = formatOverpaymentSummary(monthlyOverpayment, lumpSumPayment);
+
   // If baseline loan is written off
   if (baseline.writtenOff) {
     // Check if overpaying prevents write-off
@@ -242,7 +271,7 @@ function determineRecommendation(
       // Still written off even with overpayment - definitely don't overpay
       return {
         recommendation: "dont-overpay",
-        reason: `Your loan will be written off regardless. Every pound you overpay is money lost.`,
+        reason: `Your loan will be written off regardless. ${summary} would not reduce the total amount you pay.`,
       };
     }
     // Overpaying prevents write-off - compare total outcomes
@@ -251,7 +280,7 @@ function determineRecommendation(
     if (extraPaidByOverpaying > 0) {
       return {
         recommendation: "dont-overpay",
-        reason: `Without overpaying, ${formatCurrency(baseline.amountWrittenOff)} would be written off. Overpaying would cost you ${formatCurrency(extraPaidByOverpaying)} more.`,
+        reason: `Without overpaying, ${formatCurrency(baseline.amountWrittenOff)} would be written off. ${summary} would increase total repayments by ${formatCurrency(extraPaidByOverpaying)}.`,
       };
     }
   }
@@ -263,22 +292,26 @@ function determineRecommendation(
       : 0;
 
   if (percentageDiff < 0.1 && Math.abs(paymentDifference) < 1000) {
+    const marginalDetail =
+      paymentDifference > 0
+        ? `would only save ${formatCurrency(paymentDifference)}`
+        : `would only cost an extra ${formatCurrency(Math.abs(paymentDifference))}`;
     return {
       recommendation: "marginal",
-      reason: `The difference is small (${formatCurrency(Math.abs(paymentDifference))}). Consider other factors like flexibility and peace of mind.`,
+      reason: `${summary} ${marginalDetail}. Other factors like flexibility and peace of mind may be worth considering.`,
     };
   }
 
   if (paymentDifference > 0) {
     return {
       recommendation: "overpay",
-      reason: `Overpaying saves ${formatCurrency(paymentDifference)} in total interest paid.`,
+      reason: `${summary} could save ${formatCurrency(paymentDifference)} in total interest based on these projections.`,
     };
   }
 
   return {
     recommendation: "dont-overpay",
-    reason: `Overpaying would cost you ${formatCurrency(Math.abs(paymentDifference))} more overall.`,
+    reason: `${summary} would increase total repayments by ${formatCurrency(Math.abs(paymentDifference))} based on these projections.`,
   };
 }
 


### PR DESCRIPTION
## Summary

Verdict messages now include specific overpayment configuration details (lump sum, monthly amount, or both) instead of using generic phrasing. This gives users immediate clarity about which overpayment scenario is being analyzed. Also updated verdict titles for directness and added a conditional disclaimer when overpayment is configured.

## Context

The marginal case messaging was improved to distinguish between small savings and small extra costs. Previously, negative differences would still say "would only save" due to using absolute value, which was misleading.