### PR TITLE
feat: rewrite SEO titles and descriptions with emotional hooks

### DIFF
--- a/src/app/guides/how-interest-works/layout.tsx
+++ b/src/app/guides/how-interest-works/layout.tsx
@@ -3,9 +3,9 @@ import { formatGBP } from "@/lib/format";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
 
 export const metadata: Metadata = {
-  title: "How Interest Works on UK Student Loans",
+  title: "Why Your Student Loan Balance Keeps Growing",
   description:
-    "Understand how interest is calculated on UK student loans. Learn the sliding scale for Plan 2, RPI-only for Plan 5, and how each plan type charges interest.",
+    "You're making repayments but your balance goes up? That's not a bug — it's how the interest works. See exactly how much interest you're being charged and why it matters less than you think.",
   keywords: [
     "UK student loan interest",
     "student loan interest rate",

--- a/src/app/guides/layout.tsx
+++ b/src/app/guides/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Student Loan Guides",
+  title: "Student Loan Guides — The Stuff They Don't Tell You",
   description:
-    "In-depth guides on UK student loan repayment. Understand plan differences, interest rates, mortgage impact, self-employment, and more.",
+    "The real questions graduates ask: Will my loan affect my mortgage? Should I overpay? What if I move abroad? Clear answers with interactive charts, not jargon.",
   keywords: [
     "UK student loan guides",
     "student loan repayment guide",

--- a/src/app/guides/moving-abroad/layout.tsx
+++ b/src/app/guides/moving-abroad/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "What Happens to Your Student Loan If You Move Abroad?",
   description:
-    "Find out how UK student loan repayments work when you move overseas. Learn about SLC obligations, country-specific thresholds, and penalties for non-compliance.",
+    "Moving overseas doesn't make your student loan disappear — the SLC will find you. Here's what they expect, what the penalties look like, and how repayment thresholds change by country.",
   keywords: [
     "student loan abroad",
     "SLC overseas",

--- a/src/app/guides/pay-upfront-or-take-loan/layout.tsx
+++ b/src/app/guides/pay-upfront-or-take-loan/layout.tsx
@@ -3,9 +3,9 @@ import { formatGBP } from "@/lib/format";
 import { PLAN_CONFIGS, TUITION_FEE_CAP } from "@/lib/loans/plans";
 
 export const metadata: Metadata = {
-  title: "Should I Pay Tuition Upfront or Take the Student Loan?",
+  title: "Pay Tuition Upfront or Take the Loan? It's Not Obvious",
   description:
-    "Starting salary alone doesn't tell the whole story. See how salary growth pushes many graduates into the middle-earner zone where they pay more than the upfront cost.",
+    "The loan feels free until you realise middle earners can repay more than the original tuition. See where the break-even point is for your expected career path.",
   keywords: [
     "pay tuition upfront",
     "pay university fees upfront",

--- a/src/app/guides/plan-2-vs-plan-5/layout.tsx
+++ b/src/app/guides/plan-2-vs-plan-5/layout.tsx
@@ -5,7 +5,7 @@ import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
 export const metadata: Metadata = {
   title: "Plan 2 vs Plan 5: Which Student Loan Is Better?",
   description:
-    "Compare UK student loan Plan 2 and Plan 5 side by side. See how thresholds, interest rates, and write-off periods affect what you actually repay.",
+    "Plan 5 has lower interest but a longer repayment window. Plan 2 can cost more — or get written off sooner. See which one hits your wallet harder at your salary.",
   keywords: [
     "Plan 2 vs Plan 5",
     "UK student loan comparison",

--- a/src/app/guides/self-employment/layout.tsx
+++ b/src/app/guides/self-employment/layout.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from "next";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
 
 export const metadata: Metadata = {
-  title: "Student Loans and Self-Employment: What You Need to Know",
+  title: "Self-Employed? Your Student Loan Repayments Work Differently",
   description:
-    "Learn how UK student loan repayments work when you're self-employed. Understand Self Assessment, mixed income, and practical tips for freelancers.",
+    "No employer deducting it from your payslip means you handle repayments through Self Assessment. Get the timing, thresholds, and mixed-income rules straight before your next tax return.",
   keywords: [
     "student loan self employed",
     "self assessment student loan",

--- a/src/app/guides/student-loan-vs-mortgage/layout.tsx
+++ b/src/app/guides/student-loan-vs-mortgage/layout.tsx
@@ -5,7 +5,7 @@ import { PLAN_CONFIGS } from "@/lib/loans/plans";
 export const metadata: Metadata = {
   title: "Does Your Student Loan Affect Your Mortgage?",
   description:
-    "Understand how UK student loan repayments reduce your mortgage borrowing power. See monthly repayment impact by salary for Plan 2 and Plan 5.",
+    "Yes — and it's not about the balance. Lenders care about your monthly repayment, which quietly shrinks how much you can borrow. See the exact impact at your salary.",
   keywords: [
     "student loan mortgage",
     "mortgage affordability student loan",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,11 +21,11 @@ const jetbrainsMono = JetBrains_Mono({
 export const metadata: Metadata = {
   metadataBase: new URL("https://studentloanstudy.uk"),
   title: {
-    default: "UK Student Loan Study - Student Loan Repayment Calculator",
+    default: "UK Student Loan Study — Are You Paying More Than You Should?",
     template: "%s | UK Student Loan Study",
   },
   description:
-    "Interactive calculator to understand UK student loan repayment. Compare Plan 2 and Plan 5, visualize total repayments, and see effective interest rates based on your salary.",
+    "Middle earners pay the most on student loans — more than high earners, and far more than low earners who get written off. See where you fall and what your loan really costs.",
   keywords: [
     "UK student loan",
     "student loan calculator",

--- a/src/app/overpay/layout.tsx
+++ b/src/app/overpay/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Should I Overpay My Student Loan?",
   description:
-    "Calculate whether overpaying your UK student loan is worth it. Compare overpayment vs investing and see the best strategy for Plan 2, Plan 5, and Postgraduate loans.",
+    "That spare cash could overpay your loan or grow in an index fund. See which one leaves you better off — the answer depends on your salary trajectory, not just the interest rate.",
   keywords: [
     "UK student loan overpayment",
     "should I overpay student loan",

--- a/src/app/which-plan/layout.tsx
+++ b/src/app/which-plan/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "What Student Loan Plan Am I On?",
   description:
-    "Find out which UK student loan plan you're on with our quick 3-question quiz. Covers Plan 1, 2, 4, 5, and Postgraduate loans.",
+    "Not sure which plan you're on? Answer 3 quick questions and we'll tell you — plus what it means for your repayments, interest rate, and write-off date.",
   alternates: {
     canonical: "/which-plan",
   },


### PR DESCRIPTION
## Summary

Rewrites meta titles and descriptions across all 10 public pages to replace flat, keyword-dense copy with conversational, curiosity-driven hooks that stand out on SERPs. Titles use questions, challenges, and counterintuitive framing; descriptions create information gaps and speak to real graduate anxieties rather than listing features.

## Context

The previous copy was informational but bland — it described what the tool does ("Interactive calculator to understand...") rather than creating emotional pull. On a competitive SERP, these blended in. The new copy targets the feelings graduates actually have: confusion about growing balances, anxiety about mortgage impact, uncertainty about overpaying vs investing. Pages that already had strong search-intent titles (e.g. "Should I Overpay My Student Loan?") kept them; only the descriptions were sharpened.