### PR TITLE
feat: expand Plan 2 vs Plan 5 guide and add internal calculator links

### DIFF
--- a/src/app/guides/plan-2-vs-plan-5/layout.tsx
+++ b/src/app/guides/plan-2-vs-plan-5/layout.tsx
@@ -2,10 +2,12 @@ import type { Metadata } from "next";
 import { formatGBP } from "@/lib/format";
 import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
 
+const description =
+  "Plan 2 has higher interest but writes off after 30 years. Plan 5 charges less interest but repays over 40 years with a lower threshold. Compare the total cost at your salary.";
+
 export const metadata: Metadata = {
-  title: "Plan 2 vs Plan 5: Which Student Loan Is Better?",
-  description:
-    "Plan 5 has lower interest but a longer repayment window. Plan 2 can cost more — or get written off sooner. See which one hits your wallet harder at your salary.",
+  title: "Plan 2 vs Plan 5: Which Student Loan Costs More?",
+  description,
   keywords: [
     "Plan 2 vs Plan 5",
     "UK student loan comparison",
@@ -13,7 +15,14 @@ export const metadata: Metadata = {
     "Plan 5 student loan",
     "which student loan plan is better",
     "student loan write-off",
+    "plan 2 vs plan 5 threshold",
   ],
+  openGraph: {
+    title: "Plan 2 vs Plan 5: Which Student Loan Costs More?",
+    description,
+    url: "https://studentloanstudy.uk/guides/plan-2-vs-plan-5",
+    type: "article",
+  },
 };
 
 const breadcrumbSchema = {
@@ -63,7 +72,7 @@ const faqSchema = {
       name: "Which student loan plan costs more overall?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: `It depends on your salary. Lower earners often repay less on Plan 2 because it writes off after ${String(plan2WriteOff)} years, while Plan 5's ${String(plan5WriteOff)}-year term means more payments despite the lower interest rate. Higher earners may repay more on Plan 2 due to the sliding-scale interest that can reach RPI + 3%.`,
+        text: `It depends on your salary. Lower earners often repay less on Plan 2 because it writes off after ${String(plan2WriteOff)} years, while Plan 5's ${String(plan5WriteOff)}-year term means more payments despite the lower interest rate. Middle earners may repay more on Plan 2 because they earn too much for write-off to help but not enough to pay off the balance quickly before interest (up to RPI + 3%) compounds significantly.`,
       },
     },
     {
@@ -74,7 +83,42 @@ const faqSchema = {
         text: `Yes. Plan 5 charges interest at RPI only, while Plan 2 uses a sliding scale from RPI up to RPI + 3% depending on your income. However, Plan 5's longer ${String(plan5WriteOff)}-year repayment window and lower threshold mean you may still pay more in total despite the lower rate.`,
       },
     },
+    {
+      "@type": "Question",
+      name: "Can I switch between Plan 2 and Plan 5?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "No. Your plan is permanently determined by your course start date. There is no mechanism to switch between Plan 2 and Plan 5. If you take out a second degree after August 2023, the new loan will be on Plan 5, but your original Plan 2 loan stays on Plan 2.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What if I started university right before Plan 5 was introduced?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "The cutoff is August 2023. Students who started before this date are on Plan 2. Students starting from September 2023 onwards are on Plan 5. Also note Plan 5 is England-only — Welsh students who started after August 2023 remain on Plan 2.",
+      },
+    },
   ],
+};
+
+const articleSchema = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: "Plan 2 vs Plan 5: Which Student Loan Costs More?",
+  description,
+  url: "https://studentloanstudy.uk/guides/plan-2-vs-plan-5",
+  author: {
+    "@type": "Organization",
+    name: "UK Student Loan Study",
+    url: "https://studentloanstudy.uk",
+  },
+  publisher: {
+    "@type": "Organization",
+    name: "UK Student Loan Study",
+    url: "https://studentloanstudy.uk",
+  },
+  dateModified: "2026-02-20",
 };
 
 // Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
@@ -93,6 +137,10 @@ export default function Plan2VsPlan5Layout({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
       />
       {children}
     </>

--- a/src/app/sitemap.xml
+++ b/src/app/sitemap.xml
@@ -14,6 +14,7 @@
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/plan-2-vs-plan-5</loc>
+    <lastmod>2026-02-20</lastmod>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/how-interest-works</loc>

--- a/src/components/guides/RelatedGuides.tsx
+++ b/src/components/guides/RelatedGuides.tsx
@@ -100,9 +100,11 @@ export function RelatedGuides({
                 <HugeiconsIcon icon={Calculator01Icon} className="size-5" />
               </div>
               <div className="min-w-0 flex-1">
-                <h3 className="text-sm font-medium">Repayment Calculator</h3>
+                <h3 className="text-sm font-medium">
+                  Student Loan Repayment Calculator
+                </h3>
                 <p className="text-xs text-muted-foreground">
-                  Model your own repayment timeline
+                  See how much you will repay in total at your salary
                 </p>
               </div>
               <HugeiconsIcon

--- a/src/components/guides/how-interest-works/InterestGuide.tsx
+++ b/src/components/guides/how-interest-works/InterestGuide.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { InterestRateChart } from "./InterestRateChart";
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { Breadcrumb } from "@/components/layout/Breadcrumb";
@@ -162,7 +163,14 @@ export function InterestGuide() {
                 This is most common early in your career when salaries are lower
                 and balances are at their highest. Over time, salary growth
                 increases your repayments while the balance (hopefully) shrinks,
-                eventually tipping the scales.
+                eventually tipping the scales. Use the{" "}
+                <Link
+                  href="/"
+                  className="text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  repayment calculator
+                </Link>{" "}
+                to see when this tipping point occurs at your salary.
               </p>
             </div>
           </section>

--- a/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
+++ b/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
@@ -5,6 +5,7 @@ import {
   CreditCardIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { Breadcrumb } from "@/components/layout/Breadcrumb";
 import { Footer } from "@/components/layout/Footer";
@@ -288,6 +289,17 @@ export function MovingAbroadGuide() {
               <li>
                 Non-compliance can lead to legal action, collection agencies,
                 and credit impacts if you return to the UK.
+              </li>
+              <li>
+                Before you move, check your remaining balance and repayment
+                timeline with the{" "}
+                <Link
+                  href="/"
+                  className="text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  repayment calculator
+                </Link>
+                .
               </li>
             </ul>
           </section>

--- a/src/components/guides/pay-upfront-or-take-loan/PayUpfrontGuide.tsx
+++ b/src/components/guides/pay-upfront-or-take-loan/PayUpfrontGuide.tsx
@@ -221,7 +221,7 @@ export function PayUpfrontGuide() {
                   href="/"
                   className="text-primary underline underline-offset-4 hover:text-primary/80"
                 >
-                  Use the calculator
+                  Use the student loan repayment calculator
                 </Link>{" "}
                 to model your specific scenario with your expected salary and
                 growth rate

--- a/src/components/guides/plan-2-vs-plan-5/Plan2VsPlan5Guide.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/Plan2VsPlan5Guide.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { BalanceComparisonChart } from "./BalanceComparisonChart";
 import { ComparisonTable } from "./ComparisonTable";
 import { TotalRepaymentBySalaryChart } from "./TotalRepaymentBySalaryChart";
@@ -6,8 +7,19 @@ import { Breadcrumb } from "@/components/layout/Breadcrumb";
 import { Footer } from "@/components/layout/Footer";
 import { Header } from "@/components/layout/Header";
 import { formatGBP } from "@/lib/format";
+import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
 
 const EXAMPLE_BALANCE = 45_000;
+const EXAMPLE_SALARY = 30_000;
+const plan2Threshold = PLAN_DISPLAY_INFO.PLAN_2.yearlyThreshold;
+const plan5Threshold = PLAN_DISPLAY_INFO.PLAN_5.yearlyThreshold;
+const repaymentRate = PLAN_CONFIGS.PLAN_2.repaymentRate;
+const plan2Annual = Math.round(
+  (EXAMPLE_SALARY - plan2Threshold) * repaymentRate,
+);
+const plan5Annual = Math.round(
+  (EXAMPLE_SALARY - plan5Threshold) * repaymentRate,
+);
 
 export function Plan2VsPlan5Guide() {
   return (
@@ -80,6 +92,123 @@ export function Plan2VsPlan5Guide() {
             </div>
           </section>
 
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Which Plan Do I Have?
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <p>
+                You cannot choose between Plan 2 and Plan 5 &mdash; your plan is
+                determined by when and where you started your course. Plan 2
+                covers English and Welsh students who started university between
+                September 2012 and July 2023. Plan 5 applies to English students
+                who started from September 2023 onwards.
+              </p>
+              <p>
+                The cutoff is August 2023. If you started in the 2022&ndash;23
+                academic year, you are on Plan 2. If you started in September
+                2023 or later, you are on Plan 5. Note that Plan 5 is
+                England-only &mdash; Welsh students who started after August
+                2023 remain on Plan 2.
+              </p>
+              <p>
+                Not sure?{" "}
+                <Link
+                  href="/which-plan"
+                  className="text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  Take the which plan quiz
+                </Link>{" "}
+                to find out.
+              </p>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              How the Threshold Difference Affects You
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <p>
+                Plan 5&rsquo;s lower repayment threshold means you start
+                repaying sooner and pay more each month at the same salary. Both
+                plans charge 9% on income above the threshold, but the
+                thresholds are different: {formatGBP(plan2Threshold)} for Plan 2
+                versus {formatGBP(plan5Threshold)} for Plan 5.
+              </p>
+              <p>
+                For example, at a {formatGBP(EXAMPLE_SALARY)} salary, a Plan 2
+                borrower repays just {formatGBP(plan2Annual)} per year, while a
+                Plan 5 borrower repays {formatGBP(plan5Annual)} per year &mdash;
+                over three times as much. This gap narrows at higher salaries
+                where both plans collect substantial repayments, but at lower
+                salaries the threshold difference is the dominant factor.
+              </p>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Can You Switch Plans?
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <p>
+                No. Your plan is permanently determined by your course start
+                date. There is no mechanism to switch between Plan 2 and Plan 5.
+              </p>
+              <p>
+                If you take out a second degree after August 2023, the new loan
+                will be on Plan 5, but your original Plan 2 loan stays on Plan
+                2. The two loans are repaid separately under their own terms.
+              </p>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              Which Plan Should You Worry About?
+            </h2>
+            <div className="space-y-2 text-muted-foreground">
+              <p>
+                For most borrowers, repayments are automatic through PAYE
+                &mdash; you do not need to do anything. The real question is
+                whether it makes sense to{" "}
+                <Link
+                  href="/overpay"
+                  className="text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  overpay your loan
+                </Link>
+                .
+              </p>
+              <p>
+                Plan 2 middle earners are hit hardest. They earn too much for
+                the 30-year write-off to help significantly, but not enough to
+                pay off the balance quickly before{" "}
+                <Link
+                  href="/guides/how-interest-works"
+                  className="text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  interest
+                </Link>{" "}
+                (up to RPI + 3%) compounds over decades. These borrowers often
+                end up repaying more in total than Plan 5 borrowers on the same
+                salary.
+              </p>
+              <p>
+                Use the{" "}
+                <Link
+                  href="/"
+                  className="text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  student loan repayment calculator
+                </Link>{" "}
+                to model your specific scenario and see exactly how much
+                you&rsquo;ll repay under your plan.
+              </p>
+            </div>
+          </section>
+
           <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
             <h2 className="text-lg font-semibold tracking-tight">
               Key Takeaways
@@ -91,13 +220,29 @@ export function Plan2VsPlan5Guide() {
                 repayments.
               </li>
               <li>
-                Higher earners may pay <strong>more</strong> on Plan 2 because
-                interest can reach RPI + 3%, growing the balance faster.
+                Middle earners may pay <strong>more</strong> on Plan 2 because
+                interest can reach RPI + 3%, and they earn too much for
+                write-off to help but not enough to pay off the balance quickly.
               </li>
               <li>
                 Plan 5&rsquo;s simpler interest (RPI only) makes the balance
                 more predictable, but the longer write-off window is the real
                 cost driver.
+              </li>
+              <li>
+                Plan 5&rsquo;s lower threshold ({formatGBP(plan5Threshold)} vs{" "}
+                {formatGBP(plan2Threshold)}) means earlier and larger repayments
+                at the same salary.
+              </li>
+              <li>
+                Model your own salary in the{" "}
+                <Link
+                  href="/"
+                  className="text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  student loan calculator
+                </Link>{" "}
+                to see the total cost under each plan.
               </li>
             </ul>
           </section>

--- a/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
+++ b/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { InflationComparisonChart } from "./InflationComparisonChart";
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { Breadcrumb } from "@/components/layout/Breadcrumb";
@@ -236,6 +237,16 @@ export function RpiVsCpiGuide() {
                 <li>
                   RPI may align with CPIH by 2030, but current borrowers are
                   unlikely to benefit.
+                </li>
+                <li>
+                  See how inflation affects your total repayment with the{" "}
+                  <Link
+                    href="/"
+                    className="text-primary underline underline-offset-4 hover:text-primary/80"
+                  >
+                    student loan calculator
+                  </Link>
+                  .
                 </li>
               </ul>
             </div>

--- a/src/components/guides/self-employment/SelfEmploymentGuide.tsx
+++ b/src/components/guides/self-employment/SelfEmploymentGuide.tsx
@@ -6,6 +6,7 @@ import {
   BulbIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { Breadcrumb } from "@/components/layout/Breadcrumb";
 import { Footer } from "@/components/layout/Footer";
@@ -354,6 +355,16 @@ export function SelfEmploymentGuide() {
               <li>
                 Budget monthly by setting aside {undergradRate} of profit above
                 the threshold to avoid being caught out by large tax bills.
+              </li>
+              <li>
+                Estimate your annual repayments with the{" "}
+                <Link
+                  href="/"
+                  className="text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  student loan calculator
+                </Link>
+                .
               </li>
             </ul>
           </section>

--- a/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
+++ b/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { RepaymentImpactChart } from "./RepaymentImpactChart";
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { Breadcrumb } from "@/components/layout/Breadcrumb";
@@ -129,6 +130,14 @@ export function MortgageGuide() {
                 repayment is roughly {formatGBP(example60kMonthly)}, trimming
                 potential borrowing by about{" "}
                 {formatGBP(example60kMortgageReduction)} on the same multiplier.
+                Use the{" "}
+                <Link
+                  href="/"
+                  className="text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  student loan repayment calculator
+                </Link>{" "}
+                to see your exact monthly repayment at your salary.
               </p>
             </div>
           </section>


### PR DESCRIPTION
## Summary

Search Console data shows guide pages rank well but lack internal links to the calculator — only 1 of 7 guides had an in-content link. The Plan 2 vs Plan 5 guide was also the thinnest at ~800 words, missing coverage of common sub-queries like eligibility, thresholds, and switching plans.

This expands the Plan 2 vs Plan 5 guide with four new content sections (eligibility, threshold impact, switching plans, practical advice) and adds contextual in-content calculator links across all 7 guides with varied anchor text. Metadata and structured data are updated to target "costs more" intent and add Article schema.

## Context

The Plan 2 vs Plan 5 guide sits at position 7.6 in Search Console with 8 impressions and 0 clicks. The expanded content targets sub-queries ("plan 2 vs plan 5 threshold", "can I switch plans") and the updated title ("Costs More?" vs "Is Better?") better matches informational intent since borrowers cannot choose between plans. The internal linking strengthens the calculator's topical authority across the guide cluster.