### PR TITLE
feat: show actual assumption values in AssumptionsCallout

### DIFF
--- a/src/components/AssumptionsCallout.test.tsx
+++ b/src/components/AssumptionsCallout.test.tsx
@@ -2,47 +2,83 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { AssumptionsCallout } from "./AssumptionsCallout";
+import type { ReactNode } from "react";
+import { LoanProvider } from "@/context/LoanContext";
 
 const mockOpenAssumptions = vi.fn();
 vi.mock("@/context/AssumptionsWizardContext", () => ({
   useAssumptionsWizard: () => ({ openAssumptions: mockOpenAssumptions }),
 }));
 
+function Wrapper({ children }: { children: ReactNode }) {
+  return <LoanProvider>{children}</LoanProvider>;
+}
+
 describe("AssumptionsCallout", () => {
   beforeEach(() => {
     mockOpenAssumptions.mockReset();
   });
 
-  it("renders the descriptive text", () => {
-    render(<AssumptionsCallout />);
+  it("renders assumption values in the text", () => {
+    render(<AssumptionsCallout />, { wrapper: Wrapper });
 
-    expect(
-      screen.getByText(
-        /These projections use assumptions about salary growth, inflation, and interest rates\./,
-      ),
-    ).not.toBeNull();
+    expect(screen.getByText(/salary growth/)).not.toBeNull();
+    expect(screen.getByText(/thresholds/)).not.toBeNull();
+    expect(screen.getByText(/RPI/)).not.toBeNull();
   });
 
-  it("renders the 'See or change assumptions' button", () => {
-    const { container } = render(<AssumptionsCallout />);
+  it("renders the 'Change assumptions' button", () => {
+    const { container } = render(<AssumptionsCallout />, { wrapper: Wrapper });
 
     expect(
       within(container).getByRole("button", {
-        name: "See or change assumptions",
+        name: "Change assumptions",
       }),
     ).not.toBeNull();
   });
 
   it("calls openAssumptions when the button is clicked", async () => {
     const user = userEvent.setup();
-    const { container } = render(<AssumptionsCallout />);
+    const { container } = render(<AssumptionsCallout />, { wrapper: Wrapper });
 
     await user.click(
       within(container).getByRole("button", {
-        name: "See or change assumptions",
+        name: "Change assumptions",
       }),
     );
 
     expect(mockOpenAssumptions).toHaveBeenCalledOnce();
+  });
+
+  it("shows BOE base rate when Plan 1 is active", () => {
+    render(<AssumptionsCallout />, {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <LoanProvider
+          initialStateOverride={{
+            loans: [{ planType: "PLAN_1", balance: 20000 }],
+          }}
+        >
+          {children}
+        </LoanProvider>
+      ),
+    });
+
+    expect(screen.getByText(/base rate/)).not.toBeNull();
+  });
+
+  it("hides BOE base rate when only Plan 2 is active", () => {
+    render(<AssumptionsCallout />, {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <LoanProvider
+          initialStateOverride={{
+            loans: [{ planType: "PLAN_2", balance: 40000 }],
+          }}
+        >
+          {children}
+        </LoanProvider>
+      ),
+    });
+
+    expect(screen.queryByText(/base rate/)).toBeNull();
   });
 });

--- a/src/components/AssumptionsCallout.tsx
+++ b/src/components/AssumptionsCallout.tsx
@@ -1,14 +1,44 @@
 "use client";
 
+import { SALARY_GROWTH_OPTIONS } from "@/constants";
 import { useAssumptionsWizard } from "@/context/AssumptionsWizardContext";
+import { useLoanConfigState } from "@/context/LoanContext";
 
 export function AssumptionsCallout() {
   const { openAssumptions } = useAssumptionsWizard();
+  const config = useLoanConfigState();
+
+  const salaryLabel =
+    SALARY_GROWTH_OPTIONS.find((o) => o.value === config.salaryGrowthRate)
+      ?.label ?? `${(config.salaryGrowthRate * 100).toFixed(0)}%`;
+
+  const thresholdLabel =
+    config.thresholdGrowthRate === 0
+      ? "frozen"
+      : `+${(config.thresholdGrowthRate * 100).toFixed(0)}%/yr`;
+
+  const rpiLabel = `${config.rpiRate % 1 === 0 ? config.rpiRate.toFixed(0) : config.rpiRate.toFixed(1)}%`;
+
+  const showBoe = config.loans.some(
+    (l) => l.planType === "PLAN_1" || l.planType === "PLAN_4",
+  );
+
+  const boeLabel = `${config.boeBaseRate % 1 === 0 ? config.boeBaseRate.toFixed(0) : config.boeBaseRate.toFixed(2)}%`;
+
+  const bold = "font-medium text-foreground";
 
   return (
     <p className="text-center text-xs text-muted-foreground">
-      These projections use assumptions about salary growth, inflation, and
-      interest rates.{" "}
+      Based on <span className={bold}>{salaryLabel}</span> salary growth,{" "}
+      <span className={bold}>{thresholdLabel}</span> thresholds,
+      {showBoe ? " " : " and "}
+      <span className={bold}>{rpiLabel}</span> RPI
+      {showBoe && (
+        <>
+          , and <span className={bold}>{boeLabel}</span> base rate
+        </>
+      )}
+      .{" "}
       <button
         type="button"
         className="cursor-pointer text-primary underline underline-offset-2 hover:text-primary/80"
@@ -16,7 +46,7 @@ export function AssumptionsCallout() {
           openAssumptions();
         }}
       >
-        See or change assumptions
+        Change assumptions
       </button>
     </p>
   );

--- a/src/components/overpay/OverpayPage.tsx
+++ b/src/components/overpay/OverpayPage.tsx
@@ -10,12 +10,11 @@ import { OverpaySummaryCards } from "./OverpaySummaryCards";
 import { OverpayVerdict } from "./OverpayVerdict";
 import type { InputMode } from "@/components/InputPanel";
 import type { Preset } from "@/lib/presets";
+import { AssumptionsCallout } from "@/components/AssumptionsCallout";
 import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
 import { InputPanel } from "@/components/InputPanel";
 import { PlanFromQuery } from "@/components/PlanFromQuery";
-import { SALARY_GROWTH_OPTIONS } from "@/constants";
-import { useAssumptionsWizard } from "@/context/AssumptionsWizardContext";
 import { useLoanActions, useLoanConfigState } from "@/context/LoanContext";
 import { useOverpayAnalysis } from "@/hooks/useOverpayAnalysis";
 import {
@@ -35,15 +34,6 @@ export function OverpayPage() {
   const { applyPreset } = useLoanActions();
   const config = useLoanConfigState();
   const hasPersonalized = !isPresetConfig(config.loans);
-  const { openAssumptions } = useAssumptionsWizard();
-
-  const growthLabel =
-    SALARY_GROWTH_OPTIONS.find((o) => o.value === config.salaryGrowthRate)
-      ?.label ?? `${(config.salaryGrowthRate * 100).toFixed(0)}%`;
-  const thresholdInfo =
-    config.thresholdGrowthRate === 0
-      ? "Frozen thresholds"
-      : `+${(config.thresholdGrowthRate * 100).toFixed(0)}%/yr threshold`;
 
   useEffect(() => {
     if (mode.view !== "summary") {
@@ -137,17 +127,7 @@ export function OverpayPage() {
           onRepaymentDateChange={setRepaymentDate}
         />
 
-        <button
-          type="button"
-          onClick={() => {
-            openAssumptions();
-          }}
-          className="text-sm text-primary underline-offset-4 hover:underline"
-          aria-label="Edit growth assumptions"
-        >
-          Assuming {growthLabel} salary growth, {thresholdInfo.toLowerCase()}{" "}
-          &rarr;
-        </button>
+        <AssumptionsCallout />
       </main>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary

Replace the generic text in `AssumptionsCallout` ("These projections use assumptions about salary growth, inflation, and interest rates.") with a sentence showing the actual configured values — salary growth rate, threshold growth, RPI, and conditionally the BOE base rate (when Plan 1 or Plan 4 is active). Reuse the same component on the overpay page, replacing its inline button that had duplicated assumption-display logic.

## Context

Both pages previously showed vague or incomplete assumption info — the main page had generic text and the overpay page had a bare button showing only 2 of 4 assumptions. Now both use a single shared component that displays all relevant values with bolded figures for scannability.