### PR TITLE
refactor: move loan simulations to shared web worker for INP optimization

### DIFF
--- a/src/components/AdvancedConfigSection.tsx
+++ b/src/components/AdvancedConfigSection.tsx
@@ -5,7 +5,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { THRESHOLD_GROWTH_OPTIONS } from "@/constants";
-import { useLoanContext } from "@/context/LoanContext";
+import { useLoanActions, useLoanConfigState } from "@/context/LoanContext";
 import {
   trackAdvancedConfigToggled,
   trackThresholdGrowthSelected,
@@ -17,7 +17,8 @@ export function AdvancedConfigSection() {
   // This matches the Header personalise panel animation pattern (CSS transitions)
   // rather than shadcn Collapsible's accordion animation.
   const [isFullyOpen, setIsFullyOpen] = useState(false);
-  const { state, updateField } = useLoanContext();
+  const { updateField } = useLoanActions();
+  const { thresholdGrowthRate } = useLoanConfigState();
 
   return (
     <div>
@@ -65,16 +66,14 @@ export function AdvancedConfigSection() {
                 <Button
                   key={option.label}
                   variant={
-                    state.thresholdGrowthRate === option.value
-                      ? "default"
-                      : "outline"
+                    thresholdGrowthRate === option.value ? "default" : "outline"
                   }
                   size="sm"
                   onClick={() => {
                     trackThresholdGrowthSelected(option.value);
                     updateField("thresholdGrowthRate", option.value);
                   }}
-                  aria-pressed={state.thresholdGrowthRate === option.value}
+                  aria-pressed={thresholdGrowthRate === option.value}
                   className="flex-1"
                 >
                   {option.label}
@@ -84,7 +83,7 @@ export function AdvancedConfigSection() {
             <p className="text-xs text-muted-foreground">
               {
                 THRESHOLD_GROWTH_OPTIONS.find(
-                  (o) => o.value === state.thresholdGrowthRate,
+                  (o) => o.value === thresholdGrowthRate,
                 )?.description
               }
             </p>

--- a/src/components/AdvancedInputs.tsx
+++ b/src/components/AdvancedInputs.tsx
@@ -3,7 +3,7 @@
 import CurrencyInput from "./CurrencyInput";
 import PlanSelector from "./PlanSelector";
 import { currencyFormatter } from "@/constants";
-import { useLoanContext } from "@/context/LoanContext";
+import { useLoanActions, useLoanConfigState } from "@/context/LoanContext";
 import {
   trackUndergradBalanceChanged,
   trackPostgradBalanceChanged,
@@ -11,9 +11,10 @@ import {
 import { POSTGRADUATE_DISPLAY_INFO } from "@/lib/loans/plans";
 
 export function AdvancedInputs() {
-  const { state, updateField } = useLoanContext();
-  const hasUndergrad = state.underGradBalance > 0;
-  const hasPostgrad = state.postGradBalance > 0;
+  const { updateField } = useLoanActions();
+  const config = useLoanConfigState();
+  const hasUndergrad = config.underGradBalance > 0;
+  const hasPostgrad = config.postGradBalance > 0;
 
   return (
     <div className="space-y-6">
@@ -32,12 +33,12 @@ export function AdvancedInputs() {
             <div className="w-32">
               <CurrencyInput
                 id="adv-undergrad-balance"
-                value={state.underGradBalance}
+                value={config.underGradBalance}
                 onChange={(value) => {
                   updateField("underGradBalance", value);
                 }}
                 onBlur={() => {
-                  trackUndergradBalanceChanged(state.underGradBalance);
+                  trackUndergradBalanceChanged(config.underGradBalance);
                 }}
               />
             </div>
@@ -63,12 +64,12 @@ export function AdvancedInputs() {
             <div className="w-32">
               <CurrencyInput
                 id="adv-postgrad-balance"
-                value={state.postGradBalance}
+                value={config.postGradBalance}
                 onChange={(value) => {
                   updateField("postGradBalance", value);
                 }}
                 onBlur={() => {
-                  trackPostgradBalanceChanged(state.postGradBalance);
+                  trackPostgradBalanceChanged(config.postGradBalance);
                 }}
               />
             </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,7 +11,10 @@ import { ShareButton } from "./ShareButton";
 import ThemeToggle from "./ThemeToggle";
 import { Button } from "@/components/ui/button";
 import { currencyFormatter } from "@/constants";
-import { useLoanContext } from "@/context/LoanContext";
+import {
+  useLoanFrequentState,
+  useLoanConfigState,
+} from "@/context/LoanContext";
 import { trackPersonalisePanelToggled } from "@/lib/analytics";
 import { getAnnualInterestRate } from "@/lib/loans/interest";
 import {
@@ -69,9 +72,9 @@ function FullHeaderContent({ repaymentYear }: FullHeaderContentProps) {
   const [isFullyOpen, setIsFullyOpen] = useState(false);
   const headerRef = useRef<HTMLElement>(null);
 
-  const { state } = useLoanContext();
-  const { underGradPlanType, underGradBalance, postGradBalance, salary } =
-    state;
+  const { salary } = useLoanFrequentState();
+  const { underGradPlanType, underGradBalance, postGradBalance } =
+    useLoanConfigState();
 
   const hasUndergrad = underGradBalance > 0;
   const hasPostgrad = postGradBalance > 0;

--- a/src/components/PlanFromQuery.tsx
+++ b/src/components/PlanFromQuery.tsx
@@ -2,7 +2,7 @@
 
 import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useRef } from "react";
-import { useLoanContext } from "@/context/LoanContext";
+import { useLoanActions } from "@/context/LoanContext";
 import {
   trackSharedPlanLoaded,
   trackSharedUndergradBalanceLoaded,
@@ -21,7 +21,7 @@ interface PlanFromQueryProps {
 
 function PlanFromQueryInner({ onRepaymentYearChange }: PlanFromQueryProps) {
   const searchParams = useSearchParams();
-  const { updateField } = useLoanContext();
+  const { updateField } = useLoanActions();
   const lastAppliedParams = useRef<string>("");
 
   useEffect(() => {

--- a/src/components/PlanSelector.tsx
+++ b/src/components/PlanSelector.tsx
@@ -14,7 +14,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { currencyFormatter } from "@/constants";
-import { useLoanContext } from "@/context/LoanContext";
+import { useLoanActions, useLoanConfigState } from "@/context/LoanContext";
 import { trackPlanSelected, trackPlanInfoViewed } from "@/lib/analytics";
 import { PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
 
@@ -26,8 +26,8 @@ const PLAN_TYPES: UndergraduatePlanType[] = [
 ];
 
 export function PlanSelector() {
-  const { state, updateField } = useLoanContext();
-  const selectedPlan = state.underGradPlanType;
+  const { updateField } = useLoanActions();
+  const { underGradPlanType: selectedPlan } = useLoanConfigState();
   const selectedInfo = PLAN_DISPLAY_INFO[selectedPlan];
 
   return (

--- a/src/components/PresetPills.tsx
+++ b/src/components/PresetPills.tsx
@@ -1,19 +1,20 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { useLoanContext } from "@/context/LoanContext";
+import { useLoanActions, useLoanConfigState } from "@/context/LoanContext";
 import { trackPresetApplied } from "@/lib/analytics";
 import { PRESETS } from "@/lib/presets";
 
 export function PresetPills() {
-  const { state, applyPreset } = useLoanContext();
+  const { applyPreset } = useLoanActions();
+  const config = useLoanConfigState();
 
   // Find matching preset based on loan configuration
   const activePreset = PRESETS.find(
     (p) =>
-      p.underGradBalance === state.underGradBalance &&
-      p.postGradBalance === state.postGradBalance &&
-      p.underGradPlanType === state.underGradPlanType,
+      p.underGradBalance === config.underGradBalance &&
+      p.postGradBalance === config.postGradBalance &&
+      p.underGradPlanType === config.underGradPlanType,
   );
 
   return (

--- a/src/components/QuickInputs.tsx
+++ b/src/components/QuickInputs.tsx
@@ -9,12 +9,12 @@ import {
   SALARY_STEP,
   currencyFormatter,
 } from "@/constants";
-import { useLoanContext } from "@/context/LoanContext";
+import { useLoanActions, useLoanFrequentState } from "@/context/LoanContext";
 import { trackSalaryChanged } from "@/lib/analytics";
 
 export function QuickInputs() {
-  const { state, updateField } = useLoanContext();
-  const salary = state.salary;
+  const { updateField } = useLoanActions();
+  const { salary } = useLoanFrequentState();
 
   const handleSalaryChange = (value: number | readonly number[]) => {
     const newSalary = typeof value === "number" ? value : value[0];

--- a/src/components/SalaryGrowthPicker.tsx
+++ b/src/components/SalaryGrowthPicker.tsx
@@ -2,11 +2,12 @@
 
 import { Button } from "@/components/ui/button";
 import { SALARY_GROWTH_OPTIONS } from "@/constants";
-import { useLoanContext } from "@/context/LoanContext";
+import { useLoanActions, useLoanConfigState } from "@/context/LoanContext";
 import { trackSalaryGrowthSelected } from "@/lib/analytics";
 
 export function SalaryGrowthPicker() {
-  const { state, updateField } = useLoanContext();
+  const { updateField } = useLoanActions();
+  const { salaryGrowthRate } = useLoanConfigState();
 
   return (
     <fieldset className="space-y-2">
@@ -18,16 +19,14 @@ export function SalaryGrowthPicker() {
       >
         {SALARY_GROWTH_OPTIONS.map((option) => (
           <Button
-            key={option.label}
-            variant={
-              state.salaryGrowthRate === option.value ? "default" : "outline"
-            }
+            key={option.value}
+            variant={salaryGrowthRate === option.value ? "default" : "outline"}
             size="sm"
             onClick={() => {
               trackSalaryGrowthSelected(option.value);
               updateField("salaryGrowthRate", option.value);
             }}
-            aria-pressed={state.salaryGrowthRate === option.value}
+            aria-pressed={salaryGrowthRate === option.value}
             className="flex-1"
           >
             {option.label}
@@ -36,7 +35,7 @@ export function SalaryGrowthPicker() {
       </div>
       <p className="text-xs text-muted-foreground">
         {
-          SALARY_GROWTH_OPTIONS.find((o) => o.value === state.salaryGrowthRate)
+          SALARY_GROWTH_OPTIONS.find((o) => o.value === salaryGrowthRate)
             ?.description
         }
       </p>

--- a/src/components/TotalRepaymentChart.tsx
+++ b/src/components/TotalRepaymentChart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useDeferredValue } from "react";
 import { ChartBase } from "./charts/ChartBase";
 import type { ChartConfig } from "@/components/ui/chart";
 import { currencyFormatter, MIN_SALARY, MAX_SALARY } from "@/constants";
@@ -15,13 +16,19 @@ const chartConfig = {
 export function TotalRepaymentChart() {
   const { data, annotationSalary, annotationValue } = useTotalRepaymentData();
 
+  // Defer annotation so slider interactions aren't blocked by chart re-renders.
+  // The chart data itself doesn't change with salary (it's a full salary sweep),
+  // but the annotation position does, and re-rendering the chart is expensive.
+  const deferredSalary = useDeferredValue(annotationSalary);
+  const deferredValue = useDeferredValue(annotationValue);
+
   const annotations =
-    annotationSalary !== undefined && annotationValue !== undefined
+    deferredSalary !== undefined && deferredValue !== undefined
       ? [
           {
-            x: annotationSalary,
-            y: annotationValue,
-            label: currencyFormatter.format(annotationValue),
+            x: deferredSalary,
+            y: deferredValue,
+            label: currencyFormatter.format(deferredValue),
             color: "var(--chart-3)",
           },
         ]

--- a/src/components/overpay/OverpayPrimaryInputs.tsx
+++ b/src/components/overpay/OverpayPrimaryInputs.tsx
@@ -14,7 +14,7 @@ import {
   SALARY_STEP,
   currencyFormatter,
 } from "@/constants";
-import { useLoanContext } from "@/context/LoanContext";
+import { useLoanActions, useLoanFrequentState } from "@/context/LoanContext";
 import { useLoanConfig } from "@/hooks/useStoreSelectors";
 import {
   trackOverpaySalaryChanged,
@@ -31,7 +31,8 @@ export function OverpayPrimaryInputs({
   repaymentDate,
   onRepaymentDateChange,
 }: OverpayPrimaryInputsProps) {
-  const { state, updateField } = useLoanContext();
+  const { updateField } = useLoanActions();
+  const { salary, monthlyOverpayment, lumpSumPayment } = useLoanFrequentState();
   const { underGradBalance, postGradBalance } = useLoanConfig();
   const totalBalance = underGradBalance + postGradBalance;
 
@@ -68,13 +69,13 @@ export function OverpayPrimaryInputs({
                   type="text"
                   inputMode="numeric"
                   value={
-                    state.lumpSumPayment === 0
+                    lumpSumPayment === 0
                       ? ""
-                      : state.lumpSumPayment.toLocaleString("en-GB")
+                      : lumpSumPayment.toLocaleString("en-GB")
                   }
                   onChange={handleLumpSumChange}
                   onBlur={() => {
-                    trackOverpayLumpsumChanged(state.lumpSumPayment);
+                    trackOverpayLumpsumChanged(lumpSumPayment);
                   }}
                   placeholder="0"
                   className="pl-6"
@@ -96,12 +97,12 @@ export function OverpayPrimaryInputs({
           <div className="flex items-center justify-between">
             <Label htmlFor="overpayment-slider">Monthly Overpayment</Label>
             <span className="text-sm font-medium tabular-nums">
-              {currencyFormatter.format(state.monthlyOverpayment)}
+              {currencyFormatter.format(monthlyOverpayment)}
             </span>
           </div>
           <Slider
             id="overpayment-slider"
-            value={[state.monthlyOverpayment]}
+            value={[monthlyOverpayment]}
             onValueChange={handleOverpaymentChange}
             onValueCommitted={(value) => {
               const overpayValue = typeof value === "number" ? value : value[0];
@@ -124,12 +125,12 @@ export function OverpayPrimaryInputs({
           <div className="flex items-center justify-between">
             <Label htmlFor="salary-slider">Current Salary</Label>
             <span className="text-sm font-medium tabular-nums">
-              {currencyFormatter.format(state.salary)}
+              {currencyFormatter.format(salary)}
             </span>
           </div>
           <Slider
             id="salary-slider"
-            value={[state.salary]}
+            value={[salary]}
             onValueChange={handleSalaryChange}
             onValueCommitted={(value) => {
               const salaryValue = typeof value === "number" ? value : value[0];

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -49,7 +49,7 @@ function ChartContainer({
   const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`;
 
   return (
-    <ChartContext.Provider value={{ config }}>
+    <ChartContext value={{ config }}>
       <div
         data-slot="chart"
         data-chart={chartId}
@@ -64,7 +64,7 @@ function ChartContainer({
           {children}
         </RechartsPrimitive.ResponsiveContainer>
       </div>
-    </ChartContext.Provider>
+    </ChartContext>
   );
 }
 

--- a/src/context/LoanContext.tsx
+++ b/src/context/LoanContext.tsx
@@ -7,16 +7,38 @@ import {
   updateFieldAction,
   applyPresetAction,
 } from "./loanReducer";
+import type { UndergraduatePlanType } from "@/lib/loans/types";
 import type { Preset } from "@/lib/presets";
 import type { LoanState } from "@/types/store";
 
-interface LoanContextValue {
-  state: LoanState;
+// --- Context types ---
+
+interface LoanActionsValue {
   updateField: <K extends keyof LoanState>(key: K, value: LoanState[K]) => void;
   applyPreset: (preset: Preset) => void;
 }
 
-const LoanContext = createContext<LoanContextValue | null>(null);
+interface LoanFrequentState {
+  salary: number;
+  monthlyOverpayment: number;
+  lumpSumPayment: number;
+}
+
+interface LoanConfigState {
+  underGradPlanType: UndergraduatePlanType;
+  underGradBalance: number;
+  postGradBalance: number;
+  salaryGrowthRate: number;
+  thresholdGrowthRate: number;
+}
+
+// --- Contexts ---
+
+const LoanActionsContext = createContext<LoanActionsValue | null>(null);
+const LoanFrequentContext = createContext<LoanFrequentState | null>(null);
+const LoanConfigContext = createContext<LoanConfigState | null>(null);
+
+// --- Provider ---
 
 interface LoanProviderProps {
   children: ReactNode;
@@ -36,17 +58,64 @@ export function LoanProvider({ children }: LoanProviderProps) {
     dispatch(applyPresetAction(preset));
   };
 
+  const actions: LoanActionsValue = { updateField, applyPreset };
+
+  const frequent: LoanFrequentState = {
+    salary: state.salary,
+    monthlyOverpayment: state.monthlyOverpayment,
+    lumpSumPayment: state.lumpSumPayment,
+  };
+
+  const config: LoanConfigState = {
+    underGradPlanType: state.underGradPlanType,
+    underGradBalance: state.underGradBalance,
+    postGradBalance: state.postGradBalance,
+    salaryGrowthRate: state.salaryGrowthRate,
+    thresholdGrowthRate: state.thresholdGrowthRate,
+  };
+
   return (
-    <LoanContext value={{ state, updateField, applyPreset }}>
-      {children}
-    </LoanContext>
+    <LoanActionsContext value={actions}>
+      <LoanConfigContext value={config}>
+        <LoanFrequentContext value={frequent}>{children}</LoanFrequentContext>
+      </LoanConfigContext>
+    </LoanActionsContext>
   );
 }
 
-export function useLoanContext(): LoanContextValue {
-  const context = use(LoanContext);
+// --- Hooks ---
+
+export function useLoanActions(): LoanActionsValue {
+  const context = use(LoanActionsContext);
   if (context === null) {
-    throw new Error("useLoanContext must be used within a LoanProvider");
+    throw new Error("useLoanActions must be used within a LoanProvider");
   }
   return context;
+}
+
+export function useLoanFrequentState(): LoanFrequentState {
+  const context = use(LoanFrequentContext);
+  if (context === null) {
+    throw new Error("useLoanFrequentState must be used within a LoanProvider");
+  }
+  return context;
+}
+
+export function useLoanConfigState(): LoanConfigState {
+  const context = use(LoanConfigContext);
+  if (context === null) {
+    throw new Error("useLoanConfigState must be used within a LoanProvider");
+  }
+  return context;
+}
+
+/** Convenience hook that combines all 3 contexts (for components that need everything) */
+export function useLoanContext() {
+  const actions = useLoanActions();
+  const frequent = useLoanFrequentState();
+  const config = useLoanConfigState();
+  return {
+    state: { ...config, ...frequent },
+    ...actions,
+  };
 }

--- a/src/hooks/simulationWorkerSingleton.ts
+++ b/src/hooks/simulationWorkerSingleton.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared singleton Web Worker for loan simulation calculations.
+ *
+ * Manages a single Worker instance shared across all hooks that need simulation
+ * computations. Uses ref-counting for lifecycle management and a listeners map
+ * for multiplexed message routing.
+ *
+ * This module MUST live in src/hooks/ so the relative path to the worker file
+ * resolves correctly at build time (webpack statically analyzes the URL pattern).
+ */
+
+import type {
+  WorkerMessage,
+  WorkerResponse,
+  WorkerResultType,
+} from "@/workers/simulation.worker";
+
+type Listener = (result: WorkerResultType) => void;
+
+let worker: Worker | null = null;
+let refCount = 0;
+let nextRequestId = 0;
+const listeners = new Map<number, Listener>();
+
+function createWorker(): Worker {
+  const w = new Worker(
+    new URL("../workers/simulation.worker.ts", import.meta.url),
+  );
+
+  w.onmessage = (event: MessageEvent<WorkerResponse>) => {
+    const { id, result } = event.data;
+    const listener = listeners.get(id);
+    if (listener) {
+      listeners.delete(id);
+      listener(result);
+    }
+  };
+
+  w.onerror = (event: ErrorEvent) => {
+    console.error("[SimulationWorker] Worker error:", event.message);
+  };
+
+  return w;
+}
+
+/**
+ * Acquire a reference to the shared worker. Call releaseWorker() on cleanup.
+ * The worker is created lazily on first acquisition.
+ */
+export function acquireWorker(): void {
+  refCount++;
+  if (!worker) {
+    worker = createWorker();
+  }
+}
+
+/**
+ * Release a reference to the shared worker. When the last consumer releases,
+ * the worker is terminated to free resources.
+ */
+export function releaseWorker(): void {
+  refCount--;
+  if (refCount <= 0) {
+    worker?.terminate();
+    worker = null;
+    refCount = 0;
+    listeners.clear();
+  }
+}
+
+/**
+ * Send a message to the shared worker and register a one-shot listener
+ * for the response. Returns the request ID for cancellation.
+ */
+export function postWorkerMessage(
+  payload: WorkerMessage["payload"],
+  onResponse: Listener,
+): number {
+  const id = ++nextRequestId;
+  listeners.set(id, onResponse);
+
+  if (!worker) {
+    worker = createWorker();
+  }
+
+  worker.postMessage({ id, payload } satisfies WorkerMessage);
+  return id;
+}
+
+/**
+ * Cancel a pending request by removing its listener. The worker will still
+ * process the message, but the response will be silently discarded.
+ */
+export function cancelWorkerMessage(id: number): void {
+  listeners.delete(id);
+}

--- a/src/hooks/useChartData.test.tsx
+++ b/src/hooks/useChartData.test.tsx
@@ -1,20 +1,33 @@
-import { renderHook } from "@testing-library/react";
-import { createContext, use, useReducer, useMemo, type ReactNode } from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createContext, use, useReducer, type ReactNode } from "react";
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { useTotalRepaymentData, useBalanceOverTimeData } from "./useChartData";
 import { MIN_SALARY, MAX_SALARY, SALARY_STEP } from "../constants";
 import { loanReducer, initialState } from "../context/loanReducer";
 import type { LoanState } from "@/types/store";
 
-// Mock the context module to provide a test-friendly provider
+// Mock the context module with 3 split contexts matching production LoanProvider
 vi.mock("../context/LoanContext", () => {
-  const LoanContext = createContext<{
-    state: LoanState;
+  const ActionsContext = createContext<{
     updateField: <K extends keyof LoanState>(
       key: K,
       value: LoanState[K],
     ) => void;
-    reset: () => void;
+    applyPreset: (preset: unknown) => void;
+  } | null>(null);
+
+  const FrequentContext = createContext<{
+    salary: number;
+    monthlyOverpayment: number;
+    lumpSumPayment: number;
+  } | null>(null);
+
+  const ConfigContext = createContext<{
+    underGradPlanType: LoanState["underGradPlanType"];
+    underGradBalance: number;
+    postGradBalance: number;
+    salaryGrowthRate: LoanState["salaryGrowthRate"];
+    thresholdGrowthRate: LoanState["thresholdGrowthRate"];
   } | null>(null);
 
   return {
@@ -28,30 +41,74 @@ vi.mock("../context/LoanContext", () => {
       const mergedInitial = { ...initialState, ...initialStateOverride };
       const [state, dispatch] = useReducer(loanReducer, mergedInitial);
 
-      const contextValue = useMemo(
-        () => ({
-          state,
-          updateField: <K extends keyof LoanState>(
-            key: K,
-            value: LoanState[K],
-          ) => {
-            dispatch({ type: "UPDATE_FIELD", key, value });
-          },
-          reset: () => {
-            dispatch({ type: "RESET" });
-          },
-        }),
-        [state],
-      );
+      const actions = {
+        updateField: <K extends keyof LoanState>(
+          key: K,
+          value: LoanState[K],
+        ) => {
+          dispatch({ type: "UPDATE_FIELD", key, value });
+        },
+        applyPreset: () => {},
+      };
 
-      return <LoanContext value={contextValue}>{children}</LoanContext>;
+      const frequent = {
+        salary: state.salary,
+        monthlyOverpayment: state.monthlyOverpayment,
+        lumpSumPayment: state.lumpSumPayment,
+      };
+
+      const config = {
+        underGradPlanType: state.underGradPlanType,
+        underGradBalance: state.underGradBalance,
+        postGradBalance: state.postGradBalance,
+        salaryGrowthRate: state.salaryGrowthRate,
+        thresholdGrowthRate: state.thresholdGrowthRate,
+      };
+
+      return (
+        <ActionsContext value={actions}>
+          <ConfigContext value={config}>
+            <FrequentContext value={frequent}>{children}</FrequentContext>
+          </ConfigContext>
+        </ActionsContext>
+      );
     },
-    useLoanContext: () => {
-      const context = use(LoanContext);
+    useLoanActions: () => {
+      const context = use(ActionsContext);
       if (context === null) {
-        throw new Error("useLoanContext must be used within a LoanProvider");
+        throw new Error("useLoanActions must be used within a LoanProvider");
       }
       return context;
+    },
+    useLoanFrequentState: () => {
+      const context = use(FrequentContext);
+      if (context === null) {
+        throw new Error(
+          "useLoanFrequentState must be used within a LoanProvider",
+        );
+      }
+      return context;
+    },
+    useLoanConfigState: () => {
+      const context = use(ConfigContext);
+      if (context === null) {
+        throw new Error(
+          "useLoanConfigState must be used within a LoanProvider",
+        );
+      }
+      return context;
+    },
+    useLoanContext: () => {
+      const actions = use(ActionsContext);
+      const frequent = use(FrequentContext);
+      const config = use(ConfigContext);
+      if (!actions || !frequent || !config) {
+        throw new Error("useLoanContext must be used within a LoanProvider");
+      }
+      return {
+        state: { ...config, ...frequent },
+        ...actions,
+      };
     },
   };
 });
@@ -82,7 +139,8 @@ describe("useChartData hooks", () => {
     Math.floor((MAX_SALARY - MIN_SALARY) / SALARY_STEP) + 1;
 
   beforeEach(() => {
-    vi.useFakeTimers();
+    // Use shouldAdvanceTime to allow waitFor polling to work with fake timers
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(new Date("2024-01-15"));
     localStorage.clear();
   });
@@ -92,142 +150,196 @@ describe("useChartData hooks", () => {
   });
 
   describe("useTotalRepaymentData", () => {
-    it("returns data array with correct number of points", () => {
+    it("returns data array with correct number of points", async () => {
       const { result } = renderHook(() => useTotalRepaymentData(), {
         wrapper: createWrapper(),
       });
 
-      expect(result.current.data.length).toBe(expectedDataPoints);
+      // Wait for worker to respond
+      await vi.runAllTimersAsync();
+
+      await waitFor(() => {
+        expect(result.current.data.length).toBe(expectedDataPoints);
+      });
     });
 
-    it("returns data points as objects with salary and value", () => {
+    it("returns data points as objects with salary and value", async () => {
       const { result } = renderHook(() => useTotalRepaymentData(), {
         wrapper: createWrapper(),
       });
 
-      expect(result.current.data[0]).toHaveProperty("salary");
-      expect(result.current.data[0]).toHaveProperty("value");
-      expect(result.current.data[0].salary).toBe(MIN_SALARY);
-      expect(typeof result.current.data[0].value).toBe("number");
+      await vi.runAllTimersAsync();
+
+      await waitFor(() => {
+        expect(result.current.data[0]).toHaveProperty("salary");
+        expect(result.current.data[0]).toHaveProperty("value");
+        expect(result.current.data[0].salary).toBe(MIN_SALARY);
+        expect(typeof result.current.data[0].value).toBe("number");
+      });
     });
 
-    it("starts at MIN_SALARY and ends at MAX_SALARY", () => {
+    it("starts at MIN_SALARY and ends at MAX_SALARY", async () => {
       const { result } = renderHook(() => useTotalRepaymentData(), {
         wrapper: createWrapper(),
       });
 
-      expect(result.current.data[0].salary).toBe(MIN_SALARY);
-      expect(result.current.data[result.current.data.length - 1].salary).toBe(
-        MAX_SALARY,
-      );
+      await vi.runAllTimersAsync();
+
+      await waitFor(() => {
+        expect(result.current.data[0].salary).toBe(MIN_SALARY);
+        expect(result.current.data[result.current.data.length - 1].salary).toBe(
+          MAX_SALARY,
+        );
+      });
     });
 
-    it("returns annotationSalary when salary is in valid range", () => {
+    it("returns annotationSalary when salary is in valid range", async () => {
       const { result } = renderHook(() => useTotalRepaymentData(), {
         wrapper: createWrapper({ salary: 50_000 }),
       });
 
-      expect(result.current.annotationSalary).toBe(50_000);
+      await vi.runAllTimersAsync();
+
+      await waitFor(() => {
+        expect(result.current.annotationSalary).toBe(50_000);
+      });
     });
 
-    it("returns undefined annotationSalary when salary is below MIN_SALARY", () => {
+    it("returns undefined annotationSalary when salary is below MIN_SALARY", async () => {
       const { result } = renderHook(() => useTotalRepaymentData(), {
         wrapper: createWrapper({ salary: MIN_SALARY - 1000 }),
       });
 
+      await vi.runAllTimersAsync();
+
+      // Even after data loads, annotation should be undefined for out-of-range salary
       expect(result.current.annotationSalary).toBeUndefined();
     });
 
-    it("returns undefined annotationSalary when salary is above MAX_SALARY", () => {
+    it("returns undefined annotationSalary when salary is above MAX_SALARY", async () => {
       const { result } = renderHook(() => useTotalRepaymentData(), {
         wrapper: createWrapper({ salary: MAX_SALARY + 1000 }),
       });
 
+      await vi.runAllTimersAsync();
+
+      // Even after data loads, annotation should be undefined for out-of-range salary
       expect(result.current.annotationSalary).toBeUndefined();
     });
 
-    it("returns annotationSalary at exactly MIN_SALARY boundary", () => {
+    it("returns annotationSalary at exactly MIN_SALARY boundary", async () => {
       const { result } = renderHook(() => useTotalRepaymentData(), {
         wrapper: createWrapper({ salary: MIN_SALARY }),
       });
 
-      expect(result.current.annotationSalary).toBe(MIN_SALARY);
-      expect(result.current.annotationValue).toBeDefined();
+      await vi.runAllTimersAsync();
+
+      await waitFor(() => {
+        expect(result.current.annotationSalary).toBe(MIN_SALARY);
+        expect(result.current.annotationValue).toBeDefined();
+      });
     });
 
-    it("returns annotationSalary at exactly MAX_SALARY boundary", () => {
+    it("returns annotationSalary at exactly MAX_SALARY boundary", async () => {
       const { result } = renderHook(() => useTotalRepaymentData(), {
         wrapper: createWrapper({ salary: MAX_SALARY }),
       });
 
-      expect(result.current.annotationSalary).toBe(MAX_SALARY);
-      expect(result.current.annotationValue).toBeDefined();
+      await vi.runAllTimersAsync();
+
+      await waitFor(() => {
+        expect(result.current.annotationSalary).toBe(MAX_SALARY);
+        expect(result.current.annotationValue).toBeDefined();
+      });
     });
 
-    it("calculates higher repayment for higher earners who pay off loan", () => {
+    it("calculates higher repayment for higher earners who pay off loan", async () => {
       const { result } = renderHook(() => useTotalRepaymentData(), {
         wrapper: createWrapper(),
       });
 
-      const lowSalaryRepayment = result.current.data[0].value;
-      const highSalaryRepayment =
-        result.current.data[result.current.data.length - 1].value;
+      await vi.runAllTimersAsync();
 
-      // Higher salary typically means more total repayment (up to full payoff)
-      expect(highSalaryRepayment).toBeGreaterThanOrEqual(lowSalaryRepayment);
+      await waitFor(() => {
+        const lowSalaryRepayment = result.current.data[0].value;
+        const highSalaryRepayment =
+          result.current.data[result.current.data.length - 1].value;
+
+        // Higher salary typically means more total repayment (up to full payoff)
+        expect(highSalaryRepayment).toBeGreaterThanOrEqual(lowSalaryRepayment);
+      });
     });
   });
 
   describe("useBalanceOverTimeData", () => {
-    it("returns data array with balance points over time", () => {
+    it("returns data array with balance points over time", async () => {
       const { result } = renderHook(() => useBalanceOverTimeData(), {
         wrapper: createWrapper(),
       });
 
-      expect(result.current.data.length).toBeGreaterThan(0);
+      await vi.runAllTimersAsync();
+
+      await waitFor(() => {
+        expect(result.current.data.length).toBeGreaterThan(0);
+      });
     });
 
-    it("returns data points with month and balance properties", () => {
+    it("returns data points with month and balance properties", async () => {
       const { result } = renderHook(() => useBalanceOverTimeData(), {
         wrapper: createWrapper(),
       });
 
-      expect(result.current.data[0]).toHaveProperty("month");
-      expect(result.current.data[0]).toHaveProperty("balance");
+      await vi.runAllTimersAsync();
+
+      await waitFor(() => {
+        expect(result.current.data[0]).toHaveProperty("month");
+        expect(result.current.data[0]).toHaveProperty("balance");
+      });
     });
 
-    it("starts at month 0 with initial loan balance", () => {
+    it("starts at month 0 with initial loan balance", async () => {
       const { result } = renderHook(() => useBalanceOverTimeData(), {
         wrapper: createWrapper({ underGradBalance: 50_000 }),
       });
 
-      expect(result.current.data[0].month).toBe(0);
-      expect(result.current.data[0].balance).toBe(50_000);
+      await vi.runAllTimersAsync();
+
+      await waitFor(() => {
+        expect(result.current.data[0].month).toBe(0);
+        expect(result.current.data[0].balance).toBe(50_000);
+      });
     });
 
-    it("balance decreases over time", () => {
+    it("balance decreases over time", async () => {
       // Use a high salary where repayments clearly exceed interest
       const { result } = renderHook(() => useBalanceOverTimeData(), {
         wrapper: createWrapper({ underGradBalance: 50_000, salary: 100_000 }),
       });
 
-      const initialBalance = result.current.data[0].balance;
-      const finalBalance =
-        result.current.data[result.current.data.length - 1].balance;
+      await vi.runAllTimersAsync();
 
-      expect(finalBalance).toBeLessThan(initialBalance);
+      await waitFor(() => {
+        const initialBalance = result.current.data[0].balance;
+        const finalBalance =
+          result.current.data[result.current.data.length - 1].balance;
+
+        expect(finalBalance).toBeLessThan(initialBalance);
+      });
     });
 
-    it("returns empty data when no loans", () => {
+    it("returns empty data when no loans", async () => {
       const { result } = renderHook(() => useBalanceOverTimeData(), {
         wrapper: createWrapper({ underGradBalance: 0, postGradBalance: 0 }),
       });
 
+      await vi.runAllTimersAsync();
+
+      // Empty loans should return empty data immediately (no worker call needed)
       expect(result.current.data.length).toBe(0);
       expect(result.current.writeOffMonth).toBeNull();
     });
 
-    it("returns writeOffMonth for low earners who reach write-off", () => {
+    it("returns writeOffMonth for low earners who reach write-off", async () => {
       const { result } = renderHook(() => useBalanceOverTimeData(), {
         wrapper: createWrapper({
           underGradBalance: 50_000,
@@ -235,16 +347,27 @@ describe("useChartData hooks", () => {
         }),
       });
 
-      // Low earners should hit write-off (360 months for Plan 2)
-      expect(result.current.writeOffMonth).not.toBeNull();
+      await vi.runAllTimersAsync();
+
+      await waitFor(() => {
+        // Low earners should hit write-off (360 months for Plan 2)
+        expect(result.current.writeOffMonth).not.toBeNull();
+      });
     });
   });
 
   describe("hook memoization", () => {
-    it("useTotalRepaymentData returns equivalent data on rerender", () => {
+    it("useTotalRepaymentData returns equivalent data on rerender", async () => {
       const { result, rerender } = renderHook(() => useTotalRepaymentData(), {
         wrapper: createWrapper(),
       });
+
+      await vi.runAllTimersAsync();
+
+      await waitFor(() => {
+        expect(result.current.data.length).toBe(expectedDataPoints);
+      });
+
       const firstData = [...result.current.data];
 
       rerender();
@@ -253,15 +376,28 @@ describe("useChartData hooks", () => {
       expect(result.current.data).toStrictEqual(firstData);
     });
 
-    it("useTotalRepaymentData returns different data when config changes", () => {
+    it("useTotalRepaymentData returns different data when config changes", async () => {
       // Test that different initial configs produce different data
       const { result: result1 } = renderHook(() => useTotalRepaymentData(), {
         wrapper: createWrapper({ underGradBalance: 50_000 }),
       });
+
+      await vi.runAllTimersAsync();
+
+      await waitFor(() => {
+        expect(result1.current.data.length).toBe(expectedDataPoints);
+      });
+
       const firstData = [...result1.current.data];
 
       const { result: result2 } = renderHook(() => useTotalRepaymentData(), {
         wrapper: createWrapper({ underGradBalance: 75_000 }),
+      });
+
+      await vi.runAllTimersAsync();
+
+      await waitFor(() => {
+        expect(result2.current.data.length).toBe(expectedDataPoints);
       });
 
       // Data should differ with different config
@@ -270,13 +406,20 @@ describe("useChartData hooks", () => {
   });
 
   describe("integration with Plan 2 vs Plan 5", () => {
-    it("Plan 2 data differs from Plan 5 data", () => {
+    it("Plan 2 data differs from Plan 5 data", async () => {
       const { result: plan2Result } = renderHook(
         () => useTotalRepaymentData(),
         {
           wrapper: createWrapper({ underGradPlanType: "PLAN_2" }),
         },
       );
+
+      await vi.runAllTimersAsync();
+
+      await waitFor(() => {
+        expect(plan2Result.current.data.length).toBe(expectedDataPoints);
+      });
+
       const plan2Data = [...plan2Result.current.data];
 
       const { result: plan5Result } = renderHook(
@@ -285,6 +428,13 @@ describe("useChartData hooks", () => {
           wrapper: createWrapper({ underGradPlanType: "PLAN_5" }),
         },
       );
+
+      await vi.runAllTimersAsync();
+
+      await waitFor(() => {
+        expect(plan5Result.current.data.length).toBe(expectedDataPoints);
+      });
+
       const plan5Data = plan5Result.current.data;
 
       // At least some values should differ between plans

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -1,3 +1,4 @@
+import { useSimulationWorker } from "./useSimulationWorker";
 import {
   useLoanConfig,
   useCurrentSalary,
@@ -5,11 +6,11 @@ import {
   useThresholdGrowthRate,
 } from "./useStoreSelectors";
 import type { DataPoint, BalanceDataPoint } from "@/types/chart";
+import type {
+  SalarySeriesPayload,
+  BalanceSeriesPayload,
+} from "@/workers/simulation.worker";
 import { MIN_SALARY, MAX_SALARY } from "@/constants";
-import {
-  generateSalaryDataSeries,
-  generateBalanceTimeSeries,
-} from "@/utils/loan-calculations";
 
 interface AnnotationData {
   annotationSalary: number | undefined;
@@ -45,27 +46,31 @@ function useAnnotationData(
   return { annotationSalary: undefined, annotationValue: undefined };
 }
 
-/** Hook for total repayment chart data */
+/** Hook for total repayment chart data (runs in Web Worker) */
 export function useTotalRepaymentData() {
   const config = useLoanConfig();
   const salary = useCurrentSalary();
   const salaryGrowthRate = useSalaryGrowthRate();
   const thresholdGrowthRate = useThresholdGrowthRate();
 
-  const data = generateSalaryDataSeries(
-    config.loans,
-    (r) => r.totalRepayment,
-    undefined,
+  const payload: SalarySeriesPayload = {
+    type: "SALARY_SERIES",
+    loans: config.loans,
     salaryGrowthRate,
     thresholdGrowthRate,
-  );
+  };
+
+  const result = useSimulationWorker(payload);
+
+  // Use empty array while waiting for worker result
+  const data = result?.data ?? [];
 
   const { annotationSalary, annotationValue } = useAnnotationData(salary, data);
 
   return { data, annotationSalary, annotationValue };
 }
 
-/** Hook for balance over time chart data */
+/** Hook for balance over time chart data (runs in Web Worker) */
 export function useBalanceOverTimeData(): {
   data: BalanceDataPoint[];
   writeOffMonth: number | null;
@@ -75,11 +80,19 @@ export function useBalanceOverTimeData(): {
   const salaryGrowthRate = useSalaryGrowthRate();
   const thresholdGrowthRate = useThresholdGrowthRate();
 
-  return generateBalanceTimeSeries(
-    config.loans,
-    salary,
-    undefined,
+  const payload: BalanceSeriesPayload = {
+    type: "BALANCE_SERIES",
+    loans: config.loans,
+    annualSalary: salary,
     salaryGrowthRate,
     thresholdGrowthRate,
-  );
+  };
+
+  const result = useSimulationWorker(payload);
+
+  // Use empty data while waiting for worker result
+  return {
+    data: result?.data ?? [],
+    writeOffMonth: result?.writeOffMonth ?? null,
+  };
 }

--- a/src/hooks/useOverpayAnalysis.ts
+++ b/src/hooks/useOverpayAnalysis.ts
@@ -1,13 +1,41 @@
+import { useSimulationWorker } from "./useSimulationWorker";
 import {
   useLoanConfig,
   useCurrentSalary,
   useOverpayConfig,
 } from "./useStoreSelectors";
 import type { OverpayAnalysisResult } from "@/lib/loans/overpay-types";
-import { simulateOverpayScenarios } from "@/lib/loans/overpay-simulate";
+import type { OverpayAnalysisPayload } from "@/workers/simulation.worker";
 
 /**
- * Hook that performs overpay analysis calculations.
+ * Default empty result while waiting for worker.
+ */
+const emptyResult: OverpayAnalysisResult = {
+  baseline: {
+    totalPaid: 0,
+    monthsToPayoff: 0,
+    writtenOff: false,
+    amountWrittenOff: 0,
+    finalSalary: 0,
+  },
+  overpay: {
+    totalPaid: 0,
+    monthsToPayoff: 0,
+    writtenOff: false,
+    amountWrittenOff: 0,
+    finalSalary: 0,
+  },
+  recommendation: "marginal",
+  recommendationReason: "Calculating...",
+  balanceTimeSeries: [],
+  writeOffMonth: null,
+  paymentDifference: 0,
+  overpaymentContributions: 0,
+  monthsSaved: 0,
+};
+
+/**
+ * Hook that performs overpay analysis calculations (runs in Web Worker).
  *
  * Compares two scenarios:
  * 1. Baseline: Normal loan repayments with no overpayment
@@ -28,13 +56,22 @@ export function useOverpayAnalysis(
     lumpSumPayment,
   } = useOverpayConfig();
 
-  return simulateOverpayScenarios({
-    loans,
-    startingSalary: salary,
-    repaymentStartDate,
-    monthlyOverpayment,
-    salaryGrowthRate,
-    thresholdGrowthRate,
-    lumpSumPayment,
-  });
+  // Convert Date to ISO string for worker transfer
+  const payload: OverpayAnalysisPayload = {
+    type: "OVERPAY_ANALYSIS",
+    input: {
+      loans,
+      startingSalary: salary,
+      repaymentStartDate: repaymentStartDate.toISOString(),
+      monthlyOverpayment,
+      salaryGrowthRate,
+      thresholdGrowthRate,
+      lumpSumPayment,
+    },
+  };
+
+  const result = useSimulationWorker(payload);
+
+  // Return worker result or empty result while loading
+  return result?.result ?? emptyResult;
 }

--- a/src/hooks/usePersonalizedInsight.ts
+++ b/src/hooks/usePersonalizedInsight.ts
@@ -1,13 +1,16 @@
+import { useSimulationWorker } from "./useSimulationWorker";
 import {
   useLoanConfig,
   useCurrentSalary,
   useSalaryGrowthRate,
   useThresholdGrowthRate,
 } from "./useStoreSelectors";
-import { generateInsight, type Insight } from "@/utils/insights";
+import type { Insight } from "@/utils/insights";
+import type { InsightPayload } from "@/workers/simulation.worker";
 
 /**
- * Hook that computes a personalized insight based on current salary and loan config
+ * Hook that computes a personalized insight based on current salary and loan config.
+ * Runs the simulation in a Web Worker to keep the main thread responsive.
  */
 export function usePersonalizedInsight(): Insight | null {
   const config = useLoanConfig();
@@ -15,9 +18,17 @@ export function usePersonalizedInsight(): Insight | null {
   const salaryGrowthRate = useSalaryGrowthRate();
   const thresholdGrowthRate = useThresholdGrowthRate();
 
-  return generateInsight(salary, {
-    ...config,
+  const payload: InsightPayload = {
+    type: "INSIGHT",
+    salary,
+    loans: config.loans,
+    underGradBalance: config.underGradBalance,
+    postGradBalance: config.postGradBalance,
     salaryGrowthRate,
     thresholdGrowthRate,
-  });
+  };
+
+  const result = useSimulationWorker(payload);
+
+  return result?.insight ?? null;
 }

--- a/src/hooks/useSimulationWorker.ts
+++ b/src/hooks/useSimulationWorker.ts
@@ -1,0 +1,83 @@
+import { useState, useEffect, useRef, useTransition } from "react";
+import {
+  acquireWorker,
+  releaseWorker,
+  postWorkerMessage,
+  cancelWorkerMessage,
+} from "./simulationWorkerSingleton";
+import type {
+  WorkerPayload,
+  WorkerResultType,
+} from "@/workers/simulation.worker";
+
+/**
+ * Maps a payload type to its corresponding result type via the shared
+ * `type` discriminant on both WorkerPayload and WorkerResultType unions.
+ */
+type ResultFor<P extends WorkerPayload> = Extract<
+  WorkerResultType,
+  { type: P["type"] }
+>;
+
+/**
+ * Hook for communicating with the simulation Web Worker.
+ *
+ * Uses a shared singleton worker (acquired on mount, released on unmount).
+ * Handles request/response lifecycle and ignores stale responses.
+ *
+ * Two-pronged INP optimization:
+ * 1. Web Worker: Simulations run off the main thread
+ * 2. useTransition: Result state updates are wrapped in startTransition,
+ *    marking chart re-renders as non-urgent so React can prioritize
+ *    user interactions (like slider drags) over rendering
+ *
+ * @param payload - The payload to send to the worker (changes trigger new computation)
+ * @returns The computation result, or null while pending
+ */
+export function useSimulationWorker<P extends WorkerPayload>(
+  payload: P | null,
+): ResultFor<P> | null {
+  const [result, setResult] = useState<ResultFor<P> | null>(null);
+  const [, startTransition] = useTransition();
+  const activeRequestRef = useRef<number | null>(null);
+
+  // Acquire/release shared worker on mount/unmount
+  useEffect(() => {
+    acquireWorker();
+    return () => {
+      releaseWorker();
+    };
+  }, []);
+
+  // Send message when payload changes
+  useEffect(() => {
+    if (!payload) {
+      return;
+    }
+
+    // Cancel previous in-flight request
+    if (activeRequestRef.current !== null) {
+      cancelWorkerMessage(activeRequestRef.current);
+    }
+
+    const id = postWorkerMessage(payload, (workerResult) => {
+      if (activeRequestRef.current === id) {
+        startTransition(() => {
+          setResult(workerResult as ResultFor<P>);
+        });
+        activeRequestRef.current = null;
+      }
+    });
+
+    activeRequestRef.current = id;
+
+    return () => {
+      cancelWorkerMessage(id);
+      if (activeRequestRef.current === id) {
+        activeRequestRef.current = null;
+      }
+    };
+  }, [payload]);
+
+  return result;
+}

--- a/src/hooks/useStoreSelectors.ts
+++ b/src/hooks/useStoreSelectors.ts
@@ -1,5 +1,8 @@
 import type { Loan } from "@/lib/loans/types";
-import { useLoanContext } from "@/context/LoanContext";
+import {
+  useLoanConfigState,
+  useLoanFrequentState,
+} from "@/context/LoanContext";
 
 interface LoanConfig {
   loans: Loan[];
@@ -9,31 +12,32 @@ interface LoanConfig {
 
 /** Select the loan configuration for simulation calculations */
 export function useLoanConfig(): LoanConfig {
-  const { state } = useLoanContext();
+  const { underGradPlanType, underGradBalance, postGradBalance } =
+    useLoanConfigState();
 
   const loans: Loan[] = [];
 
-  if (state.underGradBalance > 0) {
+  if (underGradBalance > 0) {
     loans.push({
-      planType: state.underGradPlanType,
-      balance: state.underGradBalance,
+      planType: underGradPlanType,
+      balance: underGradBalance,
     });
   }
-  if (state.postGradBalance > 0) {
-    loans.push({ planType: "POSTGRADUATE", balance: state.postGradBalance });
+  if (postGradBalance > 0) {
+    loans.push({ planType: "POSTGRADUATE", balance: postGradBalance });
   }
 
   return {
     loans,
-    underGradBalance: state.underGradBalance,
-    postGradBalance: state.postGradBalance,
+    underGradBalance,
+    postGradBalance,
   };
 }
 
 /** Select current salary for chart annotation */
 export function useCurrentSalary(): number {
-  const { state } = useLoanContext();
-  return state.salary;
+  const { salary } = useLoanFrequentState();
+  return salary;
 }
 
 interface OverpayConfig {
@@ -45,23 +49,24 @@ interface OverpayConfig {
 
 /** Select salary growth rate for charts */
 export function useSalaryGrowthRate(): number {
-  const { state } = useLoanContext();
-  return state.salaryGrowthRate;
+  const { salaryGrowthRate } = useLoanConfigState();
+  return salaryGrowthRate;
 }
 
 /** Select threshold growth rate for charts */
 export function useThresholdGrowthRate(): number {
-  const { state } = useLoanContext();
-  return state.thresholdGrowthRate;
+  const { thresholdGrowthRate } = useLoanConfigState();
+  return thresholdGrowthRate;
 }
 
 /** Select overpay analysis configuration */
 export function useOverpayConfig(): OverpayConfig {
-  const { state } = useLoanContext();
+  const { monthlyOverpayment, lumpSumPayment } = useLoanFrequentState();
+  const { salaryGrowthRate, thresholdGrowthRate } = useLoanConfigState();
   return {
-    monthlyOverpayment: state.monthlyOverpayment,
-    salaryGrowthRate: state.salaryGrowthRate,
-    thresholdGrowthRate: state.thresholdGrowthRate,
-    lumpSumPayment: state.lumpSumPayment,
+    monthlyOverpayment,
+    salaryGrowthRate,
+    thresholdGrowthRate,
+    lumpSumPayment,
   };
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,89 @@
 import * as matchers from "@testing-library/jest-dom/matchers";
-import { expect } from "vitest";
+import { expect, vi } from "vitest";
+import type {
+  WorkerMessage,
+  WorkerResultType,
+} from "@/workers/simulation.worker";
+import { simulateOverpayScenarios } from "@/lib/loans/overpay-simulate";
+import { generateInsight } from "@/utils/insights";
+import {
+  generateSalaryDataSeries,
+  generateBalanceTimeSeries,
+} from "@/utils/loan-calculations";
 
 expect.extend(matchers);
+
+/**
+ * Mock Worker class for testing.
+ * Processes simulation messages synchronously and calls the same
+ * underlying functions that the real worker uses.
+ */
+class MockWorker {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+
+  postMessage(message: WorkerMessage) {
+    const { id, payload } = message;
+    let result: WorkerResultType;
+
+    switch (payload.type) {
+      case "SALARY_SERIES": {
+        const data = generateSalaryDataSeries(
+          payload.loans,
+          (r) => r.totalRepayment,
+          undefined,
+          payload.salaryGrowthRate,
+          payload.thresholdGrowthRate,
+        );
+        result = { type: "SALARY_SERIES", data };
+        break;
+      }
+      case "BALANCE_SERIES": {
+        const { data, writeOffMonth } = generateBalanceTimeSeries(
+          payload.loans,
+          payload.annualSalary,
+          undefined,
+          payload.salaryGrowthRate,
+          payload.thresholdGrowthRate,
+        );
+        result = { type: "BALANCE_SERIES", data, writeOffMonth };
+        break;
+      }
+      case "OVERPAY_ANALYSIS": {
+        const analysisResult = simulateOverpayScenarios({
+          ...payload.input,
+          repaymentStartDate: new Date(payload.input.repaymentStartDate),
+        });
+        result = { type: "OVERPAY_ANALYSIS", result: analysisResult };
+        break;
+      }
+      case "INSIGHT": {
+        const insight = generateInsight(payload.salary, {
+          loans: payload.loans,
+          underGradBalance: payload.underGradBalance,
+          postGradBalance: payload.postGradBalance,
+          salaryGrowthRate: payload.salaryGrowthRate,
+          thresholdGrowthRate: payload.thresholdGrowthRate,
+        });
+        result = { type: "INSIGHT", insight };
+        break;
+      }
+    }
+
+    // Use Promise.resolve().then() for micro-task scheduling
+    // This defers the callback until after the current synchronous code,
+    // making it work correctly with React's effect lifecycle
+    void Promise.resolve().then(() => {
+      if (this.onmessage) {
+        this.onmessage({ data: { id, result } } as MessageEvent);
+      }
+    });
+  }
+
+  terminate() {
+    // No-op for mock
+  }
+}
+
+// Mock the Worker global
+vi.stubGlobal("Worker", MockWorker);

--- a/src/workers/simulation.worker.ts
+++ b/src/workers/simulation.worker.ts
@@ -1,0 +1,174 @@
+/**
+ * Web Worker for loan simulation calculations.
+ *
+ * Moves expensive computations off the main thread to improve INP.
+ * Handles four types of simulations:
+ * - SALARY_SERIES: 126 simulations across salary range
+ * - BALANCE_SERIES: 1 simulation for balance over time
+ * - OVERPAY_ANALYSIS: 2 simulations for overpay comparison
+ * - INSIGHT: 1 simulation for personalized insight text
+ */
+
+import type {
+  OverpayInput,
+  OverpayAnalysisResult,
+} from "@/lib/loans/overpay-types";
+import type { Loan } from "@/lib/loans/types";
+import type { DataPoint, BalanceDataPoint } from "@/types/chart";
+import { simulateOverpayScenarios } from "@/lib/loans/overpay-simulate";
+import { generateInsight, type Insight } from "@/utils/insights";
+import {
+  generateSalaryDataSeries,
+  generateBalanceTimeSeries,
+  type BalanceTimeSeriesResult,
+} from "@/utils/loan-calculations";
+
+// ============================================================================
+// Message Types
+// ============================================================================
+
+export type WorkerMessageType =
+  | "SALARY_SERIES"
+  | "BALANCE_SERIES"
+  | "OVERPAY_ANALYSIS"
+  | "INSIGHT";
+
+export interface SalarySeriesPayload {
+  type: "SALARY_SERIES";
+  loans: Loan[];
+  salaryGrowthRate: number;
+  thresholdGrowthRate: number;
+}
+
+export interface BalanceSeriesPayload {
+  type: "BALANCE_SERIES";
+  loans: Loan[];
+  annualSalary: number;
+  salaryGrowthRate: number;
+  thresholdGrowthRate: number;
+}
+
+export interface OverpayAnalysisPayload {
+  type: "OVERPAY_ANALYSIS";
+  input: Omit<OverpayInput, "repaymentStartDate"> & {
+    repaymentStartDate: string; // ISO string - Date can't be transferred
+  };
+}
+
+export interface InsightPayload {
+  type: "INSIGHT";
+  salary: number;
+  loans: Loan[];
+  underGradBalance: number;
+  postGradBalance: number;
+  salaryGrowthRate: number;
+  thresholdGrowthRate: number;
+}
+
+export type WorkerPayload =
+  | SalarySeriesPayload
+  | BalanceSeriesPayload
+  | OverpayAnalysisPayload
+  | InsightPayload;
+
+export interface WorkerMessage {
+  id: number;
+  payload: WorkerPayload;
+}
+
+export type WorkerResultType =
+  | { type: "SALARY_SERIES"; data: DataPoint[] }
+  | {
+      type: "BALANCE_SERIES";
+      data: BalanceDataPoint[];
+      writeOffMonth: number | null;
+    }
+  | { type: "OVERPAY_ANALYSIS"; result: OverpayAnalysisResult }
+  | { type: "INSIGHT"; insight: Insight | null };
+
+export interface WorkerResponse {
+  id: number;
+  result: WorkerResultType;
+}
+
+// ============================================================================
+// Message Handlers
+// ============================================================================
+
+function handleSalarySeries(payload: SalarySeriesPayload): DataPoint[] {
+  return generateSalaryDataSeries(
+    payload.loans,
+    (r) => r.totalRepayment,
+    undefined,
+    payload.salaryGrowthRate,
+    payload.thresholdGrowthRate,
+  );
+}
+
+function handleBalanceSeries(
+  payload: BalanceSeriesPayload,
+): BalanceTimeSeriesResult {
+  return generateBalanceTimeSeries(
+    payload.loans,
+    payload.annualSalary,
+    undefined,
+    payload.salaryGrowthRate,
+    payload.thresholdGrowthRate,
+  );
+}
+
+function handleOverpayAnalysis(
+  payload: OverpayAnalysisPayload,
+): OverpayAnalysisResult {
+  // Convert ISO string back to Date
+  const input: OverpayInput = {
+    ...payload.input,
+    repaymentStartDate: new Date(payload.input.repaymentStartDate),
+  };
+  return simulateOverpayScenarios(input);
+}
+
+function handleInsight(payload: InsightPayload): Insight | null {
+  return generateInsight(payload.salary, {
+    loans: payload.loans,
+    underGradBalance: payload.underGradBalance,
+    postGradBalance: payload.postGradBalance,
+    salaryGrowthRate: payload.salaryGrowthRate,
+    thresholdGrowthRate: payload.thresholdGrowthRate,
+  });
+}
+
+// ============================================================================
+// Worker Entry Point
+// ============================================================================
+
+self.onmessage = (event: MessageEvent<WorkerMessage>) => {
+  const { id, payload } = event.data;
+
+  let result: WorkerResultType;
+
+  switch (payload.type) {
+    case "SALARY_SERIES": {
+      const data = handleSalarySeries(payload);
+      result = { type: "SALARY_SERIES", data };
+      break;
+    }
+    case "BALANCE_SERIES": {
+      const { data, writeOffMonth } = handleBalanceSeries(payload);
+      result = { type: "BALANCE_SERIES", data, writeOffMonth };
+      break;
+    }
+    case "OVERPAY_ANALYSIS": {
+      const analysisResult = handleOverpayAnalysis(payload);
+      result = { type: "OVERPAY_ANALYSIS", result: analysisResult };
+      break;
+    }
+    case "INSIGHT": {
+      const insight = handleInsight(payload);
+      result = { type: "INSIGHT", insight };
+      break;
+    }
+  }
+
+  self.postMessage({ id, result } satisfies WorkerResponse);
+};


### PR DESCRIPTION
## Summary

Implement a multi-layered Interaction to Next Paint (INP) optimization strategy: move expensive loan simulations from the main thread to a shared Web Worker, split the monolithic LoanContext into three granular contexts to reduce re-render scope, and use React's `useTransition` and `useDeferredValue` to defer non-urgent updates.

## Context

This refactoring addresses four code review comments on worker error handling, memory overhead from multiple worker instances, unused return types, and compliance with CLAUDE.md's memoization rules.

The optimizations reduce INP by:
1. **Web Worker** - Simulations run off-main-thread, preventing event handler blocking
2. **useTransition** - Result updates marked as non-urgent so React prioritizes user interactions (slider drags)
3. **Split contexts** - Components only re-render when state they consume actually changes
4. **useDeferredValue** - Chart annotation position updates deferred while user is dragging

All existing tests pass with updated async patterns, and the implementation maintains backwards compatibility via a convenience `useLoanContext()` hook.