### PR TITLE
fix: derive hasPersonalized from loan config instead of local state

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -13,10 +13,12 @@ import {
   trackWizardRestarted,
   trackWizardStarted,
 } from "@/lib/analytics";
+import { isPresetConfig } from "@/lib/presets";
 
 export function HeroSection() {
   const { applyPreset, updateField } = useLoanActions();
-  const { pendingQuizPlanTypes } = useLoanConfigState();
+  const config = useLoanConfigState();
+  const { pendingQuizPlanTypes } = config;
 
   const [mode, setMode] = useState<InputMode>(() => {
     if (pendingQuizPlanTypes && pendingQuizPlanTypes.length > 0) {
@@ -24,7 +26,7 @@ export function HeroSection() {
     }
     return { view: "summary" };
   });
-  const [hasPersonalized, setHasPersonalized] = useState(false);
+  const hasPersonalized = !isPresetConfig(config.loans);
 
   useEffect(() => {
     if (pendingQuizPlanTypes && pendingQuizPlanTypes.length > 0) {
@@ -52,7 +54,6 @@ export function HeroSection() {
 
   function handleWizardComplete() {
     trackWizardCompleted("loan");
-    setHasPersonalized(true);
     setMode({ view: "summary" });
   }
 

--- a/src/components/PresetPills.test.tsx
+++ b/src/components/PresetPills.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { PresetPills } from "./PresetPills";
+import { LoanProvider } from "@/context/LoanContext";
+import { type Loan } from "@/lib/loans/types";
+import { PRESETS } from "@/lib/presets";
+
+function createWrapper(loans?: Loan[]) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <LoanProvider initialStateOverride={loans ? { loans } : undefined}>
+        {children}
+      </LoanProvider>
+    );
+  };
+}
+
+const noop = vi.fn();
+
+describe("PresetPills", () => {
+  it('shows "Edit configuration" when hasPersonalized is true and config is non-preset', () => {
+    const customLoans: Loan[] = [{ planType: "PLAN_2", balance: 30_000 }];
+    render(
+      <PresetPills
+        hasPersonalized={true}
+        onPresetApplied={noop}
+        onPersonalise={noop}
+      />,
+      { wrapper: createWrapper(customLoans) },
+    );
+
+    const buttons = screen.getAllByText("Edit configuration");
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+
+  it('shows "Tailor to you" when hasPersonalized is false', () => {
+    render(
+      <PresetPills
+        hasPersonalized={false}
+        onPresetApplied={noop}
+        onPersonalise={noop}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    const buttons = screen.getAllByText("Tailor to you");
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+
+  it("highlights the matching preset button when config matches a preset", () => {
+    const plan2Grad = PRESETS.find((p) => p.id === "plan2-grad");
+    expect(plan2Grad).toBeDefined();
+    render(
+      <PresetPills
+        hasPersonalized={false}
+        onPresetApplied={noop}
+        onPersonalise={noop}
+      />,
+      { wrapper: createWrapper(plan2Grad?.loans) },
+    );
+
+    const pressedButtons = screen.getAllByRole("button", { pressed: true });
+    const presetButton = pressedButtons.find(
+      (btn) => btn.textContent && btn.textContent.includes("2012"),
+    );
+    expect(presetButton).toBeDefined();
+  });
+
+  it("highlights no preset when config is custom", () => {
+    const customLoans: Loan[] = [{ planType: "PLAN_2", balance: 30_000 }];
+    render(
+      <PresetPills
+        hasPersonalized={true}
+        onPresetApplied={noop}
+        onPersonalise={noop}
+      />,
+      { wrapper: createWrapper(customLoans) },
+    );
+
+    // All preset buttons should have aria-pressed=false
+    for (const preset of PRESETS) {
+      const regex = new RegExp(preset.label.replace(/[–+]/g, "."));
+      const buttons = screen.getAllByRole("button", { name: regex });
+      for (const button of buttons) {
+        expect(button.getAttribute("aria-pressed")).toBe("false");
+      }
+    }
+  });
+});

--- a/src/components/overpay/OverpayPage.tsx
+++ b/src/components/overpay/OverpayPage.tsx
@@ -24,7 +24,7 @@ import {
   trackWizardRestarted,
   trackWizardStarted,
 } from "@/lib/analytics";
-import { REPAYMENT_START_MONTH } from "@/lib/presets";
+import { isPresetConfig, REPAYMENT_START_MONTH } from "@/lib/presets";
 
 export function OverpayPage() {
   const [repaymentDate, setRepaymentDate] = useState<Date>(
@@ -32,9 +32,9 @@ export function OverpayPage() {
   );
   const analysis = useOverpayAnalysis(repaymentDate);
   const [mode, setMode] = useState<InputMode>({ view: "summary" });
-  const [hasPersonalized, setHasPersonalized] = useState(false);
   const { applyPreset } = useLoanActions();
   const config = useLoanConfigState();
+  const hasPersonalized = !isPresetConfig(config.loans);
   const { openAssumptions } = useAssumptionsWizard();
 
   const growthLabel =
@@ -69,7 +69,6 @@ export function OverpayPage() {
 
   function handleWizardComplete() {
     trackWizardCompleted("loan");
-    setHasPersonalized(true);
     setMode({ view: "summary" });
   }
 

--- a/src/context/AssumptionsWizardContext.test.tsx
+++ b/src/context/AssumptionsWizardContext.test.tsx
@@ -1,7 +1,7 @@
-import { cleanup, render, renderHook, screen } from "@testing-library/react";
+import { render, renderHook, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type ReactNode } from "react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AssumptionsWizardProvider,
   useAssumptionsWizard,
@@ -56,10 +56,6 @@ function renderWithProviders(ui: ReactNode) {
 // --- Tests ---
 
 describe("AssumptionsWizardContext", () => {
-  afterEach(() => {
-    cleanup();
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
     document.body.style.overflow = "";

--- a/src/lib/presets.test.ts
+++ b/src/lib/presets.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { isPresetConfig, PRESETS } from "./presets";
+import type { Loan } from "@/lib/loans/types";
+
+describe("isPresetConfig", () => {
+  it("returns true for each preset's loan config", () => {
+    for (const preset of PRESETS) {
+      expect(isPresetConfig(preset.loans)).toBe(true);
+    }
+  });
+
+  it("returns false for a custom loan config", () => {
+    const customLoans: Loan[] = [{ planType: "PLAN_2", balance: 30_000 }];
+    expect(isPresetConfig(customLoans)).toBe(false);
+  });
+
+  it("returns false for an empty loans array", () => {
+    expect(isPresetConfig([])).toBe(false);
+  });
+
+  it("returns false when plan types match but balances differ", () => {
+    const loans: Loan[] = [{ planType: "PLAN_2", balance: 99_999 }];
+    expect(isPresetConfig(loans)).toBe(false);
+  });
+
+  it("returns false when balances match but plan types differ", () => {
+    const loans: Loan[] = [{ planType: "PLAN_1", balance: 45_000 }];
+    expect(isPresetConfig(loans)).toBe(false);
+  });
+
+  it("returns false when loan count differs from all presets", () => {
+    const loans: Loan[] = [
+      { planType: "PLAN_2", balance: 45_000 },
+      { planType: "POSTGRADUATE", balance: 12_000 },
+      { planType: "PLAN_1", balance: 20_000 },
+    ];
+    expect(isPresetConfig(loans)).toBe(false);
+  });
+});

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -44,6 +44,20 @@ export const PRESETS: Preset[] = [
 
 export const DEFAULT_PRESET_ID = "plan2-grad";
 
+/** Returns true if the given loans exactly match any preset configuration. */
+export function isPresetConfig(loans: Loan[]): boolean {
+  return PRESETS.some(
+    (p) =>
+      p.loans.length === loans.length &&
+      p.loans.every(
+        (pl, i) =>
+          loans[i] &&
+          pl.planType === loans[i].planType &&
+          pl.balance === loans[i].balance,
+      ),
+  );
+}
+
 /** April is when UK student loan repayments typically start (0-indexed month) */
 export const REPAYMENT_START_MONTH = 3;
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,6 @@
 import * as matchers from "@testing-library/jest-dom/matchers";
-import { expect, vi } from "vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach, expect, vi } from "vitest";
 import type {
   WorkerMessage,
   WorkerResultType,
@@ -13,6 +14,10 @@ import {
 } from "@/utils/loan-calculations";
 
 expect.extend(matchers);
+
+afterEach(() => {
+  cleanup();
+});
 
 /**
  * Mock Worker class for testing.


### PR DESCRIPTION
## Summary

Custom loan configurations were not persisting across page navigation. When a user customized their config via "Tailor to you" on the homepage and then navigated to the overpay page, the CTA reverted to "Tailor to you" and the wizard opened empty instead of pre-filling with their config.

The root cause was `hasPersonalized` being tracked as local `useState(false)` in both `HeroSection` and `OverpayPage`. This flag reset on every mount even though the actual loan config in `LoanContext` was preserved. The fix derives `hasPersonalized` from the loan state itself — a config is "personalized" if it doesn't match any preset — using a new `isPresetConfig()` utility.

## Context

Also adds global `afterEach(cleanup)` to the test setup file, replacing per-file cleanup calls, since vitest without `globals: true` doesn't auto-cleanup `@testing-library/react` renders between tests.