### PR TITLE
fix: debounce slider onValueCommitted to dedup @base-ui/react bug

### DIFF
--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,9 +1,25 @@
 "use client";
 
 import { Slider as SliderPrimitive } from "@base-ui/react/slider";
+import { useDebouncedFunction } from "@/hooks/useDebouncedFunction";
 import { cn } from "@/lib/utils";
 
-function Slider({ className, ...props }: SliderPrimitive.Root.Props) {
+function Slider({
+  className,
+  onValueCommitted,
+  ...props
+}: SliderPrimitive.Root.Props) {
+  // Workaround: @base-ui/react v1.1.0 fires onValueCommitted multiple times
+  // per touch drag (dual touchend + pointerup listeners). Debounce to dedup.
+  // Remove once the upstream bug is fixed, and re-apply if regenerating this
+  // shadcn component.
+  const debouncedCommit = useDebouncedFunction(
+    (...args: Parameters<NonNullable<typeof onValueCommitted>>) => {
+      onValueCommitted?.(...args);
+    },
+    50,
+  );
+
   return (
     <SliderPrimitive.Root
       data-slot="slider"
@@ -11,6 +27,7 @@ function Slider({ className, ...props }: SliderPrimitive.Root.Props) {
         "relative flex w-full touch-none items-center select-none",
         className,
       )}
+      onValueCommitted={debouncedCommit}
       {...props}
     >
       <SliderPrimitive.Control className="flex w-full items-center py-2">

--- a/src/hooks/useDebouncedFunction.test.ts
+++ b/src/hooks/useDebouncedFunction.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { useDebouncedFunction } from "./useDebouncedFunction";
+
+describe("useDebouncedFunction", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires only once when called multiple times within the delay window", () => {
+    const spy = vi.fn();
+    const { result } = renderHook(() => useDebouncedFunction(spy, 50));
+
+    result.current(1);
+    result.current(2);
+    result.current(3);
+
+    vi.advanceTimersByTime(50);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires with the arguments from the last call", () => {
+    const spy = vi.fn();
+    const { result } = renderHook(() => useDebouncedFunction(spy, 50));
+
+    result.current(1);
+    result.current(2);
+    result.current(3);
+
+    vi.advanceTimersByTime(50);
+
+    expect(spy).toHaveBeenCalledWith(3);
+  });
+
+  it("does not fire before the delay elapses", () => {
+    const spy = vi.fn();
+    const { result } = renderHook(() => useDebouncedFunction(spy, 50));
+
+    result.current();
+
+    vi.advanceTimersByTime(30);
+    expect(spy).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(20);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire after unmount", () => {
+    const spy = vi.fn();
+    const { result, unmount } = renderHook(() => useDebouncedFunction(spy, 50));
+
+    result.current();
+    unmount();
+
+    vi.advanceTimersByTime(50);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useDebouncedFunction.ts
+++ b/src/hooks/useDebouncedFunction.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Returns a debounced version of `fn` that delays invocation
+ * until `delay` ms after the last call.
+ */
+export function useDebouncedFunction<Args extends unknown[]>(
+  fn: (...args: Args) => void,
+  delay: number,
+): (...args: Args) => void {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  // No manual memoization — React Compiler handles stable identity.
+  return (...args: Args) => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+    }
+    timerRef.current = setTimeout(() => {
+      fn(...args);
+    }, delay);
+  };
+}


### PR DESCRIPTION
## Summary

The @base-ui/react v1.1.0 slider component fires `onValueCommitted` multiple times per touch drag due to overlapping touchend and pointerup event listeners. This adds a debounced wrapper to deduplicate these redundant events.

## Context

With a 50ms debounce, only the final event in a series of rapid-fire duplicates is processed, preventing unnecessary repeated calls while maintaining the expected behavior for legitimate user interactions.