### PR TITLE
refactor: add idle state for overpay verdict when no overpayment entered

### DIFF
--- a/src/components/overpay/OverpayPage.tsx
+++ b/src/components/overpay/OverpayPage.tsx
@@ -131,7 +131,6 @@ export function OverpayPage() {
         <OverpayVerdict
           recommendation={analysis.recommendation}
           reason={analysis.recommendationReason}
-          showDisclaimer={analysis.overpaymentContributions > 0}
         />
 
         <div className="grid gap-6 md:grid-cols-[1fr_260px]">

--- a/src/components/overpay/OverpaySummaryCards.tsx
+++ b/src/components/overpay/OverpaySummaryCards.tsx
@@ -96,14 +96,14 @@ export function OverpaySummaryCards({ analysis }: OverpaySummaryCardsProps) {
               {formatYears(baseline.monthsToPayoff)}
             </span>
           </div>
-          {baseline.writtenOff && (
-            <div className="flex justify-between text-sm">
-              <span className="text-muted-foreground">Written off</span>
-              <span className="font-medium text-status-info-foreground tabular-nums">
-                {currencyFormatter.format(baseline.amountWrittenOff)}
-              </span>
-            </div>
-          )}
+          <div
+            className={`flex justify-between text-sm ${!baseline.writtenOff ? "invisible" : ""}`}
+          >
+            <span className="text-muted-foreground">Written off</span>
+            <span className="font-medium text-status-info-foreground tabular-nums">
+              {currencyFormatter.format(baseline.amountWrittenOff)}
+            </span>
+          </div>
         </CardContent>
       </Card>
 
@@ -129,19 +129,25 @@ export function OverpaySummaryCards({ analysis }: OverpaySummaryCardsProps) {
               {formatYears(overpay.monthsToPayoff)}
             </span>
           </div>
-          {overpay.writtenOff && (
+          {overpay.writtenOff ? (
             <div className="flex justify-between text-sm">
               <span className="text-muted-foreground">Written off</span>
               <span className="font-medium text-status-info-foreground tabular-nums">
                 {currencyFormatter.format(overpay.amountWrittenOff)}
               </span>
             </div>
-          )}
-          {!overpay.writtenOff && baseline.writtenOff && (
+          ) : baseline.writtenOff ? (
             <div className="flex justify-between text-sm">
               <span className="text-muted-foreground">Status</span>
               <span className="font-medium text-status-success-foreground">
                 Paid off
+              </span>
+            </div>
+          ) : (
+            <div className="invisible flex justify-between text-sm">
+              <span className="text-muted-foreground">Written off</span>
+              <span className="font-medium tabular-nums">
+                {currencyFormatter.format(0)}
               </span>
             </div>
           )}

--- a/src/components/overpay/OverpayVerdict.tsx
+++ b/src/components/overpay/OverpayVerdict.tsx
@@ -2,6 +2,7 @@ import {
   Alert02Icon,
   Tick02Icon,
   Cancel01Icon,
+  InformationCircleIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { RecommendationType } from "@/lib/loans/overpay-types";
@@ -30,20 +31,24 @@ const verdictConfig: Record<
     className: "bg-status-warning border-status-warning-border",
     icon: Alert02Icon,
   },
+  idle: {
+    title: "Ready to Compare",
+    className: "bg-muted/50 border-border",
+    icon: InformationCircleIcon,
+  },
 };
 
 interface OverpayVerdictProps {
   recommendation: RecommendationType;
   reason: string;
-  showDisclaimer: boolean;
 }
 
 export function OverpayVerdict({
   recommendation,
   reason,
-  showDisclaimer,
 }: OverpayVerdictProps) {
   const config = verdictConfig[recommendation];
+  const isIdle = recommendation === "idle";
 
   return (
     <Alert className={config.className} role="status" aria-live="polite">
@@ -54,12 +59,11 @@ export function OverpayVerdict({
       />
       <AlertTitle>{config.title}</AlertTitle>
       <AlertDescription>{reason}</AlertDescription>
-      {showDisclaimer && (
-        <p className="col-span-full mt-2 text-xs text-muted-foreground">
-          This is an estimate, not financial advice. Consider speaking to a
-          financial adviser.
-        </p>
-      )}
+      <p className="col-span-full mt-2 text-xs text-muted-foreground">
+        {isIdle
+          ? "Adjust the inputs below to explore different scenarios."
+          : "This is an estimate, not financial advice. Consider speaking to a financial adviser."}
+      </p>
     </Alert>
   );
 }

--- a/src/lib/loans/overpay-simulate.test.ts
+++ b/src/lib/loans/overpay-simulate.test.ts
@@ -43,8 +43,10 @@ describe("simulateOverpayScenarios", () => {
         lumpSumPayment: 0,
       });
 
-      expect(result.recommendation).toBe("marginal");
-      expect(result.recommendationReason).toContain("Enter an overpayment");
+      expect(result.recommendation).toBe("idle");
+      expect(result.recommendationReason).toContain(
+        "Enter a lump sum or monthly amount",
+      );
       // Chart data should still be generated for baseline visualization
       expect(result.balanceTimeSeries.length).toBeGreaterThan(0);
       expect(result.baseline.totalPaid).toBeGreaterThan(0);

--- a/src/lib/loans/overpay-simulate.ts
+++ b/src/lib/loans/overpay-simulate.ts
@@ -148,8 +148,9 @@ export function simulateOverpayScenarios(
         lumpSumPayment,
       )
     : {
-        recommendation: "marginal" as RecommendationType,
-        reason: "Enter an overpayment amount to compare scenarios.",
+        recommendation: "idle" as RecommendationType,
+        reason:
+          "Enter a lump sum or monthly amount to see if overpaying saves you money.",
       };
 
   return {

--- a/src/lib/loans/overpay-types.ts
+++ b/src/lib/loans/overpay-types.ts
@@ -34,7 +34,8 @@ export interface ScenarioResult {
 export type RecommendationType =
   | "dont-overpay" // Loan will be written off anyway
   | "overpay" // Overpaying saves money
-  | "marginal"; // Within 10% - personal preference
+  | "marginal" // Within 10% - personal preference
+  | "idle"; // No overpayment entered — prompt state
 
 /**
  * A single data point in the balance time series for charting.


### PR DESCRIPTION
## Summary

When no overpayment is entered (lump sum = 0, monthly = 0), the verdict alert previously showed "Marginal Difference" with amber/warning styling — misleading since there's no comparison happening. This introduces a distinct `"idle"` recommendation type that renders as a neutral, inviting "Ready to Compare" prompt with muted styling and an informational icon.

The disclaimer line below the verdict previously used `invisible` to reserve space when hidden, creating an awkward gap. Now both states always render a visible 3rd line — idle shows "Adjust the inputs below to explore different scenarios" while active states show the financial advice disclaimer — eliminating layout shift without the invisible gap.

## Context

The summary cards also received a layout consistency fix: rows like "Written off" and "Paid off" now use invisible placeholders instead of conditional rendering, so both cards maintain the same height across all states.