### PR TITLE
refactor: migrate to React 19 context pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 - Manual memoization (`useMemo`, `useCallback`, `React.memo`) — React Compiler handles this automatically. Exception: auto-generated shadcn/ui components.
 - Barrel files (`index.ts` re-export files) — import directly from source modules instead (e.g., `@/lib/loans/types` not `@/lib/loans`).
 - Default exports — use named exports instead (e.g., `export function Header` not `export default Header`). Exception: Next.js App Router requires default exports for `page.tsx` and `layout.tsx` files.
+- `Context.Provider` / `useContext` — use `<Context value={...}>` and `use(Context)` directly (React 19 pattern)
 
 Fix underlying issues instead of suppressing errors.
 

--- a/src/context/LoanContext.tsx
+++ b/src/context/LoanContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useReducer, type ReactNode } from "react";
+import { createContext, use, useReducer, type ReactNode } from "react";
 import {
   loanReducer,
   initialState,
@@ -37,14 +37,14 @@ export function LoanProvider({ children }: LoanProviderProps) {
   };
 
   return (
-    <LoanContext.Provider value={{ state, updateField, applyPreset }}>
+    <LoanContext value={{ state, updateField, applyPreset }}>
       {children}
-    </LoanContext.Provider>
+    </LoanContext>
   );
 }
 
 export function useLoanContext(): LoanContextValue {
-  const context = useContext(LoanContext);
+  const context = use(LoanContext);
   if (context === null) {
     throw new Error("useLoanContext must be used within a LoanProvider");
   }

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useSyncExternalStore,
-} from "react";
+import { createContext, use, useEffect, useSyncExternalStore } from "react";
 
 type Theme = "light" | "dark" | "system";
 type ResolvedTheme = "light" | "dark";
@@ -99,9 +94,9 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme }}>
+    <ThemeContext value={{ theme, resolvedTheme, setTheme }}>
       {children}
-    </ThemeContext.Provider>
+    </ThemeContext>
   );
 }
 
@@ -113,7 +108,7 @@ const defaultThemeValue: ThemeContextValue = {
 };
 
 export function useTheme() {
-  const context = useContext(ThemeContext);
+  const context = use(ThemeContext);
   // Return default values if context is not available (SSR safety)
   return context ?? defaultThemeValue;
 }

--- a/src/hooks/useChartData.test.tsx
+++ b/src/hooks/useChartData.test.tsx
@@ -1,11 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import {
-  createContext,
-  useContext,
-  useReducer,
-  useMemo,
-  type ReactNode,
-} from "react";
+import { createContext, use, useReducer, useMemo, type ReactNode } from "react";
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { useTotalRepaymentData, useBalanceOverTimeData } from "./useChartData";
 import { MIN_SALARY, MAX_SALARY, SALARY_STEP } from "../constants";
@@ -50,14 +44,10 @@ vi.mock("../context/LoanContext", () => {
         [state],
       );
 
-      return (
-        <LoanContext.Provider value={contextValue}>
-          {children}
-        </LoanContext.Provider>
-      );
+      return <LoanContext value={contextValue}>{children}</LoanContext>;
     },
     useLoanContext: () => {
-      const context = useContext(LoanContext);
+      const context = use(LoanContext);
       if (context === null) {
         throw new Error("useLoanContext must be used within a LoanProvider");
       }


### PR DESCRIPTION
## Summary

Migrate context providers and consumers to use React 19's simplified syntax. Replace deprecated `<Context.Provider>` with `<Context>` directly and `useContext(Context)` with `use(Context)`.

## Context

React 19 introduced new context patterns that are more concise and performant. Updated code quality guidelines to enforce this pattern across the codebase.