### PR TITLE
refactor: rename status color tokens to follow shadcn convention

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,16 +45,16 @@
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-status-info: var(--status-info);
-  --color-status-info-bg: var(--status-info-bg);
+  --color-status-info-foreground: var(--status-info-foreground);
   --color-status-info-border: var(--status-info-border);
   --color-status-success: var(--status-success);
-  --color-status-success-bg: var(--status-success-bg);
+  --color-status-success-foreground: var(--status-success-foreground);
   --color-status-success-border: var(--status-success-border);
   --color-status-warning: var(--status-warning);
-  --color-status-warning-bg: var(--status-warning-bg);
+  --color-status-warning-foreground: var(--status-warning-foreground);
   --color-status-warning-border: var(--status-warning-border);
   --color-status-danger: var(--status-danger);
-  --color-status-danger-bg: var(--status-danger-bg);
+  --color-status-danger-foreground: var(--status-danger-foreground);
   --color-status-danger-border: var(--status-danger-border);
   --font-sans: var(--font-sans);
   --font-display: var(--font-display);
@@ -94,17 +94,17 @@
   --sidebar-ring: oklch(0.708 0 0);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
-  --status-info: oklch(0.546 0.245 262.881);
-  --status-info-bg: oklch(0.97 0.014 254.604);
+  --status-info-foreground: oklch(0.546 0.245 262.881);
+  --status-info: oklch(0.97 0.014 254.604);
   --status-info-border: oklch(0.882 0.059 254.128);
-  --status-success: oklch(0.596 0.145 163.225);
-  --status-success-bg: oklch(0.979 0.021 166.113);
+  --status-success-foreground: oklch(0.596 0.145 163.225);
+  --status-success: oklch(0.979 0.021 166.113);
   --status-success-border: oklch(0.905 0.093 164.15);
-  --status-warning: oklch(0.666 0.179 58.318);
-  --status-warning-bg: oklch(0.987 0.022 95.277);
+  --status-warning-foreground: oklch(0.666 0.179 58.318);
+  --status-warning: oklch(0.987 0.022 95.277);
   --status-warning-border: oklch(0.924 0.12 95.746);
-  --status-danger: oklch(0.577 0.245 27.325);
-  --status-danger-bg: oklch(0.971 0.013 17.38);
+  --status-danger-foreground: oklch(0.577 0.245 27.325);
+  --status-danger: oklch(0.971 0.013 17.38);
   --status-danger-border: oklch(0.885 0.062 18.334);
 }
 
@@ -140,17 +140,17 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
-  --status-info: oklch(0.707 0.165 254.624);
-  --status-info-bg: oklch(0.282 0.091 267.935 / 30%);
+  --status-info-foreground: oklch(0.707 0.165 254.624);
+  --status-info: oklch(0.282 0.091 267.935 / 30%);
   --status-info-border: oklch(0.424 0.199 265.638);
-  --status-success: oklch(0.765 0.177 163.223);
-  --status-success-bg: oklch(0.262 0.051 172.552 / 20%);
+  --status-success-foreground: oklch(0.765 0.177 163.223);
+  --status-success: oklch(0.262 0.051 172.552 / 20%);
   --status-success-border: oklch(0.432 0.095 166.913);
-  --status-warning: oklch(0.828 0.189 84.429);
-  --status-warning-bg: oklch(0.279 0.077 45.635 / 30%);
+  --status-warning-foreground: oklch(0.828 0.189 84.429);
+  --status-warning: oklch(0.279 0.077 45.635 / 30%);
   --status-warning-border: oklch(0.473 0.137 46.201);
-  --status-danger: oklch(0.704 0.191 22.216);
-  --status-danger-bg: oklch(0.258 0.092 26.042 / 30%);
+  --status-danger-foreground: oklch(0.704 0.191 22.216);
+  --status-danger: oklch(0.258 0.092 26.042 / 30%);
   --status-danger-border: oklch(0.444 0.177 26.899);
 }
 

--- a/src/components/AdvancedConfigSection.tsx
+++ b/src/components/AdvancedConfigSection.tsx
@@ -84,7 +84,7 @@ export function AdvancedConfigSection() {
               }
             </p>
             {/* UPDATE: Remove or revise this note once thresholds unfreeze (expected after 2027) */}
-            <p className="text-xs text-status-warning">
+            <p className="text-xs text-status-warning-foreground">
               Note: Government has frozen thresholds through 2027.
             </p>
           </fieldset>

--- a/src/components/InsightCallout.tsx
+++ b/src/components/InsightCallout.tsx
@@ -20,15 +20,15 @@ const insightConfig: Record<
   }
 > = {
   "low-earner": {
-    className: "bg-status-info-bg border-status-info-border",
+    className: "bg-status-info border-status-info-border",
     icon: InformationCircleIcon,
   },
   "middle-earner": {
-    className: "bg-status-danger-bg border-status-danger-border",
+    className: "bg-status-danger border-status-danger-border",
     icon: Alert02Icon,
   },
   "high-earner": {
-    className: "bg-status-success-bg border-status-success-border",
+    className: "bg-status-success border-status-success-border",
     icon: Tick02Icon,
   },
 };

--- a/src/components/ResultSummary.tsx
+++ b/src/components/ResultSummary.tsx
@@ -32,20 +32,20 @@ const insightConfig: Record<
 > = {
   "low-earner": {
     icon: InformationCircleIcon,
-    iconClass: "text-status-info",
-    bgClass: "bg-status-info-bg",
+    iconClass: "text-status-info-foreground",
+    bgClass: "bg-status-info",
     borderClass: "border-status-info-border",
   },
   "middle-earner": {
     icon: Alert02Icon,
-    iconClass: "text-status-danger",
-    bgClass: "bg-status-danger-bg",
+    iconClass: "text-status-danger-foreground",
+    bgClass: "bg-status-danger",
     borderClass: "border-status-danger-border",
   },
   "high-earner": {
     icon: Tick02Icon,
-    iconClass: "text-status-success",
-    bgClass: "bg-status-success-bg",
+    iconClass: "text-status-success-foreground",
+    bgClass: "bg-status-success",
     borderClass: "border-status-success-border",
   },
 };

--- a/src/components/brand/BrandGuidelinesPage.tsx
+++ b/src/components/brand/BrandGuidelinesPage.tsx
@@ -30,32 +30,32 @@ const STATUS_GROUPS = [
   {
     name: "Info",
     tokens: [
-      { label: "Text", var: "--status-info" },
-      { label: "Background", var: "--status-info-bg" },
+      { label: "Foreground", var: "--status-info-foreground" },
+      { label: "Background", var: "--status-info" },
       { label: "Border", var: "--status-info-border" },
     ],
   },
   {
     name: "Success",
     tokens: [
-      { label: "Text", var: "--status-success" },
-      { label: "Background", var: "--status-success-bg" },
+      { label: "Foreground", var: "--status-success-foreground" },
+      { label: "Background", var: "--status-success" },
       { label: "Border", var: "--status-success-border" },
     ],
   },
   {
     name: "Warning",
     tokens: [
-      { label: "Text", var: "--status-warning" },
-      { label: "Background", var: "--status-warning-bg" },
+      { label: "Foreground", var: "--status-warning-foreground" },
+      { label: "Background", var: "--status-warning" },
       { label: "Border", var: "--status-warning-border" },
     ],
   },
   {
     name: "Danger",
     tokens: [
-      { label: "Text", var: "--status-danger" },
-      { label: "Background", var: "--status-danger-bg" },
+      { label: "Foreground", var: "--status-danger-foreground" },
+      { label: "Background", var: "--status-danger" },
       { label: "Border", var: "--status-danger-border" },
     ],
   },
@@ -187,24 +187,16 @@ export function BrandGuidelinesPage() {
                     <span className="font-display text-[13px] font-semibold text-foreground">
                       {group.name}
                     </span>
-                    <div className="space-y-2">
+                    <div className="grid grid-cols-3 gap-2">
                       {group.tokens.map((token) => (
-                        <div
-                          key={token.label}
-                          className="flex items-center gap-3"
-                        >
+                        <div key={token.label} className="flex flex-col gap-2">
                           <div
-                            className="size-8 shrink-0 rounded-md ring-1 ring-border"
+                            className="h-10 w-full rounded-md ring-1 ring-border"
                             style={{ backgroundColor: `var(${token.var})` }}
                           />
-                          <div className="flex flex-col">
-                            <span className="text-xs font-medium text-foreground">
-                              {token.label}
-                            </span>
-                            <span className="font-mono text-[10px] text-muted-foreground">
-                              {token.var}
-                            </span>
-                          </div>
+                          <span className="text-[10px] text-muted-foreground">
+                            {token.label}
+                          </span>
                         </div>
                       ))}
                     </div>

--- a/src/components/overpay/OverpaySummaryCards.tsx
+++ b/src/components/overpay/OverpaySummaryCards.tsx
@@ -23,20 +23,20 @@ export function OverpaySummaryCards({ analysis }: OverpaySummaryCardsProps) {
 
   const getCardClassName = () => {
     if (hasSavings) {
-      return "border-status-success-border bg-status-success-bg";
+      return "border-status-success-border bg-status-success";
     }
     if (hasExtraCost) {
-      return "border-status-danger-border bg-status-danger-bg";
+      return "border-status-danger-border bg-status-danger";
     }
     return "";
   };
 
   const getValueClassName = () => {
     if (hasSavings) {
-      return "text-status-success";
+      return "text-status-success-foreground";
     }
     if (hasExtraCost) {
-      return "text-status-danger";
+      return "text-status-danger-foreground";
     }
     return "";
   };
@@ -99,7 +99,7 @@ export function OverpaySummaryCards({ analysis }: OverpaySummaryCardsProps) {
           {baseline.writtenOff && (
             <div className="flex justify-between text-sm">
               <span className="text-muted-foreground">Written off</span>
-              <span className="font-medium text-status-info tabular-nums">
+              <span className="font-medium text-status-info-foreground tabular-nums">
                 {currencyFormatter.format(baseline.amountWrittenOff)}
               </span>
             </div>
@@ -132,7 +132,7 @@ export function OverpaySummaryCards({ analysis }: OverpaySummaryCardsProps) {
           {overpay.writtenOff && (
             <div className="flex justify-between text-sm">
               <span className="text-muted-foreground">Written off</span>
-              <span className="font-medium text-status-info tabular-nums">
+              <span className="font-medium text-status-info-foreground tabular-nums">
                 {currencyFormatter.format(overpay.amountWrittenOff)}
               </span>
             </div>
@@ -140,7 +140,9 @@ export function OverpaySummaryCards({ analysis }: OverpaySummaryCardsProps) {
           {!overpay.writtenOff && baseline.writtenOff && (
             <div className="flex justify-between text-sm">
               <span className="text-muted-foreground">Status</span>
-              <span className="font-medium text-status-success">Paid off</span>
+              <span className="font-medium text-status-success-foreground">
+                Paid off
+              </span>
             </div>
           )}
         </CardContent>

--- a/src/components/overpay/OverpayVerdict.tsx
+++ b/src/components/overpay/OverpayVerdict.tsx
@@ -17,17 +17,17 @@ const verdictConfig: Record<
 > = {
   "dont-overpay": {
     title: "Overpaying Costs More",
-    className: "bg-status-danger-bg border-status-danger-border",
+    className: "bg-status-danger border-status-danger-border",
     icon: Cancel01Icon,
   },
   overpay: {
     title: "Overpaying Saves Money",
-    className: "bg-status-success-bg border-status-success-border",
+    className: "bg-status-success border-status-success-border",
     icon: Tick02Icon,
   },
   marginal: {
     title: "Marginal Difference",
-    className: "bg-status-warning-bg border-status-warning-border",
+    className: "bg-status-warning border-status-warning-border",
     icon: Alert02Icon,
   },
 };

--- a/src/components/wizard/ThresholdGrowthStep.tsx
+++ b/src/components/wizard/ThresholdGrowthStep.tsx
@@ -53,7 +53,7 @@ export function ThresholdGrowthStep({
               )?.description
             }
           </p>
-          <p className="text-xs text-status-warning">
+          <p className="text-xs text-status-warning-foreground">
             Note: Government has frozen thresholds through 2027.
           </p>
         </fieldset>


### PR DESCRIPTION
## Summary

Aligns status color CSS variable naming with the shadcn/Tailwind convention where the base token (`--status-info`) is the background color and `--status-info-foreground` is the text color. Previously the naming was inverted (`--status-info` = text, `--status-info-bg` = background), creating redundant Tailwind classes like `bg-status-info-bg`.

## Context

The shadcn pattern uses `--token` for background and `--token-foreground` for text (e.g. `--card`/`--card-foreground`, `--primary`/`--primary-foreground`). The status tokens were the only group not following this convention. The brand guidelines page status section was also redesigned from a vertical list to a compact 3-column grid to prevent long variable names from wrapping.