### PR TITLE
fix: resolve Lighthouse accessibility warnings for slider labels and heading order

### DIFF
--- a/src/components/SalaryExplorer.tsx
+++ b/src/components/SalaryExplorer.tsx
@@ -19,9 +19,9 @@ export function SalaryExplorer() {
   return (
     <div>
       <div className="mb-2 flex items-baseline justify-between gap-4">
-        <h3 className="text-sm font-medium text-muted-foreground">
+        <h2 className="text-sm font-medium text-muted-foreground">
           Total repayment
-        </h3>
+        </h2>
         <div className="flex items-center gap-1 text-sm text-muted-foreground">
           Your salary:{" "}
           <span className="font-mono font-semibold text-foreground tabular-nums">

--- a/src/components/SecondaryCharts.tsx
+++ b/src/components/SecondaryCharts.tsx
@@ -4,9 +4,9 @@ export function SecondaryCharts() {
   return (
     <div className="space-y-8">
       <section className="space-y-4">
-        <h3 className="text-sm font-medium text-muted-foreground">
+        <h2 className="text-sm font-medium text-muted-foreground">
           Your Balance Over Time
-        </h3>
+        </h2>
         <div className="h-[300px] sm:h-[350px]">
           <BalanceOverTimeChart />
         </div>

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 function Slider({
   className,
   onValueCommitted,
+  "aria-label": ariaLabel,
   ...props
 }: SliderPrimitive.Root.Props) {
   // Workaround: @base-ui/react v1.1.0 fires onValueCommitted multiple times
@@ -34,7 +35,14 @@ function Slider({
         <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-input">
           <SliderPrimitive.Indicator className="absolute h-full bg-primary" />
         </SliderPrimitive.Track>
-        <SliderPrimitive.Thumb className="block size-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50" />
+        {/* Workaround: shadcn's generated Slider spreads all props onto Root,
+            which places aria-label on the outer <div role="group"> instead of
+            the Thumb's hidden <input type="range">. Destructure it out of Root
+            props and forward it here for Lighthouse / screen readers. */}
+        <SliderPrimitive.Thumb
+          aria-label={ariaLabel}
+          className="block size-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+        />
       </SliderPrimitive.Control>
     </SliderPrimitive.Root>
   );


### PR DESCRIPTION
## Summary

Fixes two Lighthouse accessibility audit warnings: slider inputs missing associated labels, and heading elements skipping levels (h1 → h3 with no h2).

## Context

The shadcn-generated `Slider` component spreads all props onto `SliderPrimitive.Root`, which places `aria-label` on the outer `<div role="group">` rather than on the Thumb's hidden `<input type="range">` where screen readers and Lighthouse expect it. The fix destructures `aria-label` out of the root props and forwards it directly to `SliderPrimitive.Thumb`.

The heading order issue was on the home page where chart section headings used `h3` directly under the `h1`, skipping `h2`. Changed to `h2` to maintain sequential order.