### PR TITLE
feat: add skeleton loading states for charts and results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ next-env.d.ts
 # TypeScript
 *.tsbuildinfo
 
+# Playwright CLI
+.playwright-cli
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/components/BalanceOverTimeChart.tsx
+++ b/src/components/BalanceOverTimeChart.tsx
@@ -2,6 +2,7 @@
 
 import { ChartBase } from "./charts/ChartBase";
 import type { ChartConfig } from "@/components/ui/chart";
+import { Skeleton } from "@/components/ui/skeleton";
 import { currencyFormatter } from "@/constants";
 import { useBalanceOverTimeData } from "@/hooks/useChartData";
 
@@ -22,8 +23,12 @@ export function BalanceOverTimeChart() {
 
   if (data.length === 0) {
     return (
-      <div className="flex h-full items-center justify-center text-muted-foreground">
-        Enter loan details to see your balance over time
+      <div
+        className="flex h-full items-center justify-center"
+        role="status"
+        aria-label="Loading chart"
+      >
+        <Skeleton className="h-[80%] w-[90%]" />
       </div>
     );
   }

--- a/src/components/ResultSummary.tsx
+++ b/src/components/ResultSummary.tsx
@@ -9,6 +9,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import type { InsightType } from "@/utils/insights";
+import { Skeleton } from "@/components/ui/skeleton";
 import { currencyFormatter } from "@/constants";
 import { usePersonalizedInsight } from "@/hooks/usePersonalizedInsight";
 import { useResultSummary } from "@/hooks/useResultSummary";
@@ -44,11 +45,43 @@ const insightConfig: Record<
 
 const pluralRules = new Intl.PluralRules("en-GB");
 
+function StatBlockSkeleton() {
+  return (
+    <div>
+      <Skeleton className="h-4 w-20" />
+      <Skeleton className="mt-0.5 h-7 w-24 min-[30rem]:h-8" />
+    </div>
+  );
+}
+
 export function ResultSummary() {
   const summary = useResultSummary();
   const insight = usePersonalizedInsight();
 
-  if (!summary) return null;
+  if (!summary) {
+    return (
+      <div
+        className="relative overflow-hidden rounded-2xl border border-border bg-card"
+        role="status"
+        aria-label="Loading results"
+      >
+        <div className="relative grid grid-cols-2 gap-0 p-4 min-[30rem]:grid-cols-3 min-[30rem]:items-center min-[30rem]:p-5">
+          <div className="col-span-2 pb-3 min-[30rem]:col-span-1 min-[30rem]:border-r min-[30rem]:border-border min-[30rem]:pr-5 min-[30rem]:pb-0">
+            <StatBlockSkeleton />
+          </div>
+          <div className="border-t border-border py-3 pr-4 min-[30rem]:border-t-0 min-[30rem]:border-r min-[30rem]:border-border min-[30rem]:px-5 min-[30rem]:py-0">
+            <StatBlockSkeleton />
+          </div>
+          <div className="border-t border-border py-3 pl-4 min-[30rem]:border-t-0 min-[30rem]:py-0 min-[30rem]:pl-5">
+            <StatBlockSkeleton />
+          </div>
+        </div>
+        <div className="relative flex min-h-26.5 items-center gap-2.5 border-t border-border px-4 py-3 min-[30rem]:px-5 sm:min-h-21.5 lg:min-h-16.5">
+          <Skeleton className="h-4 w-full max-w-md" />
+        </div>
+      </div>
+    );
+  }
 
   const years = summary.monthsToPayoff / 12;
   const rounded = Math.max(1, Math.round(years));
@@ -106,7 +139,7 @@ export function ResultSummary() {
 
       {/* Personalized insight footer — fixed min-h to prevent layout shift */}
       <div className="relative flex min-h-26.5 items-center gap-2.5 border-t border-border px-4 py-3 min-[30rem]:px-5 sm:min-h-21.5 lg:min-h-16.5">
-        {insight && (
+        {insight ? (
           <>
             <HugeiconsIcon
               icon={insightConfig[insight.type].icon}
@@ -136,6 +169,8 @@ export function ResultSummary() {
               )}
             </div>
           </>
+        ) : (
+          <Skeleton className="h-4 w-full max-w-md" />
         )}
       </div>
     </div>

--- a/src/components/TotalRepaymentChart.tsx
+++ b/src/components/TotalRepaymentChart.tsx
@@ -3,6 +3,7 @@
 import { useDeferredValue } from "react";
 import { ChartBase } from "./charts/ChartBase";
 import type { ChartConfig } from "@/components/ui/chart";
+import { Skeleton } from "@/components/ui/skeleton";
 import { currencyFormatter, MIN_SALARY, MAX_SALARY } from "@/constants";
 import { useTotalRepaymentData } from "@/hooks/useChartData";
 
@@ -21,6 +22,18 @@ export function TotalRepaymentChart() {
   // but the annotation position does, and re-rendering the chart is expensive.
   const deferredSalary = useDeferredValue(annotationSalary);
   const deferredValue = useDeferredValue(annotationValue);
+
+  if (data.length === 0) {
+    return (
+      <div
+        className="flex h-full items-center justify-center"
+        role="status"
+        aria-label="Loading chart"
+      >
+        <Skeleton className="h-[80%] w-[90%]" />
+      </div>
+    );
+  }
 
   const annotations =
     deferredSalary !== undefined && deferredValue !== undefined

--- a/src/components/overpay/OverpayPage.tsx
+++ b/src/components/overpay/OverpayPage.tsx
@@ -13,6 +13,7 @@ import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
 import { InputPanel } from "@/components/InputPanel";
 import { PlanFromQuery } from "@/components/PlanFromQuery";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useLoanActions, useLoanConfigState } from "@/context/LoanContext";
 import { useOverpayAnalysis } from "@/hooks/useOverpayAnalysis";
 import {
@@ -22,6 +23,27 @@ import {
   trackWizardStarted,
 } from "@/lib/analytics";
 import { isPresetConfig, REPAYMENT_START_MONTH } from "@/lib/presets";
+
+function OverpayPageSkeleton() {
+  return (
+    <>
+      {/* Verdict skeleton */}
+      <Skeleton className="h-28 w-full rounded-lg" />
+
+      {/* Chart + cards grid skeleton */}
+      <div className="grid gap-6 md:grid-cols-[1fr_260px]">
+        <div className="h-[260px] min-w-0 sm:h-[300px] md:h-auto md:min-h-[300px]">
+          <Skeleton className="h-full w-full" />
+        </div>
+        <div className="-mx-4 flex gap-3 px-4 py-1 sm:mx-0 sm:grid sm:grid-cols-3 sm:p-1 md:grid-cols-1">
+          <Skeleton className="h-36 min-w-[200px] shrink-0 sm:min-w-0" />
+          <Skeleton className="h-36 min-w-[200px] shrink-0 sm:min-w-0" />
+          <Skeleton className="h-36 min-w-[200px] shrink-0 sm:min-w-0" />
+        </div>
+      </div>
+    </>
+  );
+}
 
 export function OverpayPage() {
   const [repaymentDate, setRepaymentDate] = useState<Date>(
@@ -100,19 +122,25 @@ export function OverpayPage() {
           onWizardClose={handleWizardClose}
         />
 
-        <OverpayVerdict
-          recommendation={analysis.recommendation}
-          reason={analysis.recommendationReason}
-        />
+        {analysis ? (
+          <>
+            <OverpayVerdict
+              recommendation={analysis.recommendation}
+              reason={analysis.recommendationReason}
+            />
 
-        <div className="grid gap-6 md:grid-cols-[1fr_260px]">
-          <div className="h-[260px] min-w-0 sm:h-[300px] md:h-auto md:min-h-[300px]">
-            <OverpayComparisonChart analysis={analysis} />
-          </div>
-          <div className="min-w-0">
-            <OverpaySummaryCards analysis={analysis} />
-          </div>
-        </div>
+            <div className="grid gap-6 md:grid-cols-[1fr_260px]">
+              <div className="h-[260px] min-w-0 sm:h-[300px] md:h-auto md:min-h-[300px]">
+                <OverpayComparisonChart analysis={analysis} />
+              </div>
+              <div className="min-w-0">
+                <OverpaySummaryCards analysis={analysis} />
+              </div>
+            </div>
+          </>
+        ) : (
+          <OverpayPageSkeleton />
+        )}
 
         <OverpayPrimaryInputs
           repaymentDate={repaymentDate}

--- a/src/hooks/useOverpayAnalysis.ts
+++ b/src/hooks/useOverpayAnalysis.ts
@@ -8,33 +8,6 @@ import type { OverpayAnalysisResult } from "@/lib/loans/overpay-types";
 import type { OverpayAnalysisPayload } from "@/workers/simulation.worker";
 
 /**
- * Default empty result while waiting for worker.
- */
-const emptyResult: OverpayAnalysisResult = {
-  baseline: {
-    totalPaid: 0,
-    monthsToPayoff: 0,
-    writtenOff: false,
-    amountWrittenOff: 0,
-    finalSalary: 0,
-  },
-  overpay: {
-    totalPaid: 0,
-    monthsToPayoff: 0,
-    writtenOff: false,
-    amountWrittenOff: 0,
-    finalSalary: 0,
-  },
-  recommendation: "marginal",
-  recommendationReason: "Calculating...",
-  balanceTimeSeries: [],
-  writeOffMonth: null,
-  paymentDifference: 0,
-  overpaymentContributions: 0,
-  monthsSaved: 0,
-};
-
-/**
  * Hook that performs overpay analysis calculations (runs in Web Worker).
  *
  * Compares two scenarios:
@@ -42,11 +15,11 @@ const emptyResult: OverpayAnalysisResult = {
  * 2. Overpay: Add monthly overpayment to loan
  *
  * @param repaymentStartDate - Date when loan repayment started (local state from OverpayPage)
- * @returns Analysis result with recommendation, balance time series, and comparison data
+ * @returns Analysis result with recommendation, balance time series, and comparison data, or null while loading
  */
 export function useOverpayAnalysis(
   repaymentStartDate: Date,
-): OverpayAnalysisResult {
+): OverpayAnalysisResult | null {
   const { loans } = useLoanConfig();
   const salary = useCurrentSalary();
   const {
@@ -76,6 +49,5 @@ export function useOverpayAnalysis(
 
   const result = useSimulationWorker(payload);
 
-  // Return worker result or empty result while loading
-  return result?.result ?? emptyResult;
+  return result?.result ?? null;
 }


### PR DESCRIPTION
## Summary

Adds skeleton loading states across the home page and overpay page so users see animated placeholders while the web worker computes results, instead of blank space or stale text. This prevents a flash of empty content on initial load and when navigating between pages after changing loan config.

## Context

Previously, `ResultSummary` returned `null` while waiting for data, charts showed either nothing or a text placeholder, and the overpay page rendered zeroed-out values from a hardcoded `emptyResult` object. Now all these components show dimension-matched skeleton placeholders using the existing `<Skeleton>` component. The `useOverpayAnalysis` hook returns `null` during loading instead of a fake result, making the loading state explicit. On the overpay page, interactive inputs remain fully usable during loading.