### PR TITLE
feat: reduce salary slider step to £1,000 increments

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,7 @@ import type { SalaryGrowthRate } from "@/types/store";
 export const MIN_SALARY = 25_000;
 export const MAX_SALARY = 150_000;
 export const DEFAULT_SALARY = 40_000;
-export const SALARY_STEP = 5_000;
+export const SALARY_STEP = 1_000;
 
 // Overpay analysis constants
 export const MIN_MONTHLY_OVERPAYMENT = 0;


### PR DESCRIPTION
Reduces the salary slider step from £5,000 to £1,000 on both the home page and overpay page for finer-grained salary adjustments.