### PR TITLE
feat(chart): Add optional tooltip control for chart components

### DIFF
--- a/src/components/TotalRepaymentChart.tsx
+++ b/src/components/TotalRepaymentChart.tsx
@@ -44,6 +44,7 @@ export function TotalRepaymentChart() {
       ariaLabel="Chart showing total student loan repayment amount by annual salary. Lower earners pay less due to loan write-off, while middle earners often pay the most."
       chartConfig={chartConfig}
       series={[{ dataKey: "value" }]}
+      showTooltip={false}
       annotations={annotations}
       xDomain={[MIN_SALARY, MAX_SALARY]}
       margin={{ top: 25, right: 25, bottom: 8, left: 25 }}

--- a/src/components/charts/ChartBase.tsx
+++ b/src/components/charts/ChartBase.tsx
@@ -46,6 +46,7 @@ export interface ChartBaseProps {
   series: ChartSeriesConfig[];
   annotations?: ChartAnnotationConfig[];
   showLegend?: boolean;
+  showTooltip?: boolean;
   xDomain?: [number, number];
   margin?: { top?: number; right?: number; bottom?: number; left?: number };
 }
@@ -63,6 +64,7 @@ export function ChartBase({
   series,
   annotations = [],
   showLegend = false,
+  showTooltip = true,
   xDomain,
   margin: marginProp,
 }: ChartBaseProps) {
@@ -76,18 +78,22 @@ export function ChartBase({
       role="img"
       aria-label={ariaLabel}
       className="size-full touch-pinch-zoom overflow-hidden select-none"
-      onMouseEnter={() => {
-        setIsTooltipActive(true);
-      }}
-      onMouseLeave={() => {
-        setIsTooltipActive(false);
-      }}
-      onTouchStart={() => {
-        setIsTooltipActive(true);
-      }}
-      onTouchEnd={() => {
-        setIsTooltipActive(false);
-      }}
+      {...(showTooltip
+        ? {
+            onMouseEnter: () => {
+              setIsTooltipActive(true);
+            },
+            onMouseLeave: () => {
+              setIsTooltipActive(false);
+            },
+            onTouchStart: () => {
+              setIsTooltipActive(true);
+            },
+            onTouchEnd: () => {
+              setIsTooltipActive(false);
+            },
+          }
+        : {})}
     >
       <ChartContainer config={chartConfig} className="size-full">
         <ChartComponent
@@ -157,27 +163,29 @@ export function ChartBase({
                 }
               : {})}
           />
-          <ChartTooltip
-            cursor={false}
-            active={isTooltipActive}
-            content={
-              <ChartTooltipContent
-                labelFormatter={(_, payload) => {
-                  const item = payload[0].payload as Record<string, unknown>;
-                  if (xDataKey in item) {
-                    const formatted = xFormatter(Number(item[xDataKey]));
-                    return xLabel ? `${xLabel}: ${formatted}` : formatted;
-                  }
-                  return "";
-                }}
-                formatter={(value, name) => {
-                  // name corresponds to series dataKey, which must exist in chartConfig
-                  const label = chartConfig[name].label ?? String(name);
-                  return [yFormatter(Number(value)), label];
-                }}
-              />
-            }
-          />
+          {showTooltip && (
+            <ChartTooltip
+              cursor={false}
+              active={isTooltipActive}
+              content={
+                <ChartTooltipContent
+                  labelFormatter={(_, payload) => {
+                    const item = payload[0].payload as Record<string, unknown>;
+                    if (xDataKey in item) {
+                      const formatted = xFormatter(Number(item[xDataKey]));
+                      return xLabel ? `${xLabel}: ${formatted}` : formatted;
+                    }
+                    return "";
+                  }}
+                  formatter={(value, name) => {
+                    // name corresponds to series dataKey, which must exist in chartConfig
+                    const label = chartConfig[name].label ?? String(name);
+                    return [yFormatter(Number(value)), label];
+                  }}
+                />
+              }
+            />
+          )}
           {showLegend && (
             <Legend
               verticalAlign="top"


### PR DESCRIPTION
Introduce a new prop `showTooltip` to ChartBase component to provide
more flexibility in controlling tooltip visibility. This allows
components to selectively disable tooltips when not needed, such as
in the TotalRepaymentChart where tooltips are unnecessary.

Refactor event handlers and tooltip rendering to conditionally apply
based on the new prop, maintaining existing behavior by default.