### PR TITLE
feat: support arbitrary growth values

### DIFF
--- a/src/components/AdvancedConfigSection.tsx
+++ b/src/components/AdvancedConfigSection.tsx
@@ -3,28 +3,13 @@
 import { ArrowDown01Icon, ArrowUp01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useState } from "react";
-import type { ThresholdGrowthRate } from "@/types/store";
 import { Button } from "@/components/ui/button";
+import { THRESHOLD_GROWTH_OPTIONS } from "@/constants";
 import { useLoanContext } from "@/context/LoanContext";
 import {
   trackAdvancedConfigToggled,
   trackThresholdGrowthSelected,
 } from "@/lib/analytics";
-
-const thresholdGrowthOptions: {
-  value: ThresholdGrowthRate;
-  label: string;
-  description: string;
-}[] = [
-  {
-    value: "none",
-    label: "0%",
-    description: "Frozen thresholds (current policy)",
-  },
-  { value: "conservative", label: "2%", description: "Below-inflation growth" },
-  { value: "moderate", label: "3%", description: "Typical RPI-linked growth" },
-  { value: "aggressive", label: "4%", description: "Above-inflation growth" },
-];
 
 export function AdvancedConfigSection() {
   const [isOpen, setIsOpen] = useState(false);
@@ -76,9 +61,9 @@ export function AdvancedConfigSection() {
               aria-label="Threshold growth rate options"
               className="flex gap-1"
             >
-              {thresholdGrowthOptions.map((option) => (
+              {THRESHOLD_GROWTH_OPTIONS.map((option) => (
                 <Button
-                  key={option.value}
+                  key={option.label}
                   variant={
                     state.thresholdGrowthRate === option.value
                       ? "default"
@@ -98,7 +83,7 @@ export function AdvancedConfigSection() {
             </div>
             <p className="text-xs text-muted-foreground">
               {
-                thresholdGrowthOptions.find(
+                THRESHOLD_GROWTH_OPTIONS.find(
                   (o) => o.value === state.thresholdGrowthRate,
                 )?.description
               }

--- a/src/components/SalaryGrowthPicker.tsx
+++ b/src/components/SalaryGrowthPicker.tsx
@@ -18,7 +18,7 @@ export function SalaryGrowthPicker() {
       >
         {SALARY_GROWTH_OPTIONS.map((option) => (
           <Button
-            key={option.value}
+            key={option.label}
             variant={
               state.salaryGrowthRate === option.value ? "default" : "outline"
             }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,3 @@
-import type { SalaryGrowthRate } from "@/types/store";
-
 // Chart salary range
 export const MIN_SALARY = 25_000;
 export const MAX_SALARY = 150_000;
@@ -11,39 +9,35 @@ export const MIN_MONTHLY_OVERPAYMENT = 0;
 export const MAX_MONTHLY_OVERPAYMENT = 500;
 export const OVERPAYMENT_STEP = 25;
 
-/** Annual salary growth rates by preset type */
-export const SALARY_GROWTH_RATES = {
-  none: 0, // 0% - no salary growth
-  conservative: 0.02, // 2% - matches inflation only
-  moderate: 0.04, // 4% - typical career progression
-  aggressive: 0.06, // 6% - fast-track careers (tech, finance)
-} as const;
-
-/** Annual threshold growth rates by preset type.
- * Thresholds are typically RPI-linked (2-3% historically).
- * Note: Government has announced threshold freeze through 2027.
- */
-export const THRESHOLD_GROWTH_RATES = {
-  none: 0, // 0% - frozen thresholds (current policy)
-  conservative: 0.02, // 2% - below-inflation growth
-  moderate: 0.03, // 3% - typical RPI-linked growth
-  aggressive: 0.04, // 4% - above-inflation growth
-} as const;
-
-/** Salary growth rate option labels for toggle buttons */
+/** Salary growth rate options for toggle buttons */
 export const SALARY_GROWTH_OPTIONS: {
-  value: SalaryGrowthRate;
+  value: number;
   label: string;
   description: string;
 }[] = [
-  { value: "none", label: "0%", description: "No salary growth" },
-  { value: "conservative", label: "2%", description: "Matches inflation only" },
-  { value: "moderate", label: "4%", description: "Typical career progression" },
+  { value: 0, label: "0%", description: "No salary growth" },
+  { value: 0.02, label: "2%", description: "Matches inflation only" },
+  { value: 0.04, label: "4%", description: "Typical career progression" },
   {
-    value: "aggressive",
+    value: 0.06,
     label: "6%",
     description: "Fast-track careers (tech, finance)",
   },
+];
+
+/** Threshold growth rate options for toggle buttons.
+ * Thresholds are typically RPI-linked (2-3% historically).
+ * Note: Government has announced threshold freeze through 2027.
+ */
+export const THRESHOLD_GROWTH_OPTIONS: {
+  value: number;
+  label: string;
+  description: string;
+}[] = [
+  { value: 0, label: "0%", description: "Frozen thresholds (current policy)" },
+  { value: 0.02, label: "2%", description: "Below-inflation growth" },
+  { value: 0.03, label: "3%", description: "Typical RPI-linked growth" },
+  { value: 0.04, label: "4%", description: "Above-inflation growth" },
 ];
 
 // Formatters for chart display

--- a/src/context/loanReducer.ts
+++ b/src/context/loanReducer.ts
@@ -10,8 +10,8 @@ export const initialState: LoanState = {
 
   // Overpay analysis defaults
   monthlyOverpayment: 0,
-  salaryGrowthRate: "moderate",
-  thresholdGrowthRate: "none",
+  salaryGrowthRate: 0.04, // 4% - typical career progression
+  thresholdGrowthRate: 0, // 0% - frozen thresholds (current policy)
   lumpSumPayment: 10_000,
 };
 

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -5,12 +5,7 @@ import {
   useThresholdGrowthRate,
 } from "./useStoreSelectors";
 import type { DataPoint, BalanceDataPoint } from "@/types/chart";
-import {
-  MIN_SALARY,
-  MAX_SALARY,
-  SALARY_GROWTH_RATES,
-  THRESHOLD_GROWTH_RATES,
-} from "@/constants";
+import { MIN_SALARY, MAX_SALARY } from "@/constants";
 import {
   generateSalaryDataSeries,
   generateBalanceTimeSeries,
@@ -56,15 +51,13 @@ export function useTotalRepaymentData() {
   const salary = useCurrentSalary();
   const salaryGrowthRate = useSalaryGrowthRate();
   const thresholdGrowthRate = useThresholdGrowthRate();
-  const annualGrowthRate = SALARY_GROWTH_RATES[salaryGrowthRate];
-  const annualThresholdGrowth = THRESHOLD_GROWTH_RATES[thresholdGrowthRate];
 
   const data = generateSalaryDataSeries(
     config.loans,
     (r) => r.totalRepayment,
     undefined,
-    annualGrowthRate,
-    annualThresholdGrowth,
+    salaryGrowthRate,
+    thresholdGrowthRate,
   );
 
   const { annotationSalary, annotationValue } = useAnnotationData(salary, data);
@@ -81,14 +74,12 @@ export function useBalanceOverTimeData(): {
   const salary = useCurrentSalary();
   const salaryGrowthRate = useSalaryGrowthRate();
   const thresholdGrowthRate = useThresholdGrowthRate();
-  const annualGrowthRate = SALARY_GROWTH_RATES[salaryGrowthRate];
-  const annualThresholdGrowth = THRESHOLD_GROWTH_RATES[thresholdGrowthRate];
 
   return generateBalanceTimeSeries(
     config.loans,
     salary,
     undefined,
-    annualGrowthRate,
-    annualThresholdGrowth,
+    salaryGrowthRate,
+    thresholdGrowthRate,
   );
 }

--- a/src/hooks/usePersonalizedInsight.ts
+++ b/src/hooks/usePersonalizedInsight.ts
@@ -4,7 +4,6 @@ import {
   useSalaryGrowthRate,
   useThresholdGrowthRate,
 } from "./useStoreSelectors";
-import { SALARY_GROWTH_RATES, THRESHOLD_GROWTH_RATES } from "@/constants";
 import { generateInsight, type Insight } from "@/utils/insights";
 
 /**
@@ -13,12 +12,12 @@ import { generateInsight, type Insight } from "@/utils/insights";
 export function usePersonalizedInsight(): Insight | null {
   const config = useLoanConfig();
   const salary = useCurrentSalary();
-  const salaryGrowthPreset = useSalaryGrowthRate();
-  const thresholdGrowthPreset = useThresholdGrowthRate();
+  const salaryGrowthRate = useSalaryGrowthRate();
+  const thresholdGrowthRate = useThresholdGrowthRate();
 
   return generateInsight(salary, {
     ...config,
-    salaryGrowthRate: SALARY_GROWTH_RATES[salaryGrowthPreset],
-    thresholdGrowthRate: THRESHOLD_GROWTH_RATES[thresholdGrowthPreset],
+    salaryGrowthRate,
+    thresholdGrowthRate,
   });
 }

--- a/src/hooks/useStoreSelectors.ts
+++ b/src/hooks/useStoreSelectors.ts
@@ -1,5 +1,4 @@
 import type { Loan } from "@/lib/loans/types";
-import type { SalaryGrowthRate, ThresholdGrowthRate } from "@/types/store";
 import { useLoanContext } from "@/context/LoanContext";
 
 interface LoanConfig {
@@ -39,19 +38,19 @@ export function useCurrentSalary(): number {
 
 interface OverpayConfig {
   monthlyOverpayment: number;
-  salaryGrowthRate: SalaryGrowthRate;
-  thresholdGrowthRate: ThresholdGrowthRate;
+  salaryGrowthRate: number;
+  thresholdGrowthRate: number;
   lumpSumPayment: number;
 }
 
 /** Select salary growth rate for charts */
-export function useSalaryGrowthRate(): SalaryGrowthRate {
+export function useSalaryGrowthRate(): number {
   const { state } = useLoanContext();
   return state.salaryGrowthRate;
 }
 
 /** Select threshold growth rate for charts */
-export function useThresholdGrowthRate(): ThresholdGrowthRate {
+export function useThresholdGrowthRate(): number {
   const { state } = useLoanContext();
   return state.thresholdGrowthRate;
 }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -8,7 +8,7 @@ export function trackSalaryChanged(value: number) {
   track("salary_changed", { value });
 }
 
-export function trackSalaryGrowthSelected(rate: string) {
+export function trackSalaryGrowthSelected(rate: number) {
   track("salary_growth_selected", { rate });
 }
 
@@ -16,7 +16,7 @@ export function trackAdvancedConfigToggled(expanded: boolean) {
   track("advanced_config_toggled", { expanded });
 }
 
-export function trackThresholdGrowthSelected(rate: string) {
+export function trackThresholdGrowthSelected(rate: number) {
   track("threshold_growth_selected", { rate });
 }
 
@@ -128,7 +128,7 @@ export function trackSharedMonthlyOverpaymentLoaded(value: number) {
   track("shared_monthly_overpayment_loaded", { value });
 }
 
-export function trackSharedSalaryGrowthLoaded(rate: string) {
+export function trackSharedSalaryGrowthLoaded(rate: number) {
   track("shared_salary_growth_loaded", { rate });
 }
 

--- a/src/lib/loans/overpay-simulate.test.ts
+++ b/src/lib/loans/overpay-simulate.test.ts
@@ -18,7 +18,8 @@ describe("simulateOverpayScenarios", () => {
     startingSalary: 50000,
     repaymentStartDate: new Date("2022-04-01"),
     monthlyOverpayment: 200,
-    salaryGrowthRate: "moderate",
+    salaryGrowthRate: 0.04, // 4% - typical career progression
+    thresholdGrowthRate: 0, // 0% - frozen thresholds
     rpiRate: CURRENT_RATES.rpi,
     boeBaseRate: CURRENT_RATES.boeBaseRate,
   };
@@ -67,7 +68,7 @@ describe("simulateOverpayScenarios", () => {
         loans: [{ planType: "PLAN_2", balance: 100000 }],
         startingSalary: 30000,
         monthlyOverpayment: 100,
-        salaryGrowthRate: "conservative",
+        salaryGrowthRate: 0.02, // 2% - conservative
       });
 
       expect(result.baseline.writtenOff).toBe(true);
@@ -151,12 +152,12 @@ describe("simulateOverpayScenarios", () => {
     it("aggressive growth results in faster payoff", () => {
       const conservative = simulateOverpayScenarios({
         ...defaultInput,
-        salaryGrowthRate: "conservative",
+        salaryGrowthRate: 0.02, // 2% - conservative
       });
 
       const aggressive = simulateOverpayScenarios({
         ...defaultInput,
-        salaryGrowthRate: "aggressive",
+        salaryGrowthRate: 0.06, // 6% - aggressive
       });
 
       expect(aggressive.baseline.monthsToPayoff).toBeLessThanOrEqual(
@@ -168,7 +169,7 @@ describe("simulateOverpayScenarios", () => {
       const result = simulateOverpayScenarios({
         ...defaultInput,
         startingSalary: 50000,
-        salaryGrowthRate: "moderate",
+        salaryGrowthRate: 0.04, // 4% - moderate
       });
 
       if (result.baseline.monthsToPayoff > 12) {
@@ -220,7 +221,7 @@ describe("simulateOverpayScenarios", () => {
         ...defaultInput,
         loans: [{ planType: "PLAN_2", balance: 100000 }],
         startingSalary: 30000,
-        salaryGrowthRate: "conservative",
+        salaryGrowthRate: 0.02, // 2% - conservative
       });
 
       if (result.baseline.writtenOff) {
@@ -300,7 +301,7 @@ describe("simulateOverpayScenarios", () => {
         ...defaultInput,
         loans: [{ planType: "PLAN_5", balance: 60000 }],
         startingSalary: 35000,
-        salaryGrowthRate: "conservative",
+        salaryGrowthRate: 0.02, // 2% - conservative
       });
 
       expect(result.baseline.monthsToPayoff).toBeGreaterThan(0);
@@ -424,7 +425,7 @@ describe("simulateOverpayScenarios", () => {
         startingSalary: 30000,
         monthlyOverpayment: 0,
         lumpSumPayment: 10000,
-        salaryGrowthRate: "conservative",
+        salaryGrowthRate: 0.02, // 2% - conservative
       });
 
       if (result.baseline.writtenOff) {

--- a/src/lib/loans/overpay-simulate.ts
+++ b/src/lib/loans/overpay-simulate.ts
@@ -8,7 +8,6 @@ import type {
   RecommendationType,
 } from "./overpay-types";
 import type { Loan, SimulationTimeSeries } from "./types";
-import { SALARY_GROWTH_RATES, THRESHOLD_GROWTH_RATES } from "@/constants";
 import { monthsElapsedSince } from "@/lib/date-utils";
 
 /**
@@ -56,8 +55,6 @@ export function simulateOverpayScenarios(
 
   const rpi = rpiRate ?? CURRENT_RATES.rpi;
   const boe = boeBaseRate ?? CURRENT_RATES.boeBaseRate;
-  const annualGrowthRate = SALARY_GROWTH_RATES[salaryGrowthRate];
-  const annualThresholdGrowth = THRESHOLD_GROWTH_RATES[thresholdGrowthRate];
 
   // Check for empty scenarios
   const validLoans = loans.filter((l) => l.balance > 0);
@@ -83,9 +80,9 @@ export function simulateOverpayScenarios(
     loans: validLoans,
     annualSalary: startingSalary,
     monthsElapsed,
-    salaryGrowthRate: annualGrowthRate,
+    salaryGrowthRate,
     monthlyOverpayment: 0,
-    thresholdGrowthRate: annualThresholdGrowth,
+    thresholdGrowthRate,
     rpiRate: rpi,
     boeBaseRate: boe,
   });
@@ -98,9 +95,9 @@ export function simulateOverpayScenarios(
           loans: loansAfterLumpSum,
           annualSalary: startingSalary,
           monthsElapsed,
-          salaryGrowthRate: annualGrowthRate,
+          salaryGrowthRate,
           monthlyOverpayment,
-          thresholdGrowthRate: annualThresholdGrowth,
+          thresholdGrowthRate,
           rpiRate: rpi,
           boeBaseRate: boe,
         });

--- a/src/lib/loans/overpay-types.ts
+++ b/src/lib/loans/overpay-types.ts
@@ -1,5 +1,4 @@
 import type { Loan } from "./types";
-import type { SalaryGrowthRate, ThresholdGrowthRate } from "@/types/store";
 
 /**
  * Input parameters for overpay analysis simulation.
@@ -9,8 +8,10 @@ export interface OverpayInput {
   startingSalary: number;
   repaymentStartDate: Date;
   monthlyOverpayment: number;
-  salaryGrowthRate: SalaryGrowthRate;
-  thresholdGrowthRate: ThresholdGrowthRate;
+  /** Salary growth rate as decimal (e.g., 0.04 = 4%) */
+  salaryGrowthRate: number;
+  /** Threshold growth rate as decimal (e.g., 0.02 = 2%) */
+  thresholdGrowthRate: number;
   rpiRate?: number;
   boeBaseRate?: number;
   lumpSumPayment?: number;

--- a/src/lib/shareUrl.test.ts
+++ b/src/lib/shareUrl.test.ts
@@ -14,7 +14,8 @@ const mockState: LoanState = {
   postGradBalance: 12000,
   salary: 65000,
   monthlyOverpayment: 200,
-  salaryGrowthRate: "moderate",
+  salaryGrowthRate: 0.04,
+  thresholdGrowthRate: 0,
   lumpSumPayment: 10000,
 };
 
@@ -65,7 +66,7 @@ describe("encodeStateToParams", () => {
     });
 
     expect(params.get("ovp")).toBe("200");
-    expect(params.get("sgr")).toBe("moderate");
+    expect(params.get("sgr")).toBe("0.04");
     expect(params.get("lsp")).toBe("10000");
     expect(params.get("repy")).toBe("2018");
   });
@@ -76,7 +77,7 @@ describe("encodeStateToParams", () => {
     });
 
     expect(params.get("ovp")).toBe("200");
-    expect(params.get("sgr")).toBe("moderate");
+    expect(params.get("sgr")).toBe("0.04");
     expect(params.get("lsp")).toBe("10000");
     expect(params.get("repy")).toBeNull();
   });
@@ -164,16 +165,21 @@ describe("decodeParamsToState", () => {
     expect(state.postGradBalance).toBeUndefined();
   });
 
-  it("decodes overpay fields", () => {
-    const params = new URLSearchParams(
-      "ovp=300&sgr=aggressive&lsp=15000&repy=2020",
-    );
+  it("decodes overpay fields with numeric salaryGrowthRate", () => {
+    const params = new URLSearchParams("ovp=300&sgr=0.06&lsp=15000&repy=2020");
     const state = decodeParamsToState(params);
 
     expect(state.monthlyOverpayment).toBe(300);
-    expect(state.salaryGrowthRate).toBe("aggressive");
+    expect(state.salaryGrowthRate).toBe(0.06);
     expect(state.lumpSumPayment).toBe(15000);
     expect(state.repaymentYear).toBe(2020);
+  });
+
+  it("decodes legacy string salaryGrowthRate presets", () => {
+    const params = new URLSearchParams("sgr=aggressive");
+    const state = decodeParamsToState(params);
+
+    expect(state.salaryGrowthRate).toBe(0.06);
   });
 
   it("ignores invalid salaryGrowthRate values", () => {
@@ -183,18 +189,28 @@ describe("decodeParamsToState", () => {
     expect(state.salaryGrowthRate).toBeUndefined();
   });
 
-  it("validates salaryGrowthRate values", () => {
-    const validRates = [
-      "none",
-      "conservative",
-      "moderate",
-      "aggressive",
-    ] as const;
-    for (const rate of validRates) {
-      const params = new URLSearchParams(`sgr=${rate}`);
+  it("maps legacy salaryGrowthRate string values to numbers", () => {
+    const legacyMapping = [
+      { legacy: "none", expected: 0 },
+      { legacy: "conservative", expected: 0.02 },
+      { legacy: "moderate", expected: 0.04 },
+      { legacy: "aggressive", expected: 0.06 },
+    ];
+    for (const { legacy, expected } of legacyMapping) {
+      const params = new URLSearchParams(`sgr=${legacy}`);
       const state = decodeParamsToState(params);
-      expect(state.salaryGrowthRate).toBe(rate);
+      expect(state.salaryGrowthRate).toBe(expected);
     }
+  });
+
+  it("accepts arbitrary salaryGrowthRate values", () => {
+    // Negative (salary decline)
+    const paramsNegative = new URLSearchParams("sgr=-0.1");
+    expect(decodeParamsToState(paramsNegative).salaryGrowthRate).toBe(-0.1);
+
+    // High growth
+    const paramsHigh = new URLSearchParams("sgr=0.5");
+    expect(decodeParamsToState(paramsHigh).salaryGrowthRate).toBe(0.5);
   });
 
   it("clamps overpayment below minimum to 0", () => {
@@ -291,7 +307,7 @@ describe("round-trip encoding/decoding", () => {
   });
 
   it("round-trips for all salary growth rates", () => {
-    const rates = ["none", "conservative", "moderate", "aggressive"] as const;
+    const rates = [0, 0.02, 0.04, 0.06, 0.1];
     for (const rate of rates) {
       const state: LoanState = { ...mockState, salaryGrowthRate: rate };
       const params = encodeStateToParams(state, { includeOverpayFields: true });
@@ -379,7 +395,7 @@ describe("generateShareUrl", () => {
     const url = generateShareUrl(mockState, { repaymentYear: 2018 });
 
     expect(url).toContain("ovp=200");
-    expect(url).toContain("sgr=moderate");
+    expect(url).toContain("sgr=0.04");
     expect(url).toContain("lsp=10000");
     expect(url).toContain("repy=2018");
 

--- a/src/lib/shareUrl.ts
+++ b/src/lib/shareUrl.ts
@@ -1,5 +1,5 @@
 import type { UndergraduatePlanType } from "@/lib/loans/types";
-import type { LoanState, SalaryGrowthRate } from "@/types/store";
+import type { LoanState } from "@/types/store";
 import {
   MIN_SALARY,
   MAX_SALARY,
@@ -31,6 +31,14 @@ const MAX_LUMP_SUM = 100_000;
 const MIN_REPAYMENT_YEAR = 2000;
 const MAX_REPAYMENT_YEAR = 2050;
 
+// Legacy mapping for old string presets to numeric values
+const LEGACY_SALARY_GROWTH_MAPPING: Record<string, number> = {
+  none: 0,
+  conservative: 0.02,
+  moderate: 0.04,
+  aggressive: 0.06,
+};
+
 const VALID_PLANS: UndergraduatePlanType[] = [
   "PLAN_1",
   "PLAN_2",
@@ -38,19 +46,8 @@ const VALID_PLANS: UndergraduatePlanType[] = [
   "PLAN_5",
 ];
 
-const VALID_SALARY_GROWTH_RATES: SalaryGrowthRate[] = [
-  "none",
-  "conservative",
-  "moderate",
-  "aggressive",
-];
-
 function isValidPlan(plan: string): plan is UndergraduatePlanType {
   return VALID_PLANS.includes(plan as UndergraduatePlanType);
-}
-
-function isValidSalaryGrowthRate(rate: string): rate is SalaryGrowthRate {
-  return VALID_SALARY_GROWTH_RATES.includes(rate as SalaryGrowthRate);
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -77,7 +74,7 @@ export function encodeStateToParams(
 
   if (options.includeOverpayFields) {
     params.set(PARAM_OVP, String(state.monthlyOverpayment));
-    params.set(PARAM_SGR, state.salaryGrowthRate);
+    params.set(PARAM_SGR, String(state.salaryGrowthRate));
     params.set(PARAM_LSP, String(state.lumpSumPayment));
     if (options.repaymentYear !== undefined) {
       params.set(PARAM_REPY, String(options.repaymentYear));
@@ -141,8 +138,15 @@ export function decodeParamsToState(params: URLSearchParams): DecodedState {
   }
 
   const sgrParam = params.get(PARAM_SGR);
-  if (sgrParam !== null && isValidSalaryGrowthRate(sgrParam)) {
-    result.salaryGrowthRate = sgrParam;
+  if (sgrParam !== null) {
+    // Try parsing as number first (new format)
+    const numValue = parseFloat(sgrParam);
+    if (!isNaN(numValue)) {
+      result.salaryGrowthRate = numValue;
+    } else if (sgrParam in LEGACY_SALARY_GROWTH_MAPPING) {
+      // Fall back to legacy string preset mapping
+      result.salaryGrowthRate = LEGACY_SALARY_GROWTH_MAPPING[sgrParam];
+    }
   }
 
   const lspParam = params.get(PARAM_LSP);

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -1,24 +1,6 @@
 import type { UndergraduatePlanType } from "@/lib/loans/types";
 
 /**
- * Salary growth rate presets for overpay analysis.
- */
-export type SalaryGrowthRate =
-  | "none"
-  | "conservative"
-  | "moderate"
-  | "aggressive";
-
-/**
- * Threshold growth rate presets for simulation.
- */
-export type ThresholdGrowthRate =
-  | "none"
-  | "conservative"
-  | "moderate"
-  | "aggressive";
-
-/**
  * Core loan state values stored in the application state.
  */
 export interface LoanState {
@@ -34,10 +16,10 @@ export interface LoanState {
   // Overpay analysis fields
   /** Monthly overpayment amount in GBP (0-500) */
   monthlyOverpayment: number;
-  /** Expected salary growth rate preset */
-  salaryGrowthRate: SalaryGrowthRate;
-  /** Expected threshold growth rate preset */
-  thresholdGrowthRate: ThresholdGrowthRate;
+  /** Expected salary growth rate as decimal (e.g., 0.04 = 4%) */
+  salaryGrowthRate: number;
+  /** Expected threshold growth rate as decimal (e.g., 0.02 = 2%) */
+  thresholdGrowthRate: number;
   /** One-off lump sum payment in GBP */
   lumpSumPayment: number;
 }


### PR DESCRIPTION
## Summary

The simulation engine now accepts arbitrary decimal values for salary growth and threshold growth rates instead of preset strings. This enables users to simulate salary decline, extreme growth, and any custom value. Type aliases have been removed and the conversion lookup layer simplified, reducing code complexity.

## Context

Previously, users were limited to four preset growth rates ("none", "conservative", "moderate", "aggressive") which mapped to fixed percentages. The new approach removes all bounds and conversion logic, allowing direct numeric input while maintaining backward compatibility with legacy URLs that use string presets.