### PR TITLE
feat: add RPI vs CPI guide

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -17,6 +17,7 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - [All Guides](https://studentloanstudy.uk/guides): Index page listing all student loan guides
 - [Plan 2 vs Plan 5](https://studentloanstudy.uk/guides/plan-2-vs-plan-5): Compare thresholds, interest rates, and total repayments between Plan 2 and Plan 5
 - [How Interest Works](https://studentloanstudy.uk/guides/how-interest-works): Understand the sliding scale for Plan 2, RPI-only for Plan 5, and why balances grow
+- [RPI vs CPI](https://studentloanstudy.uk/guides/rpi-vs-cpi): Why student loan interest uses RPI while general inflation is measured by CPI, and what that gap means
 - [Student Loan & Mortgage](https://studentloanstudy.uk/guides/student-loan-vs-mortgage): How student loan repayments affect mortgage affordability and borrowing capacity
 - [Pay Upfront or Take Loan?](https://studentloanstudy.uk/guides/pay-upfront-or-take-loan): Should parents pay tuition upfront or let their child take the loan?
 - [Moving Abroad](https://studentloanstudy.uk/guides/moving-abroad): What happens to your student loan if you leave the UK

--- a/src/app/guides/rpi-vs-cpi/layout.tsx
+++ b/src/app/guides/rpi-vs-cpi/layout.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from "next";
+import { CURRENT_RATES } from "@/lib/loans/plans";
+
+export const metadata: Metadata = {
+  title: "RPI vs CPI: Why Your Student Loan Interest Outpaces Inflation",
+  description:
+    "Your student loan interest uses RPI, but 'real' inflation is measured by CPI. That gap means your balance grows faster than the cost of living.",
+  keywords: [
+    "RPI vs CPI",
+    "student loan RPI",
+    "student loan inflation",
+    "inflation adjusted student loan",
+  ],
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://studentloanstudy.uk",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Guides",
+      item: "https://studentloanstudy.uk/guides",
+    },
+    {
+      "@type": "ListItem",
+      position: 3,
+      name: "RPI vs CPI",
+      item: "https://studentloanstudy.uk/guides/rpi-vs-cpi",
+    },
+  ],
+};
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "What is the difference between RPI and CPI for student loans?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: `RPI (Retail Prices Index) includes housing costs and uses an arithmetic mean formula, while CPI (Consumer Prices Index) excludes housing costs and uses a geometric mean. Student loan interest is tied to RPI, which currently sits at ${String(CURRENT_RATES.rpi)}%. CPI, the Bank of England's target measure, sits lower at around 2%. This means your loan interest is based on the higher measure.`,
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Why does my student loan interest seem higher than inflation?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Your loan interest is tied to RPI, which historically runs 0.5-1 percentage points higher than CPI (the measure most people think of as 'inflation'). On top of that, some plans add up to 3% on top of RPI. So even Plan 5's 'inflation-only' rate exceeds general inflation as measured by CPI.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What does 'adjusted for inflation' mean in the student loan calculator?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "When you toggle 'Adjust for inflation' in the calculator, it discounts future values by CPI (approximately 2%) to show amounts in today's money. This does not use RPI. Any growth that remains after toggling represents the real above-inflation cost of the loan.",
+      },
+    },
+  ],
+};
+
+export default function RpiVsCpiLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/guides/rpi-vs-cpi/page.tsx
+++ b/src/app/guides/rpi-vs-cpi/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { AppErrorBoundary } from "@/components/ErrorBoundary";
+import { RpiVsCpiGuide } from "@/components/guides/rpi-vs-cpi/RpiVsCpiGuide";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/guides/rpi-vs-cpi" },
+};
+
+export default function RpiVsCpiRoute() {
+  return (
+    <AppErrorBoundary>
+      <RpiVsCpiGuide />
+    </AppErrorBoundary>
+  );
+}

--- a/src/app/sitemap.xml
+++ b/src/app/sitemap.xml
@@ -19,6 +19,9 @@
     <loc>https://studentloanstudy.uk/guides/how-interest-works</loc>
   </url>
   <url>
+    <loc>https://studentloanstudy.uk/guides/rpi-vs-cpi</loc>
+  </url>
+  <url>
     <loc>https://studentloanstudy.uk/guides/student-loan-vs-mortgage</loc>
   </url>
   <url>

--- a/src/components/ToolLinks.tsx
+++ b/src/components/ToolLinks.tsx
@@ -85,11 +85,11 @@ const GUIDES: ToolCardProps[] = [
     cta: "Read Guide",
   },
   {
-    href: "/guides/pay-upfront-or-take-loan",
+    href: "/guides/rpi-vs-cpi",
     icon: BookOpen01Icon,
-    title: "Pay Upfront or Take Loan?",
+    title: "RPI vs CPI",
     description:
-      "Why your starting salary is misleading when deciding whether to pay tuition upfront or take the loan.",
+      "Why your loan interest outpaces inflation and what \u2018adjusted for inflation\u2019 really means.",
     cta: "Read Guide",
   },
   {
@@ -128,6 +128,16 @@ export function ToolLinks() {
             <ToolCard key={guide.href} {...guide} />
           ))}
         </div>
+        <Link
+          href="/guides"
+          className="inline-flex items-center gap-1 text-sm font-medium text-primary transition-colors hover:text-primary/80"
+        >
+          View All Guides
+          <HugeiconsIcon
+            icon={ArrowRight01Icon}
+            className="size-4 transition-transform hover:translate-x-0.5"
+          />
+        </Link>
       </div>
     </section>
   );

--- a/src/components/guides/how-interest-works/InterestGuide.tsx
+++ b/src/components/guides/how-interest-works/InterestGuide.tsx
@@ -169,7 +169,7 @@ export function InterestGuide() {
 
           <RelatedGuides
             current="how-interest-works"
-            order={["plan-2-vs-plan-5", "pay-upfront-or-take-loan"]}
+            order={["rpi-vs-cpi", "plan-2-vs-plan-5"]}
           />
         </article>
       </main>

--- a/src/components/guides/rpi-vs-cpi/InflationComparisonChart.tsx
+++ b/src/components/guides/rpi-vs-cpi/InflationComparisonChart.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+import type { ChartConfig } from "@/components/ui/chart";
+import { ChartBase } from "@/components/charts/ChartBase";
+import { simulate } from "@/lib/loans/engine";
+import { CURRENT_RATES } from "@/lib/loans/plans";
+import { toPresent } from "@/utils/present-value";
+
+const SALARY_OPTIONS = [30000, 50000, 70000] as const;
+type SalaryOption = (typeof SALARY_OPTIONS)[number];
+
+const EXAMPLE_BALANCE = 45_000;
+const CPI_RATE = 0.02;
+const RPI_RATE = CURRENT_RATES.rpi / 100;
+
+const chartConfig = {
+  nominal: {
+    label: "Nominal",
+    color: "oklch(0.7 0.15 250)",
+  },
+  cpiAdjusted: {
+    label: "CPI-adjusted",
+    color: "oklch(0.7 0.15 150)",
+  },
+  rpiAdjusted: {
+    label: "RPI-adjusted",
+    color: "oklch(0.7 0.15 50)",
+  },
+} satisfies ChartConfig;
+
+interface DataPoint {
+  year: number;
+  nominal: number;
+  cpiAdjusted: number;
+  rpiAdjusted: number;
+}
+
+function buildData(salary: number): DataPoint[] {
+  const result = simulate({
+    loans: [{ planType: "PLAN_5", balance: EXAMPLE_BALANCE }],
+    annualSalary: salary,
+  });
+
+  const points: DataPoint[] = [];
+
+  for (let m = 0; m < result.snapshots.length; m += 12) {
+    const snapshot = result.snapshots[m];
+    const balance = snapshot.loans[0]?.closingBalance ?? 0;
+    if (balance <= 0) break;
+
+    points.push({
+      year: m / 12,
+      nominal: balance,
+      cpiAdjusted: toPresent(balance, CPI_RATE, m),
+      rpiAdjusted: toPresent(balance, RPI_RATE, m),
+    });
+  }
+
+  return points;
+}
+
+function formatYear(year: number): string {
+  return `${String(year)}yr`;
+}
+
+function formatCurrency(value: number): string {
+  return `\u00a3${String(Math.round(value / 1000))}k`;
+}
+
+function formatSalaryLabel(salary: number): string {
+  return `\u00a3${String(salary / 1000)}k`;
+}
+
+export function InflationComparisonChart() {
+  const [salary, setSalary] = useState<SalaryOption>(50000);
+  const data = buildData(salary);
+
+  return (
+    <div className="flex h-full flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium text-muted-foreground">
+          Salary:
+        </span>
+        <div className="flex gap-1">
+          {SALARY_OPTIONS.map((option) => (
+            <button
+              key={option}
+              type="button"
+              onClick={() => {
+                setSalary(option);
+              }}
+              className={`rounded-md px-3 py-1 text-sm font-medium transition-colors ${
+                salary === option
+                  ? "bg-foreground text-background"
+                  : "bg-muted text-muted-foreground hover:bg-muted/80"
+              }`}
+            >
+              {formatSalaryLabel(option)}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="min-h-0 flex-1">
+        <ChartBase
+          type="area"
+          data={data}
+          xDataKey="year"
+          xLabel="Years since repayment"
+          xFormatter={formatYear}
+          yLabel="Balance"
+          yFormatter={formatCurrency}
+          ariaLabel="Area chart comparing nominal, CPI-adjusted, and RPI-adjusted loan balance over time for a Plan 5 loan"
+          chartConfig={chartConfig}
+          series={[
+            { dataKey: "nominal" },
+            { dataKey: "cpiAdjusted" },
+            { dataKey: "rpiAdjusted" },
+          ]}
+          showLegend
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
+++ b/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
@@ -1,0 +1,253 @@
+import { InflationComparisonChart } from "./InflationComparisonChart";
+import { Breadcrumb } from "@/components/Breadcrumb";
+import { Footer } from "@/components/Footer";
+import { RelatedGuides } from "@/components/guides/RelatedGuides";
+import { Header } from "@/components/Header";
+import { formatPercent } from "@/lib/format";
+import { CURRENT_RATES } from "@/lib/loans/plans";
+
+const rpi = CURRENT_RATES.rpi;
+const cpiTarget = 2;
+const gap = +(rpi - cpiTarget).toFixed(1);
+const maxRate = rpi + 3;
+const plan1Rate = Math.min(rpi, CURRENT_RATES.boeBaseRate + 1);
+
+export function RpiVsCpiGuide() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <main
+        id="main-content"
+        className="mx-auto w-full max-w-4xl flex-1 px-3 pt-13 pb-6 md:pb-8"
+      >
+        <article className="space-y-8">
+          <div className="space-y-4">
+            <Breadcrumb
+              parents={[{ label: "Guides", href: "/guides" }]}
+              currentTitle="RPI vs CPI"
+            />
+
+            <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+              RPI vs CPI: Why Your Student Loan Interest Outpaces Inflation
+            </h1>
+            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+              Your student loan interest is tied to RPI, but when the calculator
+              shows &ldquo;adjusted for inflation,&rdquo; it uses CPI. RPI
+              typically runs 0.5&ndash;1% higher. That gap means your balance
+              grows faster than the general cost of living.
+            </p>
+          </div>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              What Are RPI and CPI?
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <ul className="list-disc space-y-2 pl-6">
+                <li>
+                  <strong className="text-foreground">
+                    RPI (Retail Prices Index)
+                  </strong>
+                  : includes housing costs such as mortgage interest and council
+                  tax. The Student Loans Company uses RPI to set loan interest
+                  rates. Currently {formatPercent(rpi)}.
+                </li>
+                <li>
+                  <strong className="text-foreground">
+                    CPI (Consumer Prices Index)
+                  </strong>
+                  : the Bank of England&apos;s target measure with a 2% target.
+                  Excludes housing costs. This is what the calculator&apos;s
+                  &ldquo;Adjust for inflation&rdquo; toggle uses.
+                </li>
+                <li>
+                  <strong className="text-foreground">
+                    CPIH (CPI including Housing)
+                  </strong>
+                  : the ONS&apos;s preferred headline measure since 2017. Not
+                  used for student loans.
+                </li>
+              </ul>
+              <p>
+                The government stopped using RPI for most purposes because it
+                overstates inflation, but student loans remain tied to it.
+              </p>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Why Student Loans Use RPI
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <p>
+                Plan 2 was introduced in 2012 when RPI was still widely used
+                across government policy. The government has since acknowledged
+                that RPI overstates inflation due to the &ldquo;formula
+                effect&rdquo; &mdash; it uses an arithmetic mean rather than a
+                geometric mean, which systematically produces higher figures.
+              </p>
+              <p>
+                Plans exist to align RPI with CPIH by 2030, but current loan
+                terms are unlikely to change retroactively. Each plan uses RPI
+                in its interest formula:
+              </p>
+              <ul className="list-disc space-y-1 pl-6">
+                <li>
+                  <strong className="text-foreground">Plan 5</strong>: RPI only
+                  ({formatPercent(rpi)})
+                </li>
+                <li>
+                  <strong className="text-foreground">Plan 2</strong>: RPI to
+                  RPI + 3% ({formatPercent(rpi)} &ndash;{" "}
+                  {formatPercent(maxRate)}) depending on income
+                </li>
+                <li>
+                  <strong className="text-foreground">Plan 1 &amp; 4</strong>:
+                  lesser of RPI or base rate + 1% (currently{" "}
+                  {formatPercent(plan1Rate)})
+                </li>
+                <li>
+                  <strong className="text-foreground">Postgraduate</strong>: RPI
+                  + 3% ({formatPercent(maxRate)})
+                </li>
+              </ul>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              The Gap Between RPI and CPI
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <p>
+                RPI historically exceeds CPI by roughly 0.5&ndash;1 percentage
+                points. With RPI at {formatPercent(rpi)} and the CPI target at{" "}
+                {formatPercent(cpiTarget)}, the current gap is {gap} percentage
+                points.
+              </p>
+              <p>
+                Two factors drive the gap: RPI includes housing costs that CPI
+                excludes, and RPI uses an arithmetic mean formula while CPI uses
+                a geometric mean. The arithmetic mean always produces a higher
+                result when prices are changing, which is why statisticians call
+                it the &ldquo;formula effect.&rdquo;
+              </p>
+              <p>
+                The chart below shows what this gap looks like over the life of
+                a Plan 5 loan.
+              </p>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Inflation Comparison
+            </h2>
+            <div className="h-85 sm:h-105">
+              <InflationComparisonChart />
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Plan 5, {"\u00a3"}45,000 balance. The gap between the CPI-adjusted
+              and RPI-adjusted lines is the real above-inflation cost.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Nominal, CPI-Adjusted, and RPI-Adjusted: Three Ways to See Your
+              Loan
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <ul className="list-disc space-y-2 pl-6">
+                <li>
+                  <strong className="text-foreground">Nominal</strong>: the raw
+                  balance on your SLC account. Grows at the loan interest rate.
+                </li>
+                <li>
+                  <strong className="text-foreground">CPI-adjusted</strong>:
+                  discounted by CPI &mdash; this is what the calculator&apos;s
+                  &ldquo;Adjust for inflation&rdquo; toggle shows. It tells you
+                  what the balance is worth in today&apos;s money.
+                </li>
+                <li>
+                  <strong className="text-foreground">RPI-adjusted</strong>:
+                  discounted by RPI. The balance appears roughly flat because
+                  RPI is close to the interest rate itself. But this is
+                  misleading because RPI overstates general inflation.
+                </li>
+              </ul>
+              <p>
+                The key insight: the gap between the CPI-adjusted and
+                RPI-adjusted lines is the real above-inflation cost of the loan.
+              </p>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              What This Means for Your Plan
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <ul className="list-disc space-y-2 pl-6">
+                <li>
+                  <strong className="text-foreground">Plan 5</strong>:
+                  &ldquo;RPI only&rdquo; sounds gentle, but since RPI runs
+                  higher than CPI, the loan still grows faster than general
+                  prices.
+                </li>
+                <li>
+                  <strong className="text-foreground">Plan 2</strong>: the
+                  sliding scale starts at RPI (already above CPI). High earners
+                  face RPI + 3%.
+                </li>
+                <li>
+                  <strong className="text-foreground">Plan 1 &amp; 4</strong>:
+                  capped at the lesser of RPI or base rate + 1%, so these
+                  borrowers are somewhat shielded.
+                </li>
+                <li>
+                  <strong className="text-foreground">Postgraduate</strong>: RPI
+                  + 3% means the largest gap above CPI of any plan.
+                </li>
+              </ul>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <div className="rounded-xl border bg-muted/50 p-5">
+              <h2 className="mb-3 text-lg font-semibold tracking-tight">
+                Key Takeaways
+              </h2>
+              <ul className="list-disc space-y-2 pl-6 text-muted-foreground">
+                <li>
+                  RPI typically runs 0.5&ndash;1% higher than CPI &mdash; your
+                  loan interest is tied to the higher measure.
+                </li>
+                <li>
+                  &ldquo;Adjusted for inflation&rdquo; in the calculator uses
+                  CPI, not RPI. Remaining growth after toggling is real
+                  above-inflation cost.
+                </li>
+                <li>
+                  Plan 5&apos;s &ldquo;inflation-only&rdquo; interest is
+                  RPI-inflation, not CPI-inflation.
+                </li>
+                <li>
+                  RPI may align with CPIH by 2030, but current borrowers are
+                  unlikely to benefit.
+                </li>
+              </ul>
+            </div>
+          </section>
+
+          <RelatedGuides
+            current="rpi-vs-cpi"
+            order={["how-interest-works", "plan-2-vs-plan-5"]}
+          />
+        </article>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/lib/guides.ts
+++ b/src/lib/guides.ts
@@ -2,6 +2,7 @@ export type GuideSlug =
   | "plan-2-vs-plan-5"
   | "student-loan-vs-mortgage"
   | "how-interest-works"
+  | "rpi-vs-cpi"
   | "pay-upfront-or-take-loan"
   | "moving-abroad"
   | "self-employment";
@@ -30,6 +31,12 @@ export const GUIDES: GuideEntry[] = [
     title: "How Interest Works",
     description:
       "RPI, sliding scales, and why your balance can grow despite repayments.",
+  },
+  {
+    slug: "rpi-vs-cpi",
+    title: "RPI vs CPI",
+    description:
+      "Why your loan interest outpaces inflation and what \u2018adjusted for inflation\u2019 really means.",
   },
   {
     slug: "pay-upfront-or-take-loan",


### PR DESCRIPTION
## Summary

Adds a new guide at `/guides/rpi-vs-cpi` explaining why student loan interest (tied to RPI) outpaces general inflation (measured by CPI), and what the calculator's "Adjust for inflation" toggle actually shows. Includes an interactive 3-line area chart comparing nominal, CPI-adjusted, and RPI-adjusted balances over time for a Plan 5 loan.

## Context

The app's present-value toggle uses CPI to discount future values, but loan interest is set by RPI — which historically runs 0.5–1% higher. Users see "inflation" in multiple places without understanding two different measures are at play. This guide bridges that gap with per-plan breakdowns and a visual comparison chart.

The guide is registered in the guides index, sitemap, and llms.txt. The "How Interest Works" guide now links to it as a related guide, and the home page ToolLinks swaps in the new card.