### PR TITLE
refactor: extract SalaryGrowthBadge and add to overpay page

### DIFF
--- a/src/components/SalaryExplorer.tsx
+++ b/src/components/SalaryExplorer.tsx
@@ -1,49 +1,20 @@
 "use client";
 
-import { InformationCircleIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-import { useState } from "react";
+import { SalaryGrowthBadge } from "./SalaryGrowthBadge";
 import { TotalRepaymentChart } from "./TotalRepaymentChart";
 import { Slider } from "./ui/slider";
-import {
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-} from "@/components/ui/popover";
 import {
   MIN_SALARY,
   MAX_SALARY,
   SALARY_STEP,
-  SALARY_GROWTH_OPTIONS,
   currencyFormatter,
 } from "@/constants";
-import { useAssumptionsWizard } from "@/context/AssumptionsWizardContext";
-import {
-  useLoanFrequentState,
-  useLoanConfigState,
-  useLoanActions,
-} from "@/context/LoanContext";
-import { useResultSummary } from "@/hooks/useResultSummary";
+import { useLoanFrequentState, useLoanActions } from "@/context/LoanContext";
 import { trackSalaryChanged } from "@/lib/analytics";
 
 export function SalaryExplorer() {
-  const { openAssumptions } = useAssumptionsWizard();
   const { salary } = useLoanFrequentState();
-  const { salaryGrowthRate } = useLoanConfigState();
   const { updateField } = useLoanActions();
-  const [popoverOpen, setPopoverOpen] = useState(false);
-
-  const summary = useResultSummary();
-
-  const growthLabel =
-    SALARY_GROWTH_OPTIONS.find((o) => o.value === salaryGrowthRate)?.label ??
-    `${(salaryGrowthRate * 100).toFixed(0)}%`;
-
-  const years = summary
-    ? Math.max(1, Math.round(summary.monthsToPayoff / 12))
-    : null;
-  const projectedSalary =
-    years !== null ? salary * Math.pow(1 + salaryGrowthRate, years) : null;
 
   return (
     <div>
@@ -51,59 +22,13 @@ export function SalaryExplorer() {
         <h3 className="text-sm font-medium text-muted-foreground">
           Total repayment
         </h3>
-        <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-          <PopoverTrigger
-            openOnHover
-            delay={200}
-            closeDelay={200}
-            render={
-              <button
-                type="button"
-                className="flex items-center gap-1 rounded-md text-sm text-muted-foreground hover:text-foreground"
-                aria-label="Salary growth info"
-              />
-            }
-          >
-            Your salary:{" "}
-            <span className="font-mono font-semibold text-foreground tabular-nums">
-              {currencyFormatter.format(salary)}
-            </span>
-            <span className="text-xs text-muted-foreground/70">
-              +{growthLabel}/yr
-            </span>
-            <HugeiconsIcon icon={InformationCircleIcon} className="size-4" />
-          </PopoverTrigger>
-          <PopoverContent align="end" className="w-64 p-3">
-            <p className="text-sm text-muted-foreground">
-              This is your starting annual salary. We assume it grows by{" "}
-              <span className="font-medium text-foreground">{growthLabel}</span>{" "}
-              each year
-              {salaryGrowthRate > 0 &&
-              projectedSalary !== null &&
-              years !== null ? (
-                <>
-                  , reaching{" "}
-                  <span className="font-medium text-foreground">
-                    {currencyFormatter.format(Math.round(projectedSalary))}
-                  </span>{" "}
-                  after {years} {years === 1 ? "year" : "years"}
-                </>
-              ) : null}
-              .
-            </p>
-            <div className="my-2 h-px bg-border" />
-            <button
-              type="button"
-              onClick={() => {
-                setPopoverOpen(false);
-                openAssumptions();
-              }}
-              className="w-full rounded-md px-2 py-1.5 text-left text-sm text-primary hover:bg-accent"
-            >
-              Update growth assumption &rarr;
-            </button>
-          </PopoverContent>
-        </Popover>
+        <div className="flex items-center gap-1 text-sm text-muted-foreground">
+          Your salary:{" "}
+          <span className="font-mono font-semibold text-foreground tabular-nums">
+            {currencyFormatter.format(salary)}
+          </span>
+          <SalaryGrowthBadge />
+        </div>
       </div>
 
       <div className="h-[300px] sm:h-[400px] lg:h-[450px]">

--- a/src/components/SalaryGrowthBadge.tsx
+++ b/src/components/SalaryGrowthBadge.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { InformationCircleIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useState } from "react";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover";
+import { SALARY_GROWTH_OPTIONS, currencyFormatter } from "@/constants";
+import { useAssumptionsWizard } from "@/context/AssumptionsWizardContext";
+import {
+  useLoanFrequentState,
+  useLoanConfigState,
+} from "@/context/LoanContext";
+import { useResultSummary } from "@/hooks/useResultSummary";
+
+export function SalaryGrowthBadge() {
+  const { openAssumptions } = useAssumptionsWizard();
+  const { salary } = useLoanFrequentState();
+  const { salaryGrowthRate } = useLoanConfigState();
+  const [popoverOpen, setPopoverOpen] = useState(false);
+
+  const summary = useResultSummary();
+
+  const growthLabel =
+    SALARY_GROWTH_OPTIONS.find((o) => o.value === salaryGrowthRate)?.label ??
+    `${(salaryGrowthRate * 100).toFixed(0)}%`;
+
+  const years = summary
+    ? Math.max(1, Math.round(summary.monthsToPayoff / 12))
+    : null;
+  const projectedSalary =
+    years !== null ? salary * Math.pow(1 + salaryGrowthRate, years) : null;
+
+  return (
+    <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+      <PopoverTrigger
+        openOnHover
+        delay={200}
+        closeDelay={200}
+        render={
+          <button
+            type="button"
+            className="flex items-center gap-1 rounded-md text-sm text-muted-foreground hover:text-foreground"
+            aria-label="Salary growth info"
+          />
+        }
+      >
+        <span className="text-xs text-muted-foreground/70">
+          +{growthLabel}/yr
+        </span>
+        <HugeiconsIcon icon={InformationCircleIcon} className="size-4" />
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-64 p-3">
+        <p className="text-sm text-muted-foreground">
+          This is your starting annual salary. We assume it grows by{" "}
+          <span className="font-medium text-foreground">{growthLabel}</span>{" "}
+          each year
+          {salaryGrowthRate > 0 &&
+          projectedSalary !== null &&
+          years !== null ? (
+            <>
+              , reaching{" "}
+              <span className="font-medium text-foreground">
+                {currencyFormatter.format(Math.round(projectedSalary))}
+              </span>{" "}
+              after {years} {years === 1 ? "year" : "years"}
+            </>
+          ) : null}
+          .
+        </p>
+        <div className="my-2 h-px bg-border" />
+        <button
+          type="button"
+          onClick={() => {
+            setPopoverOpen(false);
+            openAssumptions();
+          }}
+          className="w-full rounded-md px-2 py-1.5 text-left text-sm text-primary hover:bg-accent"
+        >
+          Update growth assumption &rarr;
+        </button>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/overpay/OverpayPrimaryInputs.tsx
+++ b/src/components/overpay/OverpayPrimaryInputs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { SalaryGrowthBadge } from "@/components/SalaryGrowthBadge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
@@ -123,9 +124,12 @@ export function OverpayPrimaryInputs({
         <div className="space-y-2">
           <div className="flex items-center justify-between">
             <Label htmlFor="salary-slider">Current Salary</Label>
-            <span className="text-sm font-medium tabular-nums">
-              {currencyFormatter.format(salary)}
-            </span>
+            <div className="flex items-center gap-1">
+              <span className="text-sm font-medium tabular-nums">
+                {currencyFormatter.format(salary)}
+              </span>
+              <SalaryGrowthBadge />
+            </div>
           </div>
           <Slider
             id="salary-slider"


### PR DESCRIPTION
## Summary

The salary growth popover (showing `+4%/yr`, projected salary, and a link to the assumptions wizard) was previously inlined in `SalaryExplorer`. This extracts it into a reusable `SalaryGrowthBadge` component and adds it to the overpay page's salary slider, so users can see and explore the growth assumption on both pages.

## Context

The overpay page's salary slider only showed "Current Salary" and the value, with no indication of the assumed salary growth rate. The home page already had this popover inline. Extracting a shared component avoids duplication and keeps both pages consistent.