### PR TITLE
feat: refresh hero section with result summary card

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,33 +1,47 @@
 import { AdvancedConfigSection } from "./AdvancedConfigSection";
-import { InsightCallout } from "./InsightCallout";
 import { QuickInputs } from "./QuickInputs";
+import { ResultSummary } from "./ResultSummary";
 import TotalRepaymentChart from "./TotalRepaymentChart";
 
 export function HeroSection() {
   return (
-    <section className="space-y-6">
+    <section className="space-y-8">
       <div className="space-y-2">
-        <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">
-          Student Loans Hurt Middle Earners Most
+        <h2 className="font-display text-3xl font-bold tracking-tight text-balance sm:text-4xl lg:text-[2.75rem]">
+          Student Loans Hurt{" "}
+          <span className="text-primary">Middle Earners</span> Most
         </h2>
-        <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
-          Low earners get their loans written off. High earners pay them off
-          quickly. But middle earners pay the most—often more than they
-          borrowed.
-        </p>
+        <ul className="max-w-2xl space-y-1 text-base text-muted-foreground sm:text-lg">
+          <li className="flex items-baseline gap-2">
+            <span className="size-1.5 shrink-0 -translate-y-px rounded-full bg-primary/40" />
+            Low earners get their loans written off.
+          </li>
+          <li className="flex items-baseline gap-2">
+            <span className="size-1.5 shrink-0 -translate-y-px rounded-full bg-primary/40" />
+            High earners pay them off quickly.
+          </li>
+          <li className="flex items-baseline gap-2 text-foreground">
+            <span className="size-1.5 shrink-0 -translate-y-px rounded-full bg-primary" />
+            Middle earners pay the most in total—and the most interest.
+          </li>
+        </ul>
       </div>
 
-      <div className="h-[300px] sm:h-[400px] lg:h-[450px]">
-        <TotalRepaymentChart />
+      <div className="space-y-6">
+        <ResultSummary />
+        <div className="space-y-3">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            Total repayment by salary
+          </h3>
+          <div className="h-[300px] sm:h-[400px] lg:h-[450px]">
+            <TotalRepaymentChart />
+          </div>
+        </div>
       </div>
 
       <QuickInputs />
 
       <AdvancedConfigSection />
-
-      <InsightCallout />
     </section>
   );
 }
-
-export default HeroSection;

--- a/src/components/ResultSummary.tsx
+++ b/src/components/ResultSummary.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import {
+  InformationCircleIcon,
+  Alert02Icon,
+  Tick02Icon,
+  ArrowRight01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
+import type { InsightType } from "@/utils/insights";
+import { currencyFormatter } from "@/constants";
+import { usePersonalizedInsight } from "@/hooks/usePersonalizedInsight";
+import { useResultSummary } from "@/hooks/useResultSummary";
+
+const insightConfig: Record<
+  InsightType,
+  {
+    icon: typeof InformationCircleIcon;
+    iconClass: string;
+    bgClass: string;
+  }
+> = {
+  "low-earner": {
+    icon: InformationCircleIcon,
+    iconClass: "text-blue-600 dark:text-blue-400",
+    bgClass: "bg-blue-50/60 dark:bg-blue-950/20",
+  },
+  "middle-earner": {
+    icon: Alert02Icon,
+    iconClass: "text-red-600 dark:text-red-400",
+    bgClass: "bg-red-50/60 dark:bg-red-950/20",
+  },
+  "high-earner": {
+    icon: Tick02Icon,
+    iconClass: "text-emerald-600 dark:text-emerald-400",
+    bgClass: "bg-emerald-50/60 dark:bg-emerald-950/20",
+  },
+};
+
+const pluralRules = new Intl.PluralRules("en-GB");
+
+export function ResultSummary() {
+  const summary = useResultSummary();
+  const insight = usePersonalizedInsight();
+
+  if (!summary) return null;
+
+  const years = summary.monthsToPayoff / 12;
+  const rounded = Math.max(1, Math.round(years));
+  const yearsDisplay = years >= 1 ? String(rounded) : "<1";
+  const yearsUnit = pluralRules.select(rounded) === "one" ? "year" : "years";
+
+  return (
+    <div
+      className="relative overflow-hidden rounded-2xl border border-border bg-card"
+      role="status"
+      aria-live="polite"
+    >
+      {/* Subtle gradient wash behind the hero stat */}
+      <div className="pointer-events-none absolute inset-0 bg-linear-to-br from-primary/6 via-transparent to-transparent dark:from-primary/10" />
+
+      <div className="relative flex flex-col gap-4 p-4 min-[30rem]:flex-row min-[30rem]:items-end min-[30rem]:gap-6 min-[30rem]:p-5">
+        {/* Hero stat — total repayment */}
+        <div className="flex-1">
+          <p className="text-[0.6875rem] font-medium tracking-widest text-muted-foreground uppercase min-[30rem]:text-xs">
+            Total repayment
+          </p>
+          <p className="mt-1 font-mono text-2xl font-bold tracking-tight text-primary tabular-nums min-[30rem]:text-3xl">
+            {currencyFormatter.format(summary.totalPaid)}
+          </p>
+        </div>
+
+        {/* Vertical divider — row layout only */}
+        <div className="hidden h-12 w-px bg-border min-[30rem]:block" />
+
+        {/* Supporting stats */}
+        <div className="grid grid-cols-2 gap-6 border-t border-border pt-3 min-[30rem]:flex min-[30rem]:gap-8 min-[30rem]:border-t-0 min-[30rem]:pt-0">
+          <div>
+            <p className="text-[0.6875rem] font-medium tracking-widest text-muted-foreground uppercase min-[30rem]:text-xs">
+              Monthly
+            </p>
+            <p className="mt-0.5 font-mono text-xl font-semibold tabular-nums min-[30rem]:text-2xl">
+              {currencyFormatter.format(summary.monthlyRepayment)}
+              <span className="text-sm font-normal text-muted-foreground">
+                /mo
+              </span>
+            </p>
+          </div>
+          <div>
+            <p className="text-[0.6875rem] font-medium tracking-widest text-muted-foreground uppercase min-[30rem]:text-xs">
+              Duration
+            </p>
+            <p className="mt-0.5 font-mono text-xl font-semibold tabular-nums min-[30rem]:text-2xl">
+              {yearsDisplay}
+              <span className="text-sm font-normal text-muted-foreground">
+                {" "}
+                {yearsUnit}
+              </span>
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Personalized insight footer */}
+      {insight && (
+        <div
+          className={`relative flex items-start gap-2.5 border-t border-border px-4 py-3 min-[30rem]:px-5 ${insightConfig[insight.type].bgClass}`}
+        >
+          <HugeiconsIcon
+            icon={insightConfig[insight.type].icon}
+            className={`mt-0.5 size-4 shrink-0 ${insightConfig[insight.type].iconClass}`}
+            strokeWidth={2}
+          />
+          <div className="min-w-0 text-sm">
+            <span className="font-medium">{insight.title}</span>
+            <span className="text-muted-foreground">
+              {" \u2014 "}
+              {insight.description}
+            </span>
+            {insight.cta && (
+              <>
+                {" "}
+                <Link
+                  href={insight.cta.href}
+                  className="inline-flex items-center gap-0.5 font-medium text-foreground hover:underline"
+                >
+                  {insight.cta.text}
+                  <HugeiconsIcon icon={ArrowRight01Icon} className="size-3.5" />
+                </Link>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/quiz/OptionCard.tsx
+++ b/src/components/quiz/OptionCard.tsx
@@ -25,7 +25,7 @@ export function OptionCard({
       aria-checked={isSelected}
       onClick={onClick}
       className={cn(
-        "group relative flex min-h-[72px] w-full items-center gap-4 rounded-xl border-2 px-5 py-4 text-left transition-all duration-150",
+        "group relative flex h-full min-h-[72px] w-full items-center gap-4 rounded-xl border-2 px-5 py-4 text-left transition-all duration-150",
         "hover:border-primary/50 hover:bg-accent/50",
         "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none",
         "active:scale-[0.98]",


### PR DESCRIPTION
## Summary

This PR transforms the hero section from text-heavy to data-driven. A new `ResultSummary` component displays the user's projected loan repayment total with supporting metrics (monthly payment, duration), providing immediate context before they explore the full chart. The hero heading and description are restructured for better visual hierarchy and emphasis on middle earners.

## Context

The result summary card consolidates key repayment information and replaces the previous `InsightCallout` component. It includes personalized insights based on user segment (low/middle/high earner) with color-coded styling. The chart is now positioned below the summary card with a descriptive label.