### PR TITLE
feat: add 6 guide pages with interactive charts, index page, and breadcrumb navigation

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -12,6 +12,16 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - [Which Plan Quiz](https://studentloanstudy.uk/which-plan): Find your loan plan in 3 questions
 - [Overpay Calculator](https://studentloanstudy.uk/overpay): Should you overpay or invest?
 
+## Guides
+
+- [All Guides](https://studentloanstudy.uk/guides): Index page listing all student loan guides
+- [Plan 2 vs Plan 5](https://studentloanstudy.uk/guides/plan-2-vs-plan-5): Compare thresholds, interest rates, and total repayments between Plan 2 and Plan 5
+- [How Interest Works](https://studentloanstudy.uk/guides/how-interest-works): Understand the sliding scale for Plan 2, RPI-only for Plan 5, and why balances grow
+- [Student Loan & Mortgage](https://studentloanstudy.uk/guides/student-loan-vs-mortgage): How student loan repayments affect mortgage affordability and borrowing capacity
+- [Pay Upfront or Take Loan?](https://studentloanstudy.uk/guides/pay-upfront-or-take-loan): Should parents pay tuition upfront or let their child take the loan?
+- [Moving Abroad](https://studentloanstudy.uk/guides/moving-abroad): What happens to your student loan if you leave the UK
+- [Self-Employment](https://studentloanstudy.uk/guides/self-employment): How repayments work through Self Assessment for freelancers
+
 ## Key Facts
 
 - UK student loans support multiple plan types: Plan 1, Plan 2, Plan 4, Plan 5, and Postgraduate Loans

--- a/src/app/guides/how-interest-works/layout.tsx
+++ b/src/app/guides/how-interest-works/layout.tsx
@@ -1,0 +1,95 @@
+import type { Metadata } from "next";
+import { formatGBP } from "@/lib/format";
+import { PLAN_CONFIGS } from "@/lib/loans/plans";
+
+export const metadata: Metadata = {
+  title: "How Interest Works on UK Student Loans",
+  description:
+    "Understand how interest is calculated on UK student loans. Learn the sliding scale for Plan 2, RPI-only for Plan 5, and how each plan type charges interest.",
+  keywords: [
+    "UK student loan interest",
+    "student loan interest rate",
+    "Plan 2 interest sliding scale",
+    "Plan 5 interest rate",
+    "RPI student loan",
+    "student loan balance growing",
+  ],
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://studentloanstudy.uk",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Guides",
+      item: "https://studentloanstudy.uk/guides",
+    },
+    {
+      "@type": "ListItem",
+      position: 3,
+      name: "How Interest Works",
+      item: "https://studentloanstudy.uk/guides/how-interest-works",
+    },
+  ],
+};
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "How is interest calculated on Plan 2 student loans?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: `Plan 2 uses a sliding scale based on your income. If you earn below ${formatGBP(PLAN_CONFIGS.PLAN_2.interestLowerThreshold)}, you pay RPI only. If you earn above ${formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}, you pay RPI plus 3%. Between the two thresholds, the rate scales linearly.`,
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Why does my student loan balance keep growing?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Your balance grows when the interest added each month exceeds your monthly repayment. This is common in the early years when balances are high and salaries are lower. Over time, as your salary increases, repayments typically begin to outpace interest.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What interest rate does Plan 5 charge?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Plan 5 charges interest at the rate of RPI (Retail Prices Index) only, regardless of your income. This is simpler than Plan 2 and generally results in a lower interest rate for higher earners.",
+      },
+    },
+  ],
+};
+
+// Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
+// Google reads JSON-LD from anywhere in the document, so this is functionally equivalent.
+export default function HowInterestWorksLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/guides/how-interest-works/page.tsx
+++ b/src/app/guides/how-interest-works/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { AppErrorBoundary } from "@/components/ErrorBoundary";
+import { InterestGuide } from "@/components/guides/how-interest-works/InterestGuide";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/guides/how-interest-works" },
+};
+
+export default function HowInterestWorksRoute() {
+  return (
+    <AppErrorBoundary>
+      <InterestGuide />
+    </AppErrorBoundary>
+  );
+}

--- a/src/app/guides/layout.tsx
+++ b/src/app/guides/layout.tsx
@@ -1,0 +1,52 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Student Loan Guides",
+  description:
+    "In-depth guides on UK student loan repayment. Understand plan differences, interest rates, mortgage impact, self-employment, and more.",
+  keywords: [
+    "UK student loan guides",
+    "student loan repayment guide",
+    "Plan 2 vs Plan 5",
+    "student loan interest explained",
+    "student loan mortgage impact",
+  ],
+  alternates: {
+    canonical: "/guides",
+  },
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://studentloanstudy.uk",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Guides",
+      item: "https://studentloanstudy.uk/guides",
+    },
+  ],
+};
+
+export default function GuidesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/guides/moving-abroad/layout.tsx
+++ b/src/app/guides/moving-abroad/layout.tsx
@@ -1,0 +1,93 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "What Happens to Your Student Loan If You Move Abroad?",
+  description:
+    "Find out how UK student loan repayments work when you move overseas. Learn about SLC obligations, country-specific thresholds, and penalties for non-compliance.",
+  keywords: [
+    "student loan abroad",
+    "SLC overseas",
+    "student loan move abroad",
+    "UK student loan overseas repayment",
+    "student loan living abroad",
+    "SLC overseas income assessment",
+  ],
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://studentloanstudy.uk",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Guides",
+      item: "https://studentloanstudy.uk/guides",
+    },
+    {
+      "@type": "ListItem",
+      position: 3,
+      name: "Moving Abroad",
+      item: "https://studentloanstudy.uk/guides/moving-abroad",
+    },
+  ],
+};
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "Do I still pay my student loan if I move abroad?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes. Moving abroad does not cancel your student loan. You must notify the Student Loans Company within three months of leaving the UK, provide evidence of your overseas income, and make repayments based on country-specific thresholds set by SLC.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What happens if I don't tell SLC I've moved abroad?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "If you fail to provide income evidence, SLC will apply fixed repayment amounts that can be significantly higher than what you would pay based on your actual income. They may also take legal action, pass your debt to collection agencies, or apply penalties and additional interest.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How are student loan repayments calculated when living overseas?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "SLC sets country-specific repayment thresholds based on the cost of living in your country of residence. You still repay 9% of income above the threshold (6% for Postgraduate loans), but the threshold itself varies by country rather than using the standard UK figure.",
+      },
+    },
+  ],
+};
+
+// Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
+// Google reads JSON-LD from anywhere in the document, so this is functionally equivalent.
+export default function MovingAbroadLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/guides/moving-abroad/page.tsx
+++ b/src/app/guides/moving-abroad/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { AppErrorBoundary } from "@/components/ErrorBoundary";
+import { MovingAbroadGuide } from "@/components/guides/moving-abroad/MovingAbroadGuide";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/guides/moving-abroad",
+  },
+};
+
+export default function MovingAbroadRoute() {
+  return (
+    <AppErrorBoundary>
+      <MovingAbroadGuide />
+    </AppErrorBoundary>
+  );
+}

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -1,0 +1,63 @@
+import { ArrowRight01Icon, BookOpen01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
+import { Breadcrumb } from "@/components/Breadcrumb";
+import { Footer } from "@/components/Footer";
+import { Header } from "@/components/Header";
+import { GUIDES } from "@/lib/guides";
+
+export default function GuidesPage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <main
+        id="main-content"
+        className="mx-auto w-full max-w-4xl flex-1 space-y-8 overflow-x-hidden px-3 pt-13 pb-6 md:pb-8"
+      >
+        <div className="space-y-4">
+          <Breadcrumb currentTitle="Guides" />
+
+          <div className="space-y-2">
+            <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+              Student Loan Guides
+            </h1>
+            <p className="text-muted-foreground">
+              In-depth guides to help you understand UK student loan repayment,
+              interest, and how it fits into your wider finances.
+            </p>
+          </div>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {GUIDES.map((guide) => (
+            <Link
+              key={guide.slug}
+              href={`/guides/${guide.slug}`}
+              className="group block h-full"
+            >
+              <div className="flex h-full flex-col rounded-xl bg-card p-5 ring-1 ring-foreground/10 transition-all duration-200 hover:bg-accent hover:ring-primary/30">
+                <div className="mb-3 flex items-center gap-3">
+                  <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
+                    <HugeiconsIcon icon={BookOpen01Icon} className="size-5" />
+                  </div>
+                  <h2 className="font-medium">{guide.title}</h2>
+                </div>
+                <p className="mb-4 flex-1 text-sm text-muted-foreground">
+                  {guide.description}
+                </p>
+                <div className="flex items-center gap-1 text-sm font-medium text-primary">
+                  Read Guide
+                  <HugeiconsIcon
+                    icon={ArrowRight01Icon}
+                    className="size-4 transition-transform group-hover:translate-x-0.5"
+                  />
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/guides/pay-upfront-or-take-loan/layout.tsx
+++ b/src/app/guides/pay-upfront-or-take-loan/layout.tsx
@@ -1,0 +1,100 @@
+import type { Metadata } from "next";
+import { formatGBP } from "@/lib/format";
+import { PLAN_CONFIGS, TUITION_FEE_CAP } from "@/lib/loans/plans";
+
+export const metadata: Metadata = {
+  title: "Should I Pay Tuition Upfront or Take the Student Loan?",
+  description:
+    "Starting salary alone doesn't tell the whole story. See how salary growth pushes many graduates into the middle-earner zone where they pay more than the upfront cost.",
+  keywords: [
+    "pay tuition upfront",
+    "pay university fees upfront",
+    "student loan vs paying upfront",
+    "should parents pay tuition",
+    "Plan 5 tuition cost",
+    "university fees UK",
+    "salary growth student loan",
+  ],
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://studentloanstudy.uk",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Guides",
+      item: "https://studentloanstudy.uk/guides",
+    },
+    {
+      "@type": "ListItem",
+      position: 3,
+      name: "Pay Upfront or Take Loan",
+      item: "https://studentloanstudy.uk/guides/pay-upfront-or-take-loan",
+    },
+  ],
+};
+
+const feeCapFormatted = formatGBP(TUITION_FEE_CAP);
+const tuitionFormatted = formatGBP(TUITION_FEE_CAP * 3);
+const writeOffYears = PLAN_CONFIGS.PLAN_5.writeOffYears;
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "Is it worth paying university fees upfront?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: `It depends on the graduate's earning trajectory, not just their starting salary. Low earners benefit from the loan being partially written off. Middle earners — those who earn enough to keep repaying for decades but not enough to clear the balance — often end up paying more than the upfront cost due to interest compounding. High earners clear the loan quickly and pay close to the upfront amount. Salary growth is the key factor: a £30k starting salary can reach £65k after 20 years at 4% annual growth, pushing many graduates into the middle-earner zone.`,
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Should parents pay tuition or let their child take a student loan?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: `It depends on future earnings. Plan 5 loans are written off after ${String(writeOffYears)} years, so low earners pay less than the upfront cost. However, salary growth means many graduates who start on moderate salaries end up in the middle-earner zone, where total repayments exceed the original ${tuitionFormatted} tuition cost. Paying upfront makes sense if the graduate expects moderate-to-high career earnings and the family can afford it without impacting financial security.`,
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How much does a 3-year degree cost under Plan 5?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: `At the current maximum tuition fee of ${feeCapFormatted} per year, a standard 3-year undergraduate degree costs ${tuitionFormatted} in tuition fees. This is the amount you would pay upfront or borrow as a tuition fee loan under Plan 5.`,
+      },
+    },
+  ],
+};
+
+// Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
+// Google reads JSON-LD from anywhere in the document, so this is functionally equivalent.
+export default function PayUpfrontOrTakeLoanLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/guides/pay-upfront-or-take-loan/page.tsx
+++ b/src/app/guides/pay-upfront-or-take-loan/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { AppErrorBoundary } from "@/components/ErrorBoundary";
+import { PayUpfrontGuide } from "@/components/guides/pay-upfront-or-take-loan/PayUpfrontGuide";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/guides/pay-upfront-or-take-loan" },
+};
+
+export default function PayUpfrontOrTakeLoanRoute() {
+  return (
+    <AppErrorBoundary>
+      <PayUpfrontGuide />
+    </AppErrorBoundary>
+  );
+}

--- a/src/app/guides/plan-2-vs-plan-5/layout.tsx
+++ b/src/app/guides/plan-2-vs-plan-5/layout.tsx
@@ -1,0 +1,100 @@
+import type { Metadata } from "next";
+import { formatGBP } from "@/lib/format";
+import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
+
+export const metadata: Metadata = {
+  title: "Plan 2 vs Plan 5: Which Student Loan Is Better?",
+  description:
+    "Compare UK student loan Plan 2 and Plan 5 side by side. See how thresholds, interest rates, and write-off periods affect what you actually repay.",
+  keywords: [
+    "Plan 2 vs Plan 5",
+    "UK student loan comparison",
+    "Plan 2 student loan",
+    "Plan 5 student loan",
+    "which student loan plan is better",
+    "student loan write-off",
+  ],
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://studentloanstudy.uk",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Guides",
+      item: "https://studentloanstudy.uk/guides",
+    },
+    {
+      "@type": "ListItem",
+      position: 3,
+      name: "Plan 2 vs Plan 5",
+      item: "https://studentloanstudy.uk/guides/plan-2-vs-plan-5",
+    },
+  ],
+};
+
+const plan2Threshold = formatGBP(PLAN_DISPLAY_INFO.PLAN_2.yearlyThreshold);
+const plan5Threshold = formatGBP(PLAN_DISPLAY_INFO.PLAN_5.yearlyThreshold);
+const plan2WriteOff = PLAN_CONFIGS.PLAN_2.writeOffYears;
+const plan5WriteOff = PLAN_CONFIGS.PLAN_5.writeOffYears;
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "What is the difference between Plan 2 and Plan 5?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: `Plan 2 applies to English and Welsh students who started between 2012 and 2023, with a repayment threshold of ${plan2Threshold} and ${String(plan2WriteOff)}-year write-off. Plan 5 applies to English students starting from 2023 onwards, with a lower threshold of ${plan5Threshold} but a longer ${String(plan5WriteOff)}-year write-off period. Plan 2 charges interest on a sliding scale up to RPI + 3%, while Plan 5 charges RPI only.`,
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Which student loan plan costs more overall?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: `It depends on your salary. Lower earners often repay less on Plan 2 because it writes off after ${String(plan2WriteOff)} years, while Plan 5's ${String(plan5WriteOff)}-year term means more payments despite the lower interest rate. Higher earners may repay more on Plan 2 due to the sliding-scale interest that can reach RPI + 3%.`,
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Does Plan 5 have lower interest than Plan 2?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: `Yes. Plan 5 charges interest at RPI only, while Plan 2 uses a sliding scale from RPI up to RPI + 3% depending on your income. However, Plan 5's longer ${String(plan5WriteOff)}-year repayment window and lower threshold mean you may still pay more in total despite the lower rate.`,
+      },
+    },
+  ],
+};
+
+// Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
+// Google reads JSON-LD from anywhere in the document, so this is functionally equivalent.
+export default function Plan2VsPlan5Layout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/guides/plan-2-vs-plan-5/page.tsx
+++ b/src/app/guides/plan-2-vs-plan-5/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { AppErrorBoundary } from "@/components/ErrorBoundary";
+import { Plan2VsPlan5Guide } from "@/components/guides/plan-2-vs-plan-5/Plan2VsPlan5Guide";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/guides/plan-2-vs-plan-5",
+  },
+};
+
+export default function Plan2VsPlan5Route() {
+  return (
+    <AppErrorBoundary>
+      <Plan2VsPlan5Guide />
+    </AppErrorBoundary>
+  );
+}

--- a/src/app/guides/self-employment/layout.tsx
+++ b/src/app/guides/self-employment/layout.tsx
@@ -1,0 +1,94 @@
+import type { Metadata } from "next";
+import { PLAN_CONFIGS } from "@/lib/loans/plans";
+
+export const metadata: Metadata = {
+  title: "Student Loans and Self-Employment: What You Need to Know",
+  description:
+    "Learn how UK student loan repayments work when you're self-employed. Understand Self Assessment, mixed income, and practical tips for freelancers.",
+  keywords: [
+    "student loan self employed",
+    "self assessment student loan",
+    "freelancer student loan",
+    "self employed student loan repayment",
+    "student loan sole trader",
+    "student loan tax return",
+  ],
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://studentloanstudy.uk",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Guides",
+      item: "https://studentloanstudy.uk/guides",
+    },
+    {
+      "@type": "ListItem",
+      position: 3,
+      name: "Self-Employment",
+      item: "https://studentloanstudy.uk/guides/self-employment",
+    },
+  ],
+};
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "How do I repay my student loan if I'm self-employed?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "If you're self-employed, you repay your student loan through your annual Self Assessment tax return rather than automatic PAYE deductions. HMRC calculates what you owe based on your net profit, and you pay it as part of your tax bill — typically in two lump-sum payments in January and July.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Do I pay student loan through Self Assessment?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: `Yes. Self-employed borrowers repay their student loan through Self Assessment. Your repayment is calculated at ${String(PLAN_CONFIGS.PLAN_2.repaymentRate * 100)}% (Plan 2 and Plan 5) of your profit above the repayment threshold and is included in your tax bill alongside income tax and National Insurance.`,
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What happens if I have both PAYE and self-employment income?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "If you have mixed income, HMRC collects student loan repayments through both mechanisms. Your employer deducts repayments from your salary via PAYE, and your Self Assessment tops up the difference based on your combined total income.",
+      },
+    },
+  ],
+};
+
+// Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
+// Google reads JSON-LD from anywhere in the document, so this is functionally equivalent.
+export default function SelfEmploymentLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/guides/self-employment/page.tsx
+++ b/src/app/guides/self-employment/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { AppErrorBoundary } from "@/components/ErrorBoundary";
+import { SelfEmploymentGuide } from "@/components/guides/self-employment/SelfEmploymentGuide";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/guides/self-employment" },
+};
+
+export default function SelfEmploymentRoute() {
+  return (
+    <AppErrorBoundary>
+      <SelfEmploymentGuide />
+    </AppErrorBoundary>
+  );
+}

--- a/src/app/guides/student-loan-vs-mortgage/layout.tsx
+++ b/src/app/guides/student-loan-vs-mortgage/layout.tsx
@@ -1,0 +1,104 @@
+import type { Metadata } from "next";
+import { formatGBP } from "@/lib/format";
+import { PLAN_CONFIGS } from "@/lib/loans/plans";
+
+export const metadata: Metadata = {
+  title: "Does Your Student Loan Affect Your Mortgage?",
+  description:
+    "Understand how UK student loan repayments reduce your mortgage borrowing power. See monthly repayment impact by salary for Plan 2 and Plan 5.",
+  keywords: [
+    "student loan mortgage",
+    "mortgage affordability student loan",
+    "student loan affect mortgage",
+    "student loan borrowing power",
+    "Plan 2 mortgage impact",
+    "Plan 5 mortgage impact",
+  ],
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://studentloanstudy.uk",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Guides",
+      item: "https://studentloanstudy.uk/guides",
+    },
+    {
+      "@type": "ListItem",
+      position: 3,
+      name: "Student Loan & Mortgage",
+      item: "https://studentloanstudy.uk/guides/student-loan-vs-mortgage",
+    },
+  ],
+};
+
+// Compute example values from plan constants
+const example40kMonthly = Math.round(
+  (40000 / 12 - PLAN_CONFIGS.PLAN_2.monthlyThreshold) *
+    PLAN_CONFIGS.PLAN_2.repaymentRate,
+);
+const example40kMortgageReduction = formatGBP(
+  Math.round(example40kMonthly * 12 * 4.5),
+);
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "Does a student loan count as debt for a mortgage?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "No, a UK student loan is not treated as traditional debt by mortgage lenders. However, lenders do deduct your monthly repayment from your income when calculating how much you can borrow, which reduces your affordability.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How much does a student loan reduce mortgage borrowing?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: `The impact depends on your salary and plan type. For example, someone earning £40,000 on Plan 2 repays about ${formatGBP(example40kMonthly)}/month, which could reduce their maximum mortgage by roughly ${example40kMortgageReduction} based on a typical 4.5x income multiplier applied to the annualised repayment.`,
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Does a student loan affect your credit score?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "No, UK student loans do not appear on your credit report and have no direct impact on your credit score. The Student Loans Company does not report to credit reference agencies.",
+      },
+    },
+  ],
+};
+
+// Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
+// Google reads JSON-LD from anywhere in the document, so this is functionally equivalent.
+export default function StudentLoanVsMortgageLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/guides/student-loan-vs-mortgage/page.tsx
+++ b/src/app/guides/student-loan-vs-mortgage/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { AppErrorBoundary } from "@/components/ErrorBoundary";
+import { MortgageGuide } from "@/components/guides/student-loan-vs-mortgage/MortgageGuide";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/guides/student-loan-vs-mortgage" },
+};
+
+export default function StudentLoanVsMortgageRoute() {
+  return (
+    <AppErrorBoundary>
+      <MortgageGuide />
+    </AppErrorBoundary>
+  );
+}

--- a/src/app/sitemap.xml
+++ b/src/app/sitemap.xml
@@ -2,22 +2,35 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://studentloanstudy.uk</loc>
-    <changefreq>monthly</changefreq>
-    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/which-plan</loc>
-    <changefreq>yearly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/overpay</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://studentloanstudy.uk/guides</loc>
+  </url>
+  <url>
+    <loc>https://studentloanstudy.uk/guides/plan-2-vs-plan-5</loc>
+  </url>
+  <url>
+    <loc>https://studentloanstudy.uk/guides/how-interest-works</loc>
+  </url>
+  <url>
+    <loc>https://studentloanstudy.uk/guides/student-loan-vs-mortgage</loc>
+  </url>
+  <url>
+    <loc>https://studentloanstudy.uk/guides/pay-upfront-or-take-loan</loc>
+  </url>
+  <url>
+    <loc>https://studentloanstudy.uk/guides/moving-abroad</loc>
+  </url>
+  <url>
+    <loc>https://studentloanstudy.uk/guides/self-employment</loc>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/brand</loc>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
   </url>
 </urlset>

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -1,0 +1,45 @@
+import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
+
+interface BreadcrumbItem {
+  label: string;
+  href: string;
+}
+
+interface BreadcrumbProps {
+  /** Intermediate crumbs between Home and the current page. */
+  parents?: BreadcrumbItem[];
+  /** Label for the current (non-linked) page. Omit if this IS the last parent. */
+  currentTitle?: string;
+}
+
+export function Breadcrumb({ parents, currentTitle }: BreadcrumbProps) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="flex items-center gap-1.5 text-sm text-muted-foreground"
+    >
+      <Link href="/" className="transition-colors hover:text-foreground">
+        Home
+      </Link>
+      {parents?.map((crumb) => (
+        <span key={crumb.href} className="contents">
+          <HugeiconsIcon icon={ArrowRight01Icon} className="size-3" />
+          <Link
+            href={crumb.href}
+            className="transition-colors hover:text-foreground"
+          >
+            {crumb.label}
+          </Link>
+        </span>
+      ))}
+      {currentTitle && (
+        <>
+          <HugeiconsIcon icon={ArrowRight01Icon} className="size-3" />
+          <span className="text-foreground">{currentTitle}</span>
+        </>
+      )}
+    </nav>
+  );
+}

--- a/src/components/ToolLinks.tsx
+++ b/src/components/ToolLinks.tsx
@@ -1,58 +1,133 @@
 import {
   AnalyticsUpIcon,
   ArrowRight01Icon,
+  BookOpen01Icon,
   Quiz01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 
+interface ToolCardProps {
+  href: string;
+  icon: typeof Quiz01Icon;
+  title: string;
+  description: string;
+  cta: string;
+}
+
+function ToolCard({ href, icon, title, description, cta }: ToolCardProps) {
+  return (
+    <Link href={href} className="group block h-full">
+      <div className="flex h-full flex-col rounded-xl bg-card p-5 ring-1 ring-foreground/10 transition-all duration-200 hover:bg-accent hover:ring-primary/30">
+        <div className="mb-3 flex items-center gap-3">
+          <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
+            <HugeiconsIcon icon={icon} className="size-5" />
+          </div>
+          <h4 className="font-medium">{title}</h4>
+        </div>
+        <p className="mb-4 flex-1 text-sm text-muted-foreground">
+          {description}
+        </p>
+        <div className="flex items-center gap-1 text-sm font-medium text-primary">
+          {cta}
+          <HugeiconsIcon
+            icon={ArrowRight01Icon}
+            className="size-4 transition-transform group-hover:translate-x-0.5"
+          />
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+const TOOLS: ToolCardProps[] = [
+  {
+    href: "/which-plan?ref=tool-card",
+    icon: Quiz01Icon,
+    title: "Find Your Plan",
+    description:
+      "Not sure which loan plan you\u2019re on? Take our quick 3-question quiz to find out.",
+    cta: "Take the Quiz",
+  },
+  {
+    href: "/overpay?ref=tool-card",
+    icon: AnalyticsUpIcon,
+    title: "Overpay Calculator",
+    description:
+      "Should you pay off your loan faster or invest the money instead?",
+    cta: "Calculate",
+  },
+];
+
+const GUIDES: ToolCardProps[] = [
+  {
+    href: "/guides/plan-2-vs-plan-5",
+    icon: BookOpen01Icon,
+    title: "Plan 2 vs Plan 5",
+    description:
+      "Compare thresholds, interest rates, and total repayments between the two main loan plans.",
+    cta: "Read Guide",
+  },
+  {
+    href: "/guides/how-interest-works",
+    icon: BookOpen01Icon,
+    title: "How Interest Works",
+    description:
+      "Understand the sliding scale, RPI rates, and why your balance can grow even while repaying.",
+    cta: "Read Guide",
+  },
+  {
+    href: "/guides/student-loan-vs-mortgage",
+    icon: BookOpen01Icon,
+    title: "Student Loan & Mortgage",
+    description:
+      "How student loan repayments affect your mortgage affordability and borrowing capacity.",
+    cta: "Read Guide",
+  },
+  {
+    href: "/guides/pay-upfront-or-take-loan",
+    icon: BookOpen01Icon,
+    title: "Pay Upfront or Take Loan?",
+    description:
+      "Why your starting salary is misleading when deciding whether to pay tuition upfront or take the loan.",
+    cta: "Read Guide",
+  },
+  {
+    href: "/guides/moving-abroad",
+    icon: BookOpen01Icon,
+    title: "Moving Abroad",
+    description:
+      "What happens to your student loan repayments if you leave the UK.",
+    cta: "Read Guide",
+  },
+  {
+    href: "/guides/self-employment",
+    icon: BookOpen01Icon,
+    title: "Self-Employment",
+    description:
+      "How repayments work through Self Assessment for freelancers and the self-employed.",
+    cta: "Read Guide",
+  },
+];
+
 export function ToolLinks() {
   return (
-    <section className="space-y-4">
-      <h3 className="text-base font-semibold">More Tools</h3>
-      <div className="grid gap-4 sm:grid-cols-2">
-        <Link href="/which-plan?ref=tool-card" className="group block h-full">
-          <div className="flex h-full flex-col rounded-xl bg-card p-5 ring-1 ring-foreground/10 transition-all duration-200 hover:bg-accent hover:ring-primary/30">
-            <div className="mb-3 flex items-center gap-3">
-              <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
-                <HugeiconsIcon icon={Quiz01Icon} className="size-5" />
-              </div>
-              <h4 className="font-medium">Find Your Plan</h4>
-            </div>
-            <p className="mb-4 flex-1 text-sm text-muted-foreground">
-              Not sure which loan plan you&apos;re on? Take our quick 3-question
-              quiz to find out.
-            </p>
-            <div className="flex items-center gap-1 text-sm font-medium text-primary">
-              Take the Quiz
-              <HugeiconsIcon
-                icon={ArrowRight01Icon}
-                className="size-4 transition-transform group-hover:translate-x-0.5"
-              />
-            </div>
-          </div>
-        </Link>
-
-        <Link href="/overpay?ref=tool-card" className="group block h-full">
-          <div className="flex h-full flex-col rounded-xl bg-card p-5 ring-1 ring-foreground/10 transition-all duration-200 hover:bg-accent hover:ring-primary/30">
-            <div className="mb-3 flex items-center gap-3">
-              <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
-                <HugeiconsIcon icon={AnalyticsUpIcon} className="size-5" />
-              </div>
-              <h4 className="font-medium">Overpay Calculator</h4>
-            </div>
-            <p className="mb-4 flex-1 text-sm text-muted-foreground">
-              Should you pay off your loan faster or invest the money instead?
-            </p>
-            <div className="flex items-center gap-1 text-sm font-medium text-primary">
-              Calculate
-              <HugeiconsIcon
-                icon={ArrowRight01Icon}
-                className="size-4 transition-transform group-hover:translate-x-0.5"
-              />
-            </div>
-          </div>
-        </Link>
+    <section className="space-y-6">
+      <div className="space-y-4">
+        <h3 className="text-base font-semibold">More Tools</h3>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {TOOLS.map((tool) => (
+            <ToolCard key={tool.href} {...tool} />
+          ))}
+        </div>
+      </div>
+      <div className="space-y-4">
+        <h3 className="text-base font-semibold">Guides</h3>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {GUIDES.map((guide) => (
+            <ToolCard key={guide.href} {...guide} />
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/src/components/brand/BrandGuidelinesPage.tsx
+++ b/src/components/brand/BrandGuidelinesPage.tsx
@@ -1,6 +1,4 @@
-import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-import Link from "next/link";
+import { Breadcrumb } from "../Breadcrumb";
 import { Footer } from "../Footer";
 import { Header } from "../Header";
 import { BrandIcon, BRAND_HEX } from "./BrandIcon";
@@ -81,13 +79,9 @@ export function BrandGuidelinesPage() {
     <div className="flex min-h-screen flex-col bg-background">
       <Header />
       <main className="mx-auto w-full max-w-4xl flex-1 px-4 py-6 md:px-6 md:py-8">
-        <Link
-          href="/"
-          className="mb-8 inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
-          Back to Calculator
-        </Link>
+        <div className="mb-8">
+          <Breadcrumb currentTitle="Brand Guidelines" />
+        </div>
 
         {/* Header */}
         <header className="mb-12">

--- a/src/components/charts/ChartBase.tsx
+++ b/src/components/charts/ChartBase.tsx
@@ -25,7 +25,7 @@ export interface ChartAnnotationConfig {
   y?: number;
   label: string;
   color?: string;
-  labelPosition?: "insideTop" | "insideTopLeft" | "insideTopRight";
+  labelAnchor?: "start" | "end";
   strokeDasharray?: string;
 }
 
@@ -186,13 +186,25 @@ export function ChartBase({
             tickMargin={8}
             {...(yLabel
               ? {
-                  label: {
-                    value: yLabel,
-                    angle: -90,
-                    position: "left" as const,
-                    offset: 10,
-                    className: "fill-muted-foreground text-xs",
-                  },
+                  label: ({
+                    viewBox,
+                  }: {
+                    viewBox: {
+                      x: number;
+                      y: number;
+                      height: number;
+                    };
+                  }) => (
+                    <text
+                      x={viewBox.x - 10}
+                      y={viewBox.y + viewBox.height / 2}
+                      transform={`rotate(-90, ${String(viewBox.x - 10)}, ${String(viewBox.y + viewBox.height / 2)})`}
+                      textAnchor="middle"
+                      className="fill-muted-foreground text-xs"
+                    >
+                      {yLabel}
+                    </text>
+                  ),
                 }
               : {})}
           />
@@ -304,14 +316,29 @@ export function ChartBase({
                 stroke={annotation.color ?? "var(--muted-foreground)"}
                 strokeWidth={1.5}
                 strokeDasharray={annotation.strokeDasharray ?? "6 4"}
-                label={{
-                  value: annotation.label,
-                  position: annotation.labelPosition ?? "insideTop",
-                  fill: annotation.color ?? "var(--muted-foreground)",
-                  fontSize: 11,
-                  fontWeight: 500,
-                  dy: -25,
-                }}
+                label={
+                  annotation.labelAnchor
+                    ? ({ viewBox }: { viewBox: { x: number; y: number } }) => (
+                        <text
+                          x={viewBox.x}
+                          y={viewBox.y - 20}
+                          fill={annotation.color ?? "var(--muted-foreground)"}
+                          fontSize={11}
+                          fontWeight={500}
+                          textAnchor={annotation.labelAnchor}
+                        >
+                          <tspan dy="0.355em">{annotation.label}</tspan>
+                        </text>
+                      )
+                    : {
+                        value: annotation.label,
+                        position: "insideTop" as const,
+                        fill: annotation.color ?? "var(--muted-foreground)",
+                        fontSize: 11,
+                        fontWeight: 500,
+                        dy: -25,
+                      }
+                }
               />
             ))}
           {!showCrosshair &&

--- a/src/components/guides/RelatedGuides.tsx
+++ b/src/components/guides/RelatedGuides.tsx
@@ -1,0 +1,135 @@
+import {
+  AnalyticsUpIcon,
+  ArrowRight01Icon,
+  BookOpen01Icon,
+  Calculator01Icon,
+  GlobalIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
+import type { GuideEntry, GuideSlug } from "@/lib/guides";
+import { GUIDES } from "@/lib/guides";
+
+interface ExtraLink {
+  href: string;
+  label: string;
+}
+
+interface RelatedGuidesProps {
+  current: GuideSlug;
+  order: GuideSlug[];
+  extraLinks?: ExtraLink[];
+}
+
+export function RelatedGuides({
+  current,
+  order,
+  extraLinks,
+}: RelatedGuidesProps) {
+  const guidesBySlug = new Map(GUIDES.map((g) => [g.slug, g]));
+  const orderedGuides = order
+    .filter((slug) => slug !== current)
+    .map((slug) => guidesBySlug.get(slug))
+    .filter((g): g is GuideEntry => g !== undefined)
+    .slice(0, 2);
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold tracking-tight">Related Guides</h2>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {orderedGuides.map((guide) => (
+            <Link
+              key={guide.slug}
+              href={`/guides/${guide.slug}`}
+              className="group block"
+            >
+              <div className="flex h-full flex-col rounded-xl bg-card p-4 ring-1 ring-foreground/10 transition-all duration-200 hover:bg-accent hover:ring-primary/30">
+                <div className="mb-2 flex items-center gap-2.5">
+                  <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
+                    <HugeiconsIcon icon={BookOpen01Icon} className="size-4" />
+                  </div>
+                  <h3 className="text-sm font-medium">{guide.title}</h3>
+                </div>
+                <p className="mb-3 flex-1 text-xs text-muted-foreground">
+                  {guide.description}
+                </p>
+                <div className="flex items-center gap-1 text-xs font-medium text-primary">
+                  Read Guide
+                  <HugeiconsIcon
+                    icon={ArrowRight01Icon}
+                    className="size-3.5 transition-transform group-hover:translate-x-0.5"
+                  />
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {extraLinks && extraLinks.length > 0 && (
+        <div className="flex flex-wrap gap-3">
+          {extraLinks.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group inline-flex items-center gap-2 rounded-lg border px-4 py-2.5 text-sm transition-colors hover:bg-accent"
+            >
+              <HugeiconsIcon
+                icon={GlobalIcon}
+                className="size-4 text-muted-foreground"
+              />
+              {link.label}
+              <HugeiconsIcon
+                icon={ArrowRight01Icon}
+                className="size-3.5 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+              />
+            </a>
+          ))}
+        </div>
+      )}
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold tracking-tight">More Tools</h2>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Link href="/" className="group block">
+            <div className="flex items-center gap-3 rounded-xl border p-4 transition-all duration-200 hover:bg-accent hover:ring-1 hover:ring-primary/30">
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
+                <HugeiconsIcon icon={Calculator01Icon} className="size-5" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <h3 className="text-sm font-medium">Repayment Calculator</h3>
+                <p className="text-xs text-muted-foreground">
+                  Model your own repayment timeline
+                </p>
+              </div>
+              <HugeiconsIcon
+                icon={ArrowRight01Icon}
+                className="size-4 shrink-0 text-primary transition-transform group-hover:translate-x-0.5"
+              />
+            </div>
+          </Link>
+          <Link href="/overpay" className="group block">
+            <div className="flex items-center gap-3 rounded-xl border p-4 transition-all duration-200 hover:bg-accent hover:ring-1 hover:ring-primary/30">
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
+                <HugeiconsIcon icon={AnalyticsUpIcon} className="size-5" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <h3 className="text-sm font-medium">Overpay Calculator</h3>
+                <p className="text-xs text-muted-foreground">
+                  Pay off faster or invest instead?
+                </p>
+              </div>
+              <HugeiconsIcon
+                icon={ArrowRight01Icon}
+                className="size-4 shrink-0 text-primary transition-transform group-hover:translate-x-0.5"
+              />
+            </div>
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/guides/how-interest-works/InterestGuide.tsx
+++ b/src/components/guides/how-interest-works/InterestGuide.tsx
@@ -1,0 +1,179 @@
+import { InterestRateChart } from "./InterestRateChart";
+import { Breadcrumb } from "@/components/Breadcrumb";
+import { Footer } from "@/components/Footer";
+import { RelatedGuides } from "@/components/guides/RelatedGuides";
+import { Header } from "@/components/Header";
+import { formatGBP, formatPercent } from "@/lib/format";
+import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
+
+const EXAMPLE_BALANCE = 45_000;
+const rpi = CURRENT_RATES.rpi;
+const maxRate = rpi + 3;
+const plan1Rate = Math.min(rpi, CURRENT_RATES.boeBaseRate + 1);
+const boeRatePlus1 = CURRENT_RATES.boeBaseRate + 1;
+const monthlyInterest = Math.round((EXAMPLE_BALANCE * maxRate) / 100 / 12);
+
+export function InterestGuide() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <main
+        id="main-content"
+        className="mx-auto w-full max-w-4xl flex-1 px-3 pt-13 pb-6 md:pb-8"
+      >
+        <article className="space-y-8">
+          <div className="space-y-4">
+            <Breadcrumb
+              parents={[{ label: "Guides", href: "/guides" }]}
+              currentTitle="How Interest Works"
+            />
+
+            <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+              How Interest Works on UK Student Loans
+            </h1>
+            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+              Interest is one of the most confusing parts of student loans. Each
+              plan type calculates it differently, which means the amount your
+              balance grows varies depending on when you started university and
+              how much you earn.
+            </p>
+          </div>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Plan 2: The Sliding Scale
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <p>
+                Plan 2 has the most complex interest calculation. It uses a
+                sliding scale tied to your income, ranging from RPI (currently{" "}
+                {formatPercent(rpi)}) up to RPI + 3% (currently{" "}
+                {formatPercent(maxRate)}).
+              </p>
+              <ul className="list-disc space-y-1 pl-6">
+                <li>
+                  Earning below the lower threshold of{" "}
+                  <strong className="text-foreground">
+                    {formatGBP(PLAN_CONFIGS.PLAN_2.interestLowerThreshold)}
+                  </strong>
+                  : you pay RPI only ({formatPercent(rpi)})
+                </li>
+                <li>
+                  Earning above the upper threshold of{" "}
+                  <strong className="text-foreground">
+                    {formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}
+                  </strong>
+                  : you pay the maximum of RPI + 3% ({formatPercent(maxRate)})
+                </li>
+                <li>
+                  Earning between the two: the rate scales linearly from{" "}
+                  {formatPercent(rpi)} up to {formatPercent(maxRate)}
+                </li>
+              </ul>
+              <p>
+                While studying, Plan 2 borrowers are charged the maximum rate of
+                RPI + 3%. This means your balance starts growing before you even
+                graduate.
+              </p>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Plan 5: RPI Only
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <p>
+                Plan 5, introduced for students starting from September 2023,
+                has a much simpler formula. Regardless of how much you earn, the
+                interest rate is just RPI &mdash; currently {formatPercent(rpi)}
+                .
+              </p>
+              <p>
+                This is a significant change from Plan 2. A high earner on Plan
+                2 could be paying {formatPercent(maxRate)} interest, while the
+                same earner on Plan 5 would pay only {formatPercent(rpi)}. The
+                chart below illustrates this difference clearly.
+              </p>
+            </div>
+          </section>
+
+          <InterestRateChart />
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Plan 1 and Plan 4
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <p>
+                Plan 1 (England, Wales &amp; Northern Ireland pre-2012) and Plan
+                4 (Scotland) use the same interest formula: the lesser of RPI or
+                the Bank of England base rate plus 1%.
+              </p>
+              <p>
+                With RPI at {formatPercent(rpi)} and the base rate at{" "}
+                {formatPercent(CURRENT_RATES.boeBaseRate)}, the current interest
+                rate for these plans is{" "}
+                <strong className="text-foreground">
+                  {formatPercent(plan1Rate)}
+                </strong>{" "}
+                (the lower of {formatPercent(rpi)} and{" "}
+                {formatPercent(boeRatePlus1)}).
+              </p>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Postgraduate Loans
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <p>
+                Postgraduate (Master&apos;s and Doctoral) loans always charge
+                RPI + 3%, regardless of your income. At current rates, that
+                means{" "}
+                <strong className="text-foreground">
+                  {formatPercent(maxRate)}
+                </strong>{" "}
+                interest per year &mdash; the highest rate of any UK student
+                loan plan.
+              </p>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Why Your Balance Grows
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <p>
+                Many graduates are surprised to see their loan balance increase
+                despite making repayments. This happens when the interest added
+                each month exceeds what you repay.
+              </p>
+              <p>
+                For example, on a {formatGBP(EXAMPLE_BALANCE)} balance at{" "}
+                {formatPercent(maxRate)} interest, you would accrue roughly{" "}
+                {formatGBP(monthlyInterest)} per month in interest alone. If
+                your monthly repayment is less than that, the balance will keep
+                growing.
+              </p>
+              <p>
+                This is most common early in your career when salaries are lower
+                and balances are at their highest. Over time, salary growth
+                increases your repayments while the balance (hopefully) shrinks,
+                eventually tipping the scales.
+              </p>
+            </div>
+          </section>
+
+          <RelatedGuides
+            current="how-interest-works"
+            order={["plan-2-vs-plan-5", "pay-upfront-or-take-loan"]}
+          />
+        </article>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/guides/how-interest-works/InterestRateChart.tsx
+++ b/src/components/guides/how-interest-works/InterestRateChart.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import type { ChartConfig } from "@/components/ui/chart";
+import {
+  ChartBase,
+  type ChartSeriesConfig,
+} from "@/components/charts/ChartBase";
+import { getAnnualInterestRate } from "@/lib/loans/interest";
+import { CURRENT_RATES } from "@/lib/loans/plans";
+
+const SALARY_MIN = 20_000;
+const SALARY_MAX = 80_000;
+const SALARY_STEP = 1_000;
+
+function buildChartData() {
+  const data: Array<{
+    salary: number;
+    plan2: number;
+    plan5: number;
+  }> = [];
+
+  for (let salary = SALARY_MIN; salary <= SALARY_MAX; salary += SALARY_STEP) {
+    data.push({
+      salary,
+      plan2: getAnnualInterestRate(
+        "PLAN_2",
+        salary,
+        CURRENT_RATES.rpi,
+        CURRENT_RATES.boeBaseRate,
+      ),
+      plan5: getAnnualInterestRate(
+        "PLAN_5",
+        salary,
+        CURRENT_RATES.rpi,
+        CURRENT_RATES.boeBaseRate,
+      ),
+    });
+  }
+
+  return data;
+}
+
+const chartConfig: ChartConfig = {
+  plan2: {
+    label: "Plan 2",
+    color: "var(--chart-1)",
+  },
+  plan5: {
+    label: "Plan 5",
+    color: "var(--chart-2)",
+  },
+};
+
+const series: ChartSeriesConfig[] = [
+  { dataKey: "plan2" },
+  { dataKey: "plan5" },
+];
+
+function formatSalary(value: number): string {
+  return `\u00A3${String(Math.round(value / 1000))}k`;
+}
+
+function formatRate(value: number): string {
+  return `${value.toFixed(1)}%`;
+}
+
+export function InterestRateChart() {
+  const data = buildChartData();
+
+  return (
+    <div className="h-[300px] sm:h-[360px]">
+      <ChartBase
+        type="line"
+        data={data}
+        xDataKey="salary"
+        xLabel="Annual Salary"
+        xFormatter={formatSalary}
+        yLabel="Interest Rate"
+        yFormatter={formatRate}
+        ariaLabel="Line chart comparing annual interest rates by salary for Plan 2 and Plan 5"
+        chartConfig={chartConfig}
+        series={series}
+        showLegend
+      />
+    </div>
+  );
+}

--- a/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
+++ b/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
@@ -1,0 +1,310 @@
+import {
+  AlertCircleIcon,
+  Globe02Icon,
+  CoinsPoundIcon,
+  CreditCardIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Breadcrumb } from "@/components/Breadcrumb";
+import { Footer } from "@/components/Footer";
+import { RelatedGuides } from "@/components/guides/RelatedGuides";
+import { Header } from "@/components/Header";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { PLAN_CONFIGS } from "@/lib/loans/plans";
+
+const undergradRate = `${String(PLAN_CONFIGS.PLAN_2.repaymentRate * 100)}%`;
+const postgradRate = `${String(PLAN_CONFIGS.POSTGRADUATE.repaymentRate * 100)}%`;
+
+const govUkAbroadLink =
+  "https://www.gov.uk/repaying-your-student-loan/repaying-from-abroad";
+
+const linkClasses =
+  "text-primary underline-offset-2 hover:underline font-medium";
+
+export function MovingAbroadGuide() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <main
+        id="main-content"
+        className="mx-auto w-full max-w-4xl flex-1 space-y-8 overflow-x-hidden px-3 pt-13 pb-6 md:pb-8"
+      >
+        <article className="space-y-8">
+          <div className="space-y-4">
+            <Breadcrumb
+              parents={[{ label: "Guides", href: "/guides" }]}
+              currentTitle="Moving Abroad"
+            />
+
+            <div className="space-y-2">
+              <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+                What Happens to Your Student Loan If You Move Abroad?
+              </h1>
+              <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+                Moving overseas doesn&rsquo;t make your student loan disappear.
+                The Student Loans Company (SLC) continues to collect repayments
+                regardless of where you live, and the rules for how much you pay
+                change when you leave the UK.
+              </p>
+            </div>
+          </div>
+
+          <section className="space-y-4">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              You Must Notify SLC
+            </h2>
+            <p className="text-sm text-muted-foreground sm:text-base">
+              If you&rsquo;re planning to leave the UK for more than three
+              months, you are legally required to inform SLC. This applies
+              whether you&rsquo;re moving for work, travel, or any other reason.
+            </p>
+            <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+              <li>
+                Notify SLC <strong>within three months</strong> of moving abroad
+              </li>
+              <li>Provide your new overseas address and contact details</li>
+              <li>
+                Submit evidence of your income through the{" "}
+                <a
+                  href={govUkAbroadLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={linkClasses}
+                >
+                  overseas income assessment form
+                </a>
+              </li>
+              <li>
+                Continue providing income evidence annually to keep your
+                repayments accurate
+              </li>
+            </ul>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              How Repayments Work Abroad
+            </h2>
+            <p className="text-sm text-muted-foreground sm:text-base">
+              When you live in the UK, repayments are automatically deducted
+              from your salary through PAYE. Abroad, the system works
+              differently.
+            </p>
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
+                <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
+                  <HugeiconsIcon
+                    icon={Globe02Icon}
+                    className="size-5 text-primary"
+                  />
+                </div>
+                <p className="font-medium">Country Thresholds</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  SLC sets{" "}
+                  <a
+                    href={govUkAbroadLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={linkClasses}
+                  >
+                    country-specific repayment thresholds
+                  </a>{" "}
+                  based on local cost of living — they may be higher or lower
+                  than the UK threshold.
+                </p>
+              </div>
+              <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
+                <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
+                  <HugeiconsIcon
+                    icon={CoinsPoundIcon}
+                    className="size-5 text-primary"
+                  />
+                </div>
+                <p className="font-medium">Repayment Rates</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  You still repay {undergradRate} of income above the threshold
+                  for undergraduate loans ({postgradRate} for Postgraduate
+                  Loans).
+                </p>
+              </div>
+              <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
+                <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
+                  <HugeiconsIcon
+                    icon={CreditCardIcon}
+                    className="size-5 text-primary"
+                  />
+                </div>
+                <p className="font-medium">Direct Payments to SLC</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Repayments are made directly to SLC rather than through your
+                  employer.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <Alert variant="destructive">
+              <HugeiconsIcon icon={AlertCircleIcon} className="size-4" />
+              <AlertTitle>
+                What If You Don&rsquo;t Provide Income Evidence?
+              </AlertTitle>
+              <AlertDescription>
+                <p>
+                  If you fail to complete the overseas income assessment, SLC
+                  doesn&rsquo;t simply stop collecting. Instead, they apply{" "}
+                  <strong>fixed repayment amounts</strong> that are not based on
+                  your actual earnings.
+                </p>
+                <ul className="mt-2 list-inside list-disc space-y-1">
+                  <li>
+                    Fixed amounts can be <strong>significantly higher</strong>{" "}
+                    than what you would pay based on your real income
+                  </li>
+                  <li>
+                    This effectively acts as a penalty for not engaging with the
+                    process
+                  </li>
+                  <li>
+                    You can avoid this by submitting your income evidence on
+                    time each year
+                  </li>
+                </ul>
+              </AlertDescription>
+            </Alert>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Consequences of Non-Compliance
+            </h2>
+            <div className="rounded-lg border-l-4 border-destructive bg-card p-4 ring-1 ring-foreground/10 sm:p-5">
+              <p className="mb-3 text-sm text-muted-foreground sm:text-base">
+                Ignoring your student loan obligations while abroad can have
+                serious consequences. SLC has several enforcement mechanisms
+                available.
+              </p>
+              <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+                <li>
+                  SLC can take <strong>legal action</strong> to recover the debt
+                </li>
+                <li>
+                  Your debt may be passed to{" "}
+                  <strong>collection agencies</strong>
+                </li>
+                <li>
+                  If you return to the UK, missed payments could{" "}
+                  <strong>affect your credit record</strong>
+                </li>
+                <li>
+                  Additional <strong>penalties and interest</strong> may be
+                  applied to your balance
+                </li>
+                <li>
+                  HMRC can resume automatic deductions from your salary if you
+                  return to UK employment
+                </li>
+              </ul>
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Practical Steps Before You Move
+            </h2>
+            <p className="text-sm text-muted-foreground sm:text-base">
+              If you&rsquo;re planning to move abroad, take these steps to stay
+              on top of your loan.
+            </p>
+            <div className="space-y-0 divide-y rounded-lg border bg-card ring-1 ring-foreground/10">
+              {[
+                {
+                  title: "Notify SLC",
+                  description:
+                    "Inform SLC of your move and new address as early as possible.",
+                },
+                {
+                  title: "Complete the overseas income assessment",
+                  description:
+                    "Submit the form to ensure your repayments are based on your actual income.",
+                },
+                {
+                  title: "Check your country\u2019s threshold",
+                  description:
+                    "Look up the SLC website so you know what to expect for your destination.",
+                },
+                {
+                  title: "Set up a payment method",
+                  description:
+                    "Arrange a way to make direct repayments to SLC from abroad.",
+                },
+                {
+                  title: "Keep records",
+                  description:
+                    "Save all correspondence and payment confirmations with SLC.",
+                },
+                {
+                  title: "Set annual reminders",
+                  description:
+                    "Resubmit income evidence before the deadline each year.",
+                },
+              ].map((step, i) => (
+                <div key={i} className="flex gap-4 p-4">
+                  <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
+                    {i + 1}
+                  </span>
+                  <div>
+                    <p className="font-medium">{step.title}</p>
+                    <p className="mt-0.5 text-sm text-muted-foreground">
+                      {step.description}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
+            <h2 className="text-lg font-semibold tracking-tight">
+              Key Takeaways
+            </h2>
+            <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+              <li>
+                Moving abroad does <strong>not</strong> cancel or pause your
+                student loan repayments.
+              </li>
+              <li>
+                You must notify SLC within three months and provide annual
+                income evidence.
+              </li>
+              <li>
+                Repayment thresholds vary by country based on local cost of
+                living.
+              </li>
+              <li>
+                Failing to engage with SLC results in fixed repayment amounts
+                that are typically higher than income-based payments.
+              </li>
+              <li>
+                Non-compliance can lead to legal action, collection agencies,
+                and credit impacts if you return to the UK.
+              </li>
+            </ul>
+          </section>
+
+          <RelatedGuides
+            current="moving-abroad"
+            order={["self-employment", "plan-2-vs-plan-5"]}
+            extraLinks={[
+              {
+                href: "https://www.gov.uk/repaying-your-student-loan/repaying-from-abroad",
+                label: "GOV.UK: Repaying from Abroad",
+              },
+            ]}
+          />
+        </article>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/guides/pay-upfront-or-take-loan/CostComparisonChart.tsx
+++ b/src/components/guides/pay-upfront-or-take-loan/CostComparisonChart.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import type { ChartConfig } from "@/components/ui/chart";
+import { ChartBase } from "@/components/charts/ChartBase";
+import { simulate } from "@/lib/loans/engine";
+import { TUITION_FEE_CAP } from "@/lib/loans/plans";
+
+const TUITION_COST = TUITION_FEE_CAP * 3;
+
+const chartConfig = {
+  loanCost: {
+    label: "Loan (flat salary)",
+    color: "var(--chart-1)",
+  },
+  loanCostWithGrowth: {
+    label: "Loan (4% annual growth)",
+    color: "var(--chart-3)",
+  },
+  upfrontCost: {
+    label: "Upfront cost",
+    color: "oklch(0.7 0.15 50)",
+  },
+} satisfies ChartConfig;
+
+function buildChartData() {
+  const points: Array<{
+    salary: number;
+    loanCost: number;
+    loanCostWithGrowth: number;
+    upfrontCost: number;
+  }> = [];
+
+  for (let salary = 25000; salary <= 100000; salary += 1000) {
+    const flatResult = simulate({
+      loans: [{ planType: "PLAN_5", balance: TUITION_COST }],
+      annualSalary: salary,
+    });
+    const growthResult = simulate({
+      loans: [{ planType: "PLAN_5", balance: TUITION_COST }],
+      annualSalary: salary,
+      salaryGrowthRate: 0.04,
+    });
+    points.push({
+      salary,
+      loanCost: Math.round(flatResult.summary.totalPaid),
+      loanCostWithGrowth: Math.round(growthResult.summary.totalPaid),
+      upfrontCost: TUITION_COST,
+    });
+  }
+
+  return points;
+}
+
+const data = buildChartData();
+
+const xFormatter = (value: number) => `£${String(value / 1000)}k`;
+const yFormatter = (value: number) => `£${String(Math.round(value / 1000))}k`;
+
+export function CostComparisonChart() {
+  return (
+    <ChartBase
+      type="line"
+      data={data}
+      xDataKey="salary"
+      xLabel="Starting annual salary"
+      xFormatter={xFormatter}
+      yLabel="Total cost"
+      yFormatter={yFormatter}
+      ariaLabel="Line chart comparing total cost of taking a student loan at flat and growing salaries versus paying tuition upfront"
+      chartConfig={chartConfig}
+      series={[
+        { dataKey: "loanCost" },
+        { dataKey: "loanCostWithGrowth" },
+        { dataKey: "upfrontCost" },
+      ]}
+      showLegend
+    />
+  );
+}

--- a/src/components/guides/pay-upfront-or-take-loan/PayUpfrontGuide.tsx
+++ b/src/components/guides/pay-upfront-or-take-loan/PayUpfrontGuide.tsx
@@ -1,0 +1,241 @@
+import Link from "next/link";
+import { CostComparisonChart } from "./CostComparisonChart";
+import { Breadcrumb } from "@/components/Breadcrumb";
+import { Footer } from "@/components/Footer";
+import { RelatedGuides } from "@/components/guides/RelatedGuides";
+import { Header } from "@/components/Header";
+import { formatGBP } from "@/lib/format";
+import {
+  PLAN_CONFIGS,
+  PLAN_DISPLAY_INFO,
+  TUITION_FEE_CAP,
+} from "@/lib/loans/plans";
+
+const tuitionTotal = TUITION_FEE_CAP * 3;
+const writeOffYears = PLAN_CONFIGS.PLAN_5.writeOffYears;
+const threshold = formatGBP(PLAN_DISPLAY_INFO.PLAN_5.yearlyThreshold);
+const tuitionFormatted = formatGBP(tuitionTotal);
+const feeCapFormatted = formatGBP(TUITION_FEE_CAP);
+
+export function PayUpfrontGuide() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <main
+        id="main-content"
+        className="mx-auto w-full max-w-4xl flex-1 px-3 pt-13 pb-6 md:pb-8"
+      >
+        <article className="space-y-8">
+          <div className="space-y-4">
+            <Breadcrumb
+              parents={[{ label: "Guides", href: "/guides" }]}
+              currentTitle="Pay Upfront or Take the Loan?"
+            />
+
+            <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+              Should You Pay Tuition Upfront or Take the Loan?
+            </h1>
+            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+              The answer depends on how much the graduate will earn over their
+              career &mdash; and starting salary alone doesn&rsquo;t tell the
+              whole story.
+            </p>
+          </div>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              The Cost of Paying Upfront
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <p>
+                At the current maximum tuition fee of {feeCapFormatted} per
+                year, a standard three-year undergraduate degree costs{" "}
+                <strong className="text-foreground">{tuitionFormatted}</strong>{" "}
+                in tuition fees alone. Paying this upfront means handing over
+                that sum before the student even starts, with no possibility of
+                getting any of it back.
+              </p>
+              <p>
+                That money is gone regardless of what happens next &mdash;
+                whether the graduate earns &pound;25,000 or &pound;100,000 a
+                year, the cost is fixed at {tuitionFormatted}.
+              </p>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              What Happens If You Take the Loan Instead
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <p>
+                Under Plan 5, tuition fee loans are written off{" "}
+                <strong className="text-foreground">
+                  {writeOffYears} years
+                </strong>{" "}
+                after the graduate becomes eligible to repay. Repayments are 9%
+                of earnings above the {threshold} threshold, and interest is
+                charged at RPI only.
+              </p>
+              <p>
+                The total you end up paying depends on your earning trajectory
+                over those {writeOffYears} years, and graduates broadly fall
+                into three groups:
+              </p>
+              <ul className="list-disc space-y-2 pl-6">
+                <li>
+                  <strong className="text-foreground">Low earners</strong>{" "}
+                  &mdash; repayments stay small and the loan is partially
+                  written off. Total cost ends up well below {tuitionFormatted}.
+                  The loan is clearly cheaper than paying upfront.
+                </li>
+                <li>
+                  <strong className="text-foreground">Middle earners</strong>{" "}
+                  &mdash; this is the trap. You earn enough to keep repaying for
+                  decades but not enough to clear the balance before interest
+                  compounds. Total repayments can exceed the upfront cost,
+                  sometimes significantly. This is the group that ends up paying
+                  the most.
+                </li>
+                <li>
+                  <strong className="text-foreground">High earners</strong>{" "}
+                  &mdash; clear the loan relatively quickly, so interest
+                  doesn&rsquo;t compound much. Total cost is close to or
+                  slightly above the upfront price, and you kept your capital in
+                  the meantime.
+                </li>
+              </ul>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              The Salary Growth Trap
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <p>
+                A graduate starting on &pound;30,000 might think &ldquo;at this
+                salary I&rsquo;ll barely repay anything.&rdquo; But salaries
+                grow. At 4% annual growth &mdash; a typical career progression
+                &mdash; a &pound;30k starting salary reaches roughly &pound;65k
+                after 20 years.
+              </p>
+              <p>
+                As salary grows, repayments increase, and many graduates who
+                expected to be in the &ldquo;low earner&rdquo; category end up
+                firmly in the middle-earner zone, paying more than the upfront
+                cost over the life of the loan.
+              </p>
+              <p>
+                The chart below shows how this plays out. Notice the gap between
+                the flat-salary line and the growing-salary line &mdash; that
+                gap is the hidden cost of salary growth that a snapshot of your
+                starting salary won&rsquo;t reveal.
+              </p>
+            </div>
+          </section>
+
+          <CostComparisonChart />
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              When Paying Upfront Makes Sense
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <p>
+                Paying upfront can save money for graduates who will land in the
+                middle-earner zone &mdash; not just the highest earners.
+              </p>
+              <ul className="list-disc space-y-1 pl-6">
+                <li>
+                  The graduate expects moderate-to-high earnings over their
+                  career (the middle-earner zone where total repayments exceed
+                  the upfront cost)
+                </li>
+                <li>
+                  The family has the funds available without impacting their own
+                  financial security
+                </li>
+                <li>
+                  The graduate wants to avoid decades of repayments that end up
+                  exceeding the original tuition cost
+                </li>
+              </ul>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              When Taking the Loan Makes Sense
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <p>
+                The loan works best at the extremes of the earning spectrum, and
+                as a safety net for uncertainty.
+              </p>
+              <ul className="list-disc space-y-1 pl-6">
+                <li>
+                  The graduate expects to stay on a lower salary &mdash; the
+                  loan will be partially written off, costing less than paying
+                  upfront
+                </li>
+                <li>
+                  The graduate expects very high earnings &mdash; they clear the
+                  loan quickly and kept their capital invested in the meantime
+                </li>
+                <li>
+                  The family would rather keep the {tuitionFormatted} as a
+                  financial safety net
+                </li>
+                <li>
+                  Repayments adjust automatically if earnings drop &mdash;
+                  built-in insurance that paying upfront doesn&rsquo;t offer
+                </li>
+              </ul>
+            </div>
+          </section>
+
+          <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
+            <h2 className="text-lg font-semibold tracking-tight">
+              Key Takeaways
+            </h2>
+            <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+              <li>
+                The loan is not universally cheaper than paying upfront &mdash;
+                it depends on earning trajectory
+              </li>
+              <li>
+                Starting salary is misleading; salary growth pushes many
+                graduates into higher repayment brackets over time
+              </li>
+              <li>
+                Middle earners often end up paying the most due to interest
+                compounding over decades of repayments
+              </li>
+              <li>
+                The loan works best for genuine low earners (partial write-off)
+                or very high earners (fast repayment)
+              </li>
+              <li>
+                <Link
+                  href="/"
+                  className="text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  Use the calculator
+                </Link>{" "}
+                to model your specific scenario with your expected salary and
+                growth rate
+              </li>
+            </ul>
+          </section>
+
+          <RelatedGuides
+            current="pay-upfront-or-take-loan"
+            order={["how-interest-works", "plan-2-vs-plan-5"]}
+          />
+        </article>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/guides/plan-2-vs-plan-5/BalanceComparisonChart.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/BalanceComparisonChart.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import type { ChartAnnotationConfig } from "@/components/charts/ChartBase";
+import type { ChartConfig } from "@/components/ui/chart";
+import { ChartBase } from "@/components/charts/ChartBase";
+import { simulate } from "@/lib/loans/engine";
+import { PLAN_CONFIGS } from "@/lib/loans/plans";
+
+const SALARY_OPTIONS = [30000, 50000, 70000] as const;
+type SalaryOption = (typeof SALARY_OPTIONS)[number];
+
+const EXAMPLE_BALANCE = 45_000;
+
+const chartConfig = {
+  plan2: {
+    label: "Plan 2",
+    color: "oklch(0.7 0.15 250)",
+  },
+  plan5: {
+    label: "Plan 5",
+    color: "oklch(0.7 0.15 150)",
+  },
+} satisfies ChartConfig;
+
+const PLAN_2_WRITEOFF_MONTHS = PLAN_CONFIGS.PLAN_2.writeOffYears * 12;
+const PLAN_5_WRITEOFF_MONTHS = PLAN_CONFIGS.PLAN_5.writeOffYears * 12;
+
+function buildData(salary: number) {
+  const plan2Result = simulate({
+    loans: [{ planType: "PLAN_2", balance: EXAMPLE_BALANCE }],
+    annualSalary: salary,
+  });
+  const plan5Result = simulate({
+    loans: [{ planType: "PLAN_5", balance: EXAMPLE_BALANCE }],
+    annualSalary: salary,
+  });
+
+  const maxMonths = PLAN_5_WRITEOFF_MONTHS;
+  const points: Array<{ month: number; plan2: number; plan5: number }> = [];
+
+  for (let m = 0; m < maxMonths; m++) {
+    const plan2Balance =
+      m < plan2Result.snapshots.length && m < PLAN_2_WRITEOFF_MONTHS
+        ? (plan2Result.snapshots[m].loans[0]?.closingBalance ?? 0)
+        : 0;
+    const plan5Balance =
+      m < plan5Result.snapshots.length
+        ? (plan5Result.snapshots[m].loans[0]?.closingBalance ?? 0)
+        : 0;
+
+    points.push({ month: m, plan2: plan2Balance, plan5: plan5Balance });
+  }
+
+  return points;
+}
+
+const annotations: ChartAnnotationConfig[] = [
+  {
+    x: PLAN_2_WRITEOFF_MONTHS,
+    label: `Plan 2 write-off (${String(PLAN_CONFIGS.PLAN_2.writeOffYears)}yr)`,
+    color: "oklch(0.7 0.15 250)",
+    labelAnchor: "end",
+  },
+  {
+    x: PLAN_5_WRITEOFF_MONTHS - 1,
+    label: `Plan 5 write-off (${String(PLAN_CONFIGS.PLAN_5.writeOffYears)}yr)`,
+    color: "oklch(0.7 0.15 150)",
+    labelAnchor: "end",
+  },
+];
+
+function formatYear(month: number): string {
+  const year = Math.round(month / 12);
+  return `${String(year)}yr`;
+}
+
+function formatCurrency(value: number): string {
+  return `\u00a3${String(Math.round(value / 1000))}k`;
+}
+
+function formatSalaryLabel(salary: number): string {
+  return `\u00a3${String(salary / 1000)}k`;
+}
+
+export function BalanceComparisonChart() {
+  const [salary, setSalary] = useState<SalaryOption>(50000);
+  const data = buildData(salary);
+
+  return (
+    <div className="flex h-full flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium text-muted-foreground">
+          Salary:
+        </span>
+        <div className="flex gap-1">
+          {SALARY_OPTIONS.map((option) => (
+            <button
+              key={option}
+              type="button"
+              onClick={() => {
+                setSalary(option);
+              }}
+              className={`rounded-md px-3 py-1 text-sm font-medium transition-colors ${
+                salary === option
+                  ? "bg-foreground text-background"
+                  : "bg-muted text-muted-foreground hover:bg-muted/80"
+              }`}
+            >
+              {formatSalaryLabel(option)}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="min-h-0 flex-1">
+        <ChartBase
+          type="area"
+          data={data}
+          xDataKey="month"
+          xLabel="Years since repayment"
+          xFormatter={formatYear}
+          yLabel="Balance"
+          yFormatter={formatCurrency}
+          ariaLabel="Area chart comparing loan balance over time for Plan 2 and Plan 5"
+          chartConfig={chartConfig}
+          series={[{ dataKey: "plan2" }, { dataKey: "plan5" }]}
+          annotations={annotations}
+          showLegend
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/guides/plan-2-vs-plan-5/ComparisonTable.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/ComparisonTable.tsx
@@ -1,0 +1,75 @@
+import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
+
+const plan2 = PLAN_DISPLAY_INFO.PLAN_2;
+const plan5 = PLAN_DISPLAY_INFO.PLAN_5;
+
+const plan2Threshold = String(PLAN_CONFIGS.PLAN_2.monthlyThreshold * 12);
+const plan5Threshold = String(PLAN_CONFIGS.PLAN_5.monthlyThreshold * 12);
+const repaymentRate = String(plan2.repaymentRate * 100);
+
+const rows = [
+  {
+    label: "Eligibility",
+    plan2: plan2.years,
+    plan5: plan5.years,
+  },
+  {
+    label: "Repayment threshold",
+    plan2: `\u00a3${plan2Threshold}/yr`,
+    plan5: `\u00a3${plan5Threshold}/yr`,
+  },
+  {
+    label: "Repayment rate",
+    plan2: `${repaymentRate}%`,
+    plan5: `${repaymentRate}%`,
+  },
+  {
+    label: "Interest rate",
+    plan2: "RPI to RPI + 3% (sliding scale)",
+    plan5: "RPI only",
+  },
+  {
+    label: "Write-off period",
+    plan2: `${String(plan2.writeOffYears)} years`,
+    plan5: `${String(plan5.writeOffYears)} years`,
+  },
+];
+
+export function ComparisonTable() {
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b bg-muted/50">
+            <th
+              scope="col"
+              className="px-4 py-3 text-left font-medium text-muted-foreground"
+            >
+              Feature
+            </th>
+            <th scope="col" className="px-4 py-3 text-left font-medium">
+              Plan 2
+            </th>
+            <th scope="col" className="px-4 py-3 text-left font-medium">
+              Plan 5
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.label} className="border-b last:border-b-0">
+              <th
+                scope="row"
+                className="px-4 py-3 text-left font-medium text-muted-foreground"
+              >
+                {row.label}
+              </th>
+              <td className="px-4 py-3">{row.plan2}</td>
+              <td className="px-4 py-3">{row.plan5}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/guides/plan-2-vs-plan-5/Plan2VsPlan5Guide.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/Plan2VsPlan5Guide.tsx
@@ -1,0 +1,114 @@
+import { BalanceComparisonChart } from "./BalanceComparisonChart";
+import { ComparisonTable } from "./ComparisonTable";
+import { TotalRepaymentBySalaryChart } from "./TotalRepaymentBySalaryChart";
+import { Breadcrumb } from "@/components/Breadcrumb";
+import { Footer } from "@/components/Footer";
+import { RelatedGuides } from "@/components/guides/RelatedGuides";
+import { Header } from "@/components/Header";
+import { formatGBP } from "@/lib/format";
+
+const EXAMPLE_BALANCE = 45_000;
+
+export function Plan2VsPlan5Guide() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <main
+        id="main-content"
+        className="mx-auto w-full max-w-4xl flex-1 space-y-8 overflow-x-hidden px-3 pt-13 pb-6 md:pb-8"
+      >
+        <article className="space-y-8">
+          <div className="space-y-4">
+            <Breadcrumb
+              parents={[{ label: "Guides", href: "/guides" }]}
+              currentTitle="Plan 2 vs Plan 5"
+            />
+
+            <div className="space-y-2">
+              <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+                Plan 2 vs Plan 5: Which Is Better?
+              </h1>
+              <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+                Plan 2 and Plan 5 are the two loan types most English university
+                students will encounter. Plan 2 covers those who started between
+                2012 and 2023, while Plan 5 applies from 2023 onwards. They
+                differ in repayment threshold, interest rate, and write-off
+                period — and these differences can mean tens of thousands of
+                pounds more or less repaid over your career.
+              </p>
+            </div>
+          </div>
+
+          <section className="space-y-4">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Side-by-Side Comparison
+            </h2>
+            <p className="text-sm text-muted-foreground sm:text-base">
+              The key terms of each plan at a glance. Plan 5 has a lower
+              threshold and longer write-off, but simpler (and lower) interest.
+            </p>
+            <ComparisonTable />
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Total Repayment by Salary
+            </h2>
+            <p className="text-sm text-muted-foreground sm:text-base">
+              How much you repay in total depends heavily on your salary. This
+              chart shows the total amount repaid over the life of each loan for
+              a range of starting salaries, assuming a balance of
+              {"\u00a0"}
+              {formatGBP(EXAMPLE_BALANCE)}.
+            </p>
+            <div className="h-[300px] sm:h-[380px]">
+              <TotalRepaymentBySalaryChart />
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Balance Over Time
+            </h2>
+            <p className="text-sm text-muted-foreground sm:text-base">
+              See how the outstanding balance changes month by month. Toggle
+              between salary levels to see how income affects the repayment
+              trajectory for each plan.
+            </p>
+            <div className="h-[340px] sm:h-[420px]">
+              <BalanceComparisonChart />
+            </div>
+          </section>
+
+          <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
+            <h2 className="text-lg font-semibold tracking-tight">
+              Key Takeaways
+            </h2>
+            <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+              <li>
+                Lower earners often pay <strong>more</strong> on Plan 5 because
+                the 40-year term and lower threshold mean more months of
+                repayments.
+              </li>
+              <li>
+                Higher earners may pay <strong>more</strong> on Plan 2 because
+                interest can reach RPI + 3%, growing the balance faster.
+              </li>
+              <li>
+                Plan 5&rsquo;s simpler interest (RPI only) makes the balance
+                more predictable, but the longer write-off window is the real
+                cost driver.
+              </li>
+            </ul>
+          </section>
+
+          <RelatedGuides
+            current="plan-2-vs-plan-5"
+            order={["how-interest-works", "pay-upfront-or-take-loan"]}
+          />
+        </article>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/guides/plan-2-vs-plan-5/TotalRepaymentBySalaryChart.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/TotalRepaymentBySalaryChart.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import type { ChartConfig } from "@/components/ui/chart";
+import { ChartBase } from "@/components/charts/ChartBase";
+import { simulate } from "@/lib/loans/engine";
+
+const EXAMPLE_BALANCE = 45_000;
+
+const chartConfig = {
+  plan2: {
+    label: "Plan 2",
+    color: "oklch(0.7 0.15 250)", // Blue
+  },
+  plan5: {
+    label: "Plan 5",
+    color: "oklch(0.7 0.15 150)", // Green
+  },
+} satisfies ChartConfig;
+
+function buildData() {
+  const points: Array<{ salary: number; plan2: number; plan5: number }> = [];
+
+  for (let salary = 25000; salary <= 100000; salary += 1000) {
+    const plan2Result = simulate({
+      loans: [{ planType: "PLAN_2", balance: EXAMPLE_BALANCE }],
+      annualSalary: salary,
+    });
+    const plan5Result = simulate({
+      loans: [{ planType: "PLAN_5", balance: EXAMPLE_BALANCE }],
+      annualSalary: salary,
+    });
+    points.push({
+      salary,
+      plan2: plan2Result.summary.totalPaid,
+      plan5: plan5Result.summary.totalPaid,
+    });
+  }
+
+  return points;
+}
+
+const data = buildData();
+
+function formatSalaryCurrency(value: number): string {
+  return `\u00a3${String(Math.round(value / 1000))}k`;
+}
+
+export function TotalRepaymentBySalaryChart() {
+  return (
+    <ChartBase
+      type="line"
+      data={data}
+      xDataKey="salary"
+      xLabel="Starting salary"
+      xFormatter={formatSalaryCurrency}
+      yLabel="Total repaid"
+      yFormatter={formatSalaryCurrency}
+      ariaLabel="Line chart comparing total repayment amount by salary for Plan 2 and Plan 5"
+      chartConfig={chartConfig}
+      series={[{ dataKey: "plan2" }, { dataKey: "plan5" }]}
+      showLegend
+    />
+  );
+}

--- a/src/components/guides/self-employment/SelfEmploymentGuide.tsx
+++ b/src/components/guides/self-employment/SelfEmploymentGuide.tsx
@@ -1,0 +1,376 @@
+import {
+  AlertCircleIcon,
+  Calculator01Icon,
+  Briefcase01Icon,
+  Coins01Icon,
+  BulbIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Breadcrumb } from "@/components/Breadcrumb";
+import { Footer } from "@/components/Footer";
+import { RelatedGuides } from "@/components/guides/RelatedGuides";
+import { Header } from "@/components/Header";
+import { PLAN_CONFIGS } from "@/lib/loans/plans";
+
+const undergradRate = `${String(PLAN_CONFIGS.PLAN_2.repaymentRate * 100)}%`;
+const postgradRate = `${String(PLAN_CONFIGS.POSTGRADUATE.repaymentRate * 100)}%`;
+
+const linkClasses =
+  "text-primary underline-offset-2 hover:underline font-medium";
+
+export function SelfEmploymentGuide() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <main
+        id="main-content"
+        className="mx-auto w-full max-w-4xl flex-1 space-y-8 overflow-x-hidden px-3 pt-13 pb-6 md:pb-8"
+      >
+        <article className="space-y-8">
+          <div className="space-y-4">
+            <Breadcrumb
+              parents={[{ label: "Guides", href: "/guides" }]}
+              currentTitle="Self-Employment"
+            />
+
+            <div className="space-y-2">
+              <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+                Student Loans and Self-Employment
+              </h1>
+              <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+                If you&rsquo;re self-employed, your student loan repayments work
+                differently from PAYE. Instead of automatic monthly deductions
+                from your payslip, you repay through your annual{" "}
+                <a
+                  href="https://www.gov.uk/self-assessment-tax-returns"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={linkClasses}
+                >
+                  Self Assessment tax return
+                </a>{" "}
+                — and that changes how you need to plan your finances.
+              </p>
+            </div>
+          </div>
+
+          <section className="space-y-4">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              How Repayments Work Through Self Assessment
+            </h2>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
+                <p className="mb-2 text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                  PAYE (Employed)
+                </p>
+                <ul className="space-y-1.5 text-sm text-muted-foreground">
+                  <li className="flex gap-2">
+                    <span className="text-primary">&#x2022;</span>Monthly
+                    deductions from payslip
+                  </li>
+                  <li className="flex gap-2">
+                    <span className="text-primary">&#x2022;</span>Automatic —
+                    employer handles it
+                  </li>
+                  <li className="flex gap-2">
+                    <span className="text-primary">&#x2022;</span>Based on
+                    salary each pay period
+                  </li>
+                </ul>
+              </div>
+              <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
+                <p className="mb-2 text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                  Self Assessment (Self-employed)
+                </p>
+                <ul className="space-y-1.5 text-sm text-muted-foreground">
+                  <li className="flex gap-2">
+                    <span className="text-primary">&#x2022;</span>Annual lump
+                    sums (Jan &amp; Jul)
+                  </li>
+                  <li className="flex gap-2">
+                    <span className="text-primary">&#x2022;</span>You calculate
+                    and submit
+                  </li>
+                  <li className="flex gap-2">
+                    <span className="text-primary">&#x2022;</span>Based on net
+                    profit for the year
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="space-y-3 text-sm text-muted-foreground sm:text-base">
+              <p>
+                When you&rsquo;re employed, your employer deducts student loan
+                repayments from your salary each month via PAYE. When
+                you&rsquo;re self-employed, there is no employer to do this —
+                HMRC calculates your repayment based on your{" "}
+                <a
+                  href="https://www.gov.uk/self-assessment-tax-returns"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={linkClasses}
+                >
+                  Self Assessment tax return
+                </a>{" "}
+                instead.
+              </p>
+              <p>
+                This means your repayments are <strong>annual</strong>, not
+                monthly. You typically pay in two lump sums: one in January and
+                one in July (as part of HMRC&rsquo;s{" "}
+                <a
+                  href="https://www.gov.uk/understand-self-assessment-bill/payments-on-account"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={linkClasses}
+                >
+                  payment on account
+                </a>{" "}
+                system). The repayment is {undergradRate} of your net profit
+                above the repayment threshold for Plan 2 and Plan 5, or{" "}
+                {postgradRate} for Postgraduate Loans.
+              </p>
+              <p>
+                Because payments are based on your <strong>profit</strong> — not
+                your total revenue — business expenses you claim directly reduce
+                your student loan repayment as well as your tax bill.
+              </p>
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              What Counts as Income?
+            </h2>
+            <p className="text-sm text-muted-foreground sm:text-base">
+              HMRC looks at your total taxable income when calculating student
+              loan repayments. For the self-employed, this includes:
+            </p>
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
+                <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
+                  <HugeiconsIcon
+                    icon={Calculator01Icon}
+                    className="size-5 text-primary"
+                  />
+                </div>
+                <p className="font-medium">Net Profit</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Revenue minus allowable business expenses from
+                  self-employment.
+                </p>
+              </div>
+              <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
+                <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
+                  <HugeiconsIcon
+                    icon={Briefcase01Icon}
+                    className="size-5 text-primary"
+                  />
+                </div>
+                <p className="font-medium">Employment Income</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Salary from a PAYE job if you also have one alongside
+                  freelancing.
+                </p>
+              </div>
+              <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
+                <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
+                  <HugeiconsIcon
+                    icon={Coins01Icon}
+                    className="size-5 text-primary"
+                  />
+                </div>
+                <p className="font-medium">Other Taxable Income</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Rental income, dividends, interest above your personal savings
+                  allowance, etc.
+                </p>
+              </div>
+            </div>
+            <p className="text-sm text-muted-foreground sm:text-base">
+              All of these sources are combined to determine whether you exceed
+              the repayment threshold and how much you owe.
+            </p>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Mixed Employment
+            </h2>
+            <div className="space-y-3 text-sm text-muted-foreground sm:text-base">
+              <p>
+                Many freelancers also have a part-time or full-time PAYE job. If
+                this applies to you, HMRC collects repayments through both
+                mechanisms:
+              </p>
+              <ul className="list-inside list-disc space-y-2">
+                <li>
+                  Your employer deducts repayments from your salary
+                  automatically via PAYE
+                </li>
+                <li>
+                  Your Self Assessment tops up the difference based on your
+                  combined total income
+                </li>
+              </ul>
+              <p>
+                For example, if your PAYE salary is below the threshold but your
+                combined income (salary + freelance profit) is above it,
+                you&rsquo;ll owe the full repayment through Self Assessment. If
+                your PAYE income alone exceeds the threshold, your employer
+                already deducts repayments — and Self Assessment adds further
+                repayments on your self-employment profit.
+              </p>
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Common Mistakes to Avoid
+            </h2>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {[
+                {
+                  title: "Not budgeting for annual payments",
+                  description:
+                    "Unlike monthly PAYE deductions, Self Assessment repayments arrive as large lump sums. A sudden bill of several thousand pounds in January can catch freelancers off guard.",
+                },
+                {
+                  title: "Late filing penalties",
+                  description:
+                    "Missing the 31 January Self Assessment deadline means a \u00A3100 penalty \u2014 plus your student loan repayment is delayed, which can lead to estimated charges from HMRC.",
+                },
+                {
+                  title: "Underestimating income",
+                  description:
+                    "If your payments on account are based on a lower previous year, you may face a balancing payment when your actual profit is higher than expected.",
+                },
+                {
+                  title: "Not claiming legitimate expenses",
+                  description:
+                    "Every pound of allowable business expense you miss increases your net profit \u2014 and therefore your student loan repayment. Common overlooked expenses include home office costs, professional subscriptions, and travel.",
+                },
+              ].map((mistake, i) => (
+                <div
+                  key={i}
+                  className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10"
+                >
+                  <div className="mb-2 flex items-center gap-2.5">
+                    <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-destructive/10 text-sm font-semibold text-destructive">
+                      <HugeiconsIcon
+                        icon={AlertCircleIcon}
+                        className="size-4"
+                      />
+                    </span>
+                    <p className="font-medium">{mistake.title}</p>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    {mistake.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Practical Tips for Freelancers
+            </h2>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {[
+                {
+                  title: `Set aside ${undergradRate} monthly`,
+                  description: `Calculate ${undergradRate} of your profit above the repayment threshold each month and put it in a separate savings account. This avoids a nasty surprise when your tax bill arrives.`,
+                },
+                {
+                  title: "Register for Self Assessment early",
+                  description: (
+                    <>
+                      You must{" "}
+                      <a
+                        href="https://www.gov.uk/register-for-self-assessment"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={linkClasses}
+                      >
+                        register with HMRC by 5 October
+                      </a>{" "}
+                      following the end of the tax year in which you became
+                      self-employed. Registering late can result in penalties.
+                    </>
+                  ),
+                },
+                {
+                  title: "Keep good records",
+                  description:
+                    "Track all income and expenses throughout the year. Good record-keeping makes filing easier and ensures you claim every expense you\u2019re entitled to.",
+                },
+                {
+                  title: "Consider an accountant",
+                  description:
+                    "An accountant familiar with student loans can help you optimise your expenses, avoid mistakes, and ensure your repayments are calculated correctly.",
+                },
+              ].map((tip, i) => (
+                <div
+                  key={i}
+                  className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10"
+                >
+                  <div className="mb-2 flex items-center gap-2.5">
+                    <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/10">
+                      <HugeiconsIcon
+                        icon={BulbIcon}
+                        className="size-4 text-primary"
+                      />
+                    </span>
+                    <p className="font-medium">{tip.title}</p>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    {tip.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
+            <h2 className="text-lg font-semibold tracking-tight">
+              Key Takeaways
+            </h2>
+            <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+              <li>
+                Self-employed borrowers repay through Self Assessment, not PAYE
+                — expect annual lump-sum payments, not monthly deductions.
+              </li>
+              <li>
+                Repayments are based on <strong>net profit</strong>, so claiming
+                all legitimate business expenses directly reduces what you owe.
+              </li>
+              <li>
+                If you have mixed income (PAYE + freelance), HMRC collects
+                through both mechanisms based on your combined total income.
+              </li>
+              <li>
+                Budget monthly by setting aside {undergradRate} of profit above
+                the threshold to avoid being caught out by large tax bills.
+              </li>
+            </ul>
+          </section>
+
+          <RelatedGuides
+            current="self-employment"
+            order={["moving-abroad", "plan-2-vs-plan-5"]}
+            extraLinks={[
+              {
+                href: "https://www.gov.uk/repaying-your-student-loan/repaying-student-loans-overview",
+                label: "GOV.UK: Repaying Your Student Loan",
+              },
+            ]}
+          />
+        </article>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
+++ b/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
@@ -1,0 +1,176 @@
+import { RepaymentImpactChart } from "./RepaymentImpactChart";
+import { Breadcrumb } from "@/components/Breadcrumb";
+import { Footer } from "@/components/Footer";
+import { RelatedGuides } from "@/components/guides/RelatedGuides";
+import { Header } from "@/components/Header";
+import { formatGBP } from "@/lib/format";
+import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
+
+const plan2Threshold = PLAN_DISPLAY_INFO.PLAN_2.yearlyThreshold;
+const plan5Threshold = PLAN_DISPLAY_INFO.PLAN_5.yearlyThreshold;
+const repaymentRate = PLAN_CONFIGS.PLAN_2.repaymentRate;
+const repaymentRateDisplay = `${String(repaymentRate * 100)}%`;
+
+// Example: £40k salary on Plan 2
+const example40kMonthly = Math.round(
+  (40000 / 12 - PLAN_CONFIGS.PLAN_2.monthlyThreshold) * repaymentRate,
+);
+const example40kAnnual = example40kMonthly * 12;
+const example40kMortgageReduction = Math.round(example40kAnnual * 4.5);
+
+// Example: £60k salary on Plan 2
+const example60kMonthly = Math.round(
+  (60000 / 12 - PLAN_CONFIGS.PLAN_2.monthlyThreshold) * repaymentRate,
+);
+const example60kAnnual = example60kMonthly * 12;
+const example60kMortgageReduction = Math.round(example60kAnnual * 4.5);
+
+export function MortgageGuide() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <main
+        id="main-content"
+        className="mx-auto w-full max-w-4xl flex-1 space-y-8 px-3 pt-13 pb-6 md:pb-8"
+      >
+        <article className="space-y-8">
+          <div className="space-y-4">
+            <Breadcrumb
+              parents={[{ label: "Guides", href: "/guides" }]}
+              currentTitle="Student Loans & Mortgages"
+            />
+
+            <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+              Does Your Student Loan Affect Your Mortgage?
+            </h1>
+
+            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+              Your student loan won&rsquo;t stop you getting a mortgage, but the
+              monthly repayments reduce how much lenders think you can afford.
+              Here&rsquo;s how it works.
+            </p>
+          </div>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              How Lenders See Your Student Loan
+            </h2>
+            <div className="space-y-3 text-muted-foreground">
+              <p>
+                Unlike credit cards or car finance, a UK student loan is not
+                treated as conventional debt. It doesn&rsquo;t appear on your
+                credit report and won&rsquo;t lower your credit score.
+              </p>
+              <p>
+                However, mortgage lenders do factor in the monthly repayment.
+                When they assess your affordability, they look at your net
+                disposable income after tax, National Insurance, pension
+                contributions, and student loan repayments. A higher repayment
+                means less income available for mortgage payments.
+              </p>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              The Repayment &ldquo;Tax&rdquo;
+            </h2>
+            <div className="space-y-3 text-muted-foreground">
+              <p>
+                Student loan repayments work like an extra income tax. You pay{" "}
+                {repaymentRateDisplay} of everything you earn above your
+                plan&rsquo;s repayment threshold. The higher your salary, the
+                more you repay each month, and the bigger the impact on your
+                mortgage affordability.
+              </p>
+              <p>
+                Plan 5 has a lower threshold than Plan 2, so repayments start
+                sooner and are slightly higher at every salary level. The chart
+                below shows exactly how much you&rsquo;d repay each month.
+              </p>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Monthly Repayment by Salary
+            </h2>
+            <div className="h-[300px] sm:h-[360px]">
+              <RepaymentImpactChart />
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Based on current thresholds: Plan 2 at {formatGBP(plan2Threshold)}{" "}
+              and Plan 5 at {formatGBP(plan5Threshold)} per year. Both charge{" "}
+              {repaymentRateDisplay} on income above the threshold.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              What This Means for Your Borrowing Capacity
+            </h2>
+            <div className="space-y-3 text-muted-foreground">
+              <p>
+                Most lenders offer roughly 4 to 4.5 times your annual income as
+                a mortgage. But they calculate that multiple based on your
+                income after committed expenditure, including student loan
+                repayments.
+              </p>
+              <p>
+                For example, someone earning &pound;40,000 on Plan 2 repays
+                about {formatGBP(example40kMonthly)} per month. Annualised,
+                that&rsquo;s around {formatGBP(example40kAnnual)} which a lender
+                might effectively subtract from income before applying their
+                multiplier. On a 4.5x basis, that reduces the maximum mortgage
+                by roughly {formatGBP(example40kMortgageReduction)}.
+              </p>
+              <p>
+                At higher salaries the gap grows. At &pound;60,000 the monthly
+                repayment is roughly {formatGBP(example60kMonthly)}, trimming
+                potential borrowing by about{" "}
+                {formatGBP(example60kMortgageReduction)} on the same multiplier.
+              </p>
+            </div>
+          </section>
+
+          <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
+            <h2 className="text-lg font-semibold tracking-tight">
+              Key Takeaways
+            </h2>
+            <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+              <li>
+                A student loan is <strong>not</strong> conventional debt &mdash;
+                it won&rsquo;t appear on your credit report.
+              </li>
+              <li>
+                Lenders deduct your monthly repayment when calculating how much
+                you can borrow, reducing your affordability.
+              </li>
+              <li>
+                Your credit score is <strong>not</strong> affected by having a
+                student loan.
+              </li>
+              <li>
+                Any remaining balance is written off after{" "}
+                {PLAN_CONFIGS.PLAN_2.writeOffYears} years (Plan 2) or{" "}
+                {PLAN_CONFIGS.PLAN_5.writeOffYears} years (Plan 5) &mdash; you
+                are never chased for unpaid amounts.
+              </li>
+              <li>
+                Overpaying your student loan to boost mortgage affordability
+                rarely makes sense &mdash; the reduction in borrowing power is
+                modest compared to deposit savings.
+              </li>
+            </ul>
+          </section>
+
+          <RelatedGuides
+            current="student-loan-vs-mortgage"
+            order={["plan-2-vs-plan-5", "how-interest-works"]}
+          />
+        </article>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/guides/student-loan-vs-mortgage/RepaymentImpactChart.tsx
+++ b/src/components/guides/student-loan-vs-mortgage/RepaymentImpactChart.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { ChartConfig } from "@/components/ui/chart";
+import { ChartBase } from "@/components/charts/ChartBase";
+import { PLAN_CONFIGS } from "@/lib/loans/plans";
+
+const chartConfig = {
+  plan2: {
+    label: "Plan 2",
+    color: "var(--chart-1)",
+  },
+  plan5: {
+    label: "Plan 5",
+    color: "oklch(0.7 0.15 50)",
+  },
+} satisfies ChartConfig;
+
+function buildChartData() {
+  const salaries: number[] = [];
+  for (let s = 25000; s <= 80000; s += 1000) {
+    salaries.push(s);
+  }
+
+  return salaries.map((salary) => {
+    const monthlyIncome = salary / 12;
+    const plan2Repayment = Math.max(
+      0,
+      (monthlyIncome - PLAN_CONFIGS.PLAN_2.monthlyThreshold) *
+        PLAN_CONFIGS.PLAN_2.repaymentRate,
+    );
+    const plan5Repayment = Math.max(
+      0,
+      (monthlyIncome - PLAN_CONFIGS.PLAN_5.monthlyThreshold) *
+        PLAN_CONFIGS.PLAN_5.repaymentRate,
+    );
+    return {
+      salary,
+      plan2: Math.round(plan2Repayment * 100) / 100,
+      plan5: Math.round(plan5Repayment * 100) / 100,
+    };
+  });
+}
+
+const data = buildChartData();
+
+const xFormatter = (value: number) => `£${String(value / 1000)}k`;
+const yFormatter = (value: number) => `£${String(Math.round(value))}/mo`;
+
+export function RepaymentImpactChart() {
+  return (
+    <ChartBase
+      type="line"
+      data={data}
+      xDataKey="salary"
+      xLabel="Annual salary"
+      xFormatter={xFormatter}
+      yLabel="Monthly repayment"
+      yFormatter={yFormatter}
+      ariaLabel="Line chart showing monthly student loan repayment by salary for Plan 2 and Plan 5"
+      chartConfig={chartConfig}
+      series={[{ dataKey: "plan2" }, { dataKey: "plan5" }]}
+      showLegend
+    />
+  );
+}

--- a/src/components/overpay/OverpayPage.tsx
+++ b/src/components/overpay/OverpayPage.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-import Link from "next/link";
 import { useEffect, useState } from "react";
 import { OverpayComparisonChart } from "./OverpayComparisonChart";
 import { OverpayPrimaryInputs } from "./OverpayPrimaryInputs";
@@ -11,6 +8,7 @@ import { OverpayVerdict } from "./OverpayVerdict";
 import type { InputMode } from "@/components/InputPanel";
 import type { Preset } from "@/lib/presets";
 import { AssumptionsCallout } from "@/components/AssumptionsCallout";
+import { Breadcrumb } from "@/components/Breadcrumb";
 import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
 import { InputPanel } from "@/components/InputPanel";
@@ -81,13 +79,7 @@ export function OverpayPage() {
         className="mx-auto w-full max-w-4xl flex-1 space-y-6 overflow-x-hidden px-3 pt-13 pb-6 md:pb-8"
       >
         <div className="space-y-4">
-          <Link
-            href="/"
-            className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
-            Back to Calculator
-          </Link>
+          <Breadcrumb currentTitle="Overpay Calculator" />
 
           <div className="space-y-2">
             <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,15 @@
+/**
+ * Format a number as a GBP currency string with thousands separators.
+ * @example formatGBP(28470) → "£28,470"
+ */
+export function formatGBP(value: number): string {
+  return `£${value.toLocaleString("en-GB")}`;
+}
+
+/**
+ * Format a number as a percentage string.
+ * @example formatPercent(3.2) → "3.2%"
+ */
+export function formatPercent(value: number): string {
+  return `${String(value)}%`;
+}

--- a/src/lib/guides.ts
+++ b/src/lib/guides.ts
@@ -1,0 +1,52 @@
+export type GuideSlug =
+  | "plan-2-vs-plan-5"
+  | "student-loan-vs-mortgage"
+  | "how-interest-works"
+  | "pay-upfront-or-take-loan"
+  | "moving-abroad"
+  | "self-employment";
+
+export interface GuideEntry {
+  slug: GuideSlug;
+  title: string;
+  description: string;
+}
+
+export const GUIDES: GuideEntry[] = [
+  {
+    slug: "plan-2-vs-plan-5",
+    title: "Plan 2 vs Plan 5",
+    description:
+      "Compare lifetime repayment costs for pre- and post-2023 loans side by side.",
+  },
+  {
+    slug: "student-loan-vs-mortgage",
+    title: "Student Loans & Mortgages",
+    description:
+      "How lenders factor student loan repayments into your borrowing capacity.",
+  },
+  {
+    slug: "how-interest-works",
+    title: "How Interest Works",
+    description:
+      "RPI, sliding scales, and why your balance can grow despite repayments.",
+  },
+  {
+    slug: "pay-upfront-or-take-loan",
+    title: "Pay Upfront or Take the Loan?",
+    description:
+      "When paying tuition upfront beats taking the loan, and when it doesn\u2019t.",
+  },
+  {
+    slug: "moving-abroad",
+    title: "Moving Abroad",
+    description:
+      "Country-specific thresholds, SLC obligations, and what happens if you don\u2019t comply.",
+  },
+  {
+    slug: "self-employment",
+    title: "Self-Employment",
+    description:
+      "How Self Assessment changes your repayments and common mistakes to avoid.",
+  },
+];

--- a/src/lib/loans/plans.ts
+++ b/src/lib/loans/plans.ts
@@ -105,6 +105,12 @@ export const POSTGRADUATE_DISPLAY_INFO = {
   repaymentRate: PLAN_CONFIGS.POSTGRADUATE.repaymentRate,
 } as const;
 
+/**
+ * Maximum tuition fee per year (England).
+ * Update when the government changes the cap.
+ */
+export const TUITION_FEE_CAP = 9_250;
+
 // =============================================================================
 // END OF ANNUAL UPDATE SECTION
 // =============================================================================


### PR DESCRIPTION
## Summary

Adds 6 new educational guide pages under `/guides/`, each with interactive charts powered by the existing loan simulation engine, full SEO metadata, and structured data. Also introduces a guides index page, a reusable breadcrumb component, and several SEO improvements.

## Context

**New guide pages** — each includes prose content, interactive charts, FAQPage JSON-LD (3 questions each), BreadcrumbList JSON-LD, and a `RelatedGuides` footer linking to related content:

- **Plan 2 vs Plan 5** — comparison table, total repayment by salary chart, interactive balance over time chart with salary toggle
- **How Interest Works** — Plan 2 sliding scale explanation, interest rate comparison chart (Plan 2 vs Plan 5 by salary)
- **Student Loans & Mortgages** — mortgage affordability impact with computed examples, repayment impact chart by salary
- **Pay Upfront or Take the Loan?** — cost comparison chart (flat salary vs 4% growth vs upfront), salary growth analysis
- **Moving Abroad** — SLC obligations, overseas repayment thresholds, penalties and consequences
- **Self-Employment** — PAYE vs Self Assessment comparison, income types, common mistakes

**Supporting infrastructure:**
- `/guides` index page listing all 6 guides in a card grid
- `Breadcrumb` component replacing ad-hoc "Back to Calculator" links across guides, overpay, and brand pages
- `formatGBP`/`formatPercent` utilities and shared `GUIDES` registry in `src/lib/`
- `TUITION_FEE_CAP` constant in `plans.ts`
- `ChartBase` updated with custom SVG label rendering (`labelAnchor` prop)
- `ToolLinks` refactored to data-driven pattern with a new "Guides" section

**SEO cleanup:**
- FAQ JSON-LD answers interpolate values from `PLAN_CONFIGS` instead of hardcoding them
- Sitemap stripped of `<changefreq>` and `<priority>` (Google ignores both), added 7 new URLs
- `llms.txt` updated with guides section