### PR TITLE
chore: condense CLAUDE.md into concise bullet points

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,125 +6,67 @@
 pnpm dev           # Start dev server (expect it to be already running)
 pnpm build         # Build for production
 pnpm lint          # Run ESLint
-pnpm typecheck    # Run TypeScript compiler (covers test files next build misses)
+pnpm typecheck     # Run TypeScript compiler (covers test files next build misses)
 pnpm format        # Format with Prettier
 pnpm test          # Run tests
 pnpm test:e2e      # Run Playwright e2e tests
 pnpm check:govuk   # Scrape GOV.UK and check for figure changes
 ```
 
+**Before considering any change done**, run: `pnpm lint && pnpm typecheck && pnpm test && pnpm build && pnpm format`
+
 ## Tech Stack
 
-This project uses TypeScript and React 19. When making changes, ensure compatibility with React 19 patterns (no legacy context, proper use of hooks).
+- Next.js (App Router), React 19, TypeScript
+- **Data flow**: React Context (`src/context/`) → loan simulation (`src/lib/loans/`) → chart hooks → chart components
+- Plan configurations: `src/lib/loans/plans.ts`
 
-**Before considering any change done**, run all five checks and confirm they pass:
+## GOV.UK Figure Automation
 
-```bash
-pnpm lint && pnpm typecheck && pnpm test && pnpm build && pnpm format
-```
+Daily GitHub Action scrapes GOV.UK + Bank of England, auto-creates a PR when figures change.
 
-## Architecture
+Local steps:
 
-UK student loan repayment calculator built with Next.js (App Router), React, and TypeScript.
+1. `pnpm check:govuk` — scrape to `scripts/check-govuk-figures/results/scraped-data.json`
+2. `pnpx tsx scripts/check-govuk-figures/update-files.ts` — compare & regenerate files
 
-**Data flow**: React Context (`src/context/`) → loan simulation library (`src/lib/loans/`) → chart data hooks → chart components
+**Auto-generated files — do not edit manually** (edit templates in `scripts/check-govuk-figures/templates.ts` instead):
 
-**Domain knowledge**: UK student loans have different plan types with varying thresholds, interest rates, and write-off periods. Plan configurations live in `src/lib/loans/plans.ts`.
+- `src/lib/loans/plans.ts` → `generatePlansTs`
+- `src/lib/loans/plans.test.ts` → `generatePlansTestTs`
+- `public/llms.txt` → `generateLlmsTxt`
 
-### GOV.UK figure automation
+## UI & Styling
 
-A daily GitHub Action (`.github/workflows/check-govuk-figures.yml`) scrapes GOV.UK and the Bank of England, compares figures against the codebase, and auto-creates a PR when anything changes. It can also be triggered manually via `workflow_dispatch`.
+- Always support light and dark mode
+- Icons: `@hugeicons/react` with `@hugeicons/core-free-icons` — `<HugeiconsIcon icon={Quiz01Icon} />`
+- **No arbitrary Tailwind values** — use standard tokens only (`text-sm` not `text-[13px]`)
+- Standard Tailwind breakpoints only (`sm`/`md`/`lg`/`xl`/`2xl`). Exception: `min-[30rem]` for mobile-to-tablet
+- **Brand green:** `#2B7F55` — used in `--primary` (light), `BRAND_HEX.green`, `icon.svg`, `scripts/generate-social-images.mjs`. Update ALL locations when changing.
+- `dark` / `light` classes on containers scope CSS variables for that subtree
 
-The pipeline has two steps that can be run locally:
+## Code Quality
 
-```bash
-pnpm check:govuk                                    # Step 1: scrape GOV.UK (Playwright)
-pnpx tsx scripts/check-govuk-figures/update-files.ts # Step 2: compare & regenerate files
-```
+**Never use:**
 
-Step 1 (`pnpm check:govuk`) runs a Playwright scraper that saves results to `scripts/check-govuk-figures/results/scraped-data.json`. Step 2 reads that file, fetches the BoE base rate, compares everything against the current codebase, and overwrites the generated files if anything differs.
+- `eslint-disable`, `@ts-ignore`, `@ts-expect-error`
+- `any` type or unsafe assertions (`as unknown as X`)
+- `useMemo`, `useCallback`, `React.memo` — React Compiler handles this (exception: shadcn/ui)
+- Barrel files — import from source modules directly
+- Default exports (exception: `page.tsx` / `layout.tsx`)
+- `Context.Provider` / `useContext` — use `<Context value={...}>` and `use(Context)` (React 19)
 
-**Auto-generated files — do not edit manually:**
-
-| File                          | Template function     |
-| ----------------------------- | --------------------- |
-| `src/lib/loans/plans.ts`      | `generatePlansTs`     |
-| `src/lib/loans/plans.test.ts` | `generatePlansTestTs` |
-| `public/llms.txt`             | `generateLlmsTxt`     |
-
-These files are fully overwritten by the automation. Any manual edits will be lost on the next run. To change their content, edit the corresponding template function in `scripts/check-govuk-figures/templates.ts` instead.
-
-**Icons**: Use `@hugeicons/react` with icons from `@hugeicons/core-free-icons`. Example:
-
-```tsx
-import { Quiz01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-
-<HugeiconsIcon icon={Quiz01Icon} className="size-5" />;
-```
-
-## UI Development
-
-When building UI components or design boards, always verify that content fits within its parent container boundaries. Check for overflow issues before presenting results.
-
-Always support both light and dark mode when creating or modifying UI components and design elements. Never deliver a light-mode-only implementation unless explicitly told to.
-
-When verifying visual elements (fonts, colors, layouts), always cross-reference the actual rendered output via browser rather than relying solely on code/variable values. Visual inspection is the source of truth for design work.
-
-## Design System
-
-When updating design tokens (CSS variables, color tokens, etc.), always propagate changes to ALL references including hardcoded values in brand guidelines, component swatches, and semantic color mappings. Never assume a variable change is complete until all consumers are updated.
-
-## Tailwind CSS
-
-**No arbitrary values.** Always use standard Tailwind utility classes for sizing, spacing, typography, border radius, tracking, etc. Never introduce arbitrary values like `text-[13px]`, `rounded-[10px]`, or `tracking-[2px]` — use the closest standard token (`text-sm`, `rounded-lg`, `tracking-widest`). This applies to all properties, not just breakpoints.
-
-Use built-in Tailwind breakpoints (`sm`, `md`, `lg`, `xl`, `2xl`) for responsive design. Do not introduce arbitrary breakpoint values like `min-[58rem]` — stick with the standard set for consistency. The only exception is `min-[30rem]` which is already established in the codebase for the mobile-to-tablet transition.
-
-## Brand Colors & Theme Scoping
-
-**Brand green:** `#2B7F55` — used as `--primary` in light mode, in `BRAND_HEX.green` (`src/components/brand/BrandIcon.tsx`), `icon.svg`, and `scripts/generate-social-images.mjs`. When changing the brand color, update ALL of these locations.
-
-**Theme scoping with `dark` / `light` classes:** The CSS defines `:root, .light { ... }` and `.dark { ... }` blocks. Adding `class="dark"` or `class="light"` to a container scopes all CSS variables for that subtree, useful for brand demos that need to show both themes regardless of the current page theme (see `BrandGuidelinesPage.tsx`).
-
-## Code Quality Rules
-
-**Never use these:**
-
-- `eslint-disable` comments
-- Ignore eslint warnings
-- `any` type
-- `@ts-ignore` / `@ts-expect-error`
-- Unsafe type assertions (`as unknown as X`)
-- Manual memoization (`useMemo`, `useCallback`, `React.memo`) — React Compiler handles this automatically. Exception: auto-generated shadcn/ui components.
-- Barrel files (`index.ts` re-export files) — import directly from source modules instead (e.g., `@/lib/loans/types` not `@/lib/loans`).
-- Default exports — use named exports instead (e.g., `export function Header` not `export default Header`). Exception: Next.js App Router requires default exports for `page.tsx` and `layout.tsx` files.
-- `Context.Provider` / `useContext` — use `<Context value={...}>` and `use(Context)` directly (React 19 pattern)
-
-Fix underlying issues instead of suppressing errors.
+**Lint errors:** Run `pnpm lint --fix` before manual fixes.
 
 ## Testing
 
-When testing hooks that consume React Context, use the real `LoanProvider` with its `initialStateOverride` prop instead of mocking the context module with `vi.mock`. This keeps tests coupled to the public API, not internal context structure.
-
-```tsx
-import { LoanProvider } from "../context/LoanContext";
-
-function createWrapper(overrides?: Partial<LoanState>) {
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return (
-      <LoanProvider initialStateOverride={overrides}>{children}</LoanProvider>
-    );
-  };
-}
-```
+- Test hooks with real `LoanProvider` using `initialStateOverride` — don't mock context with `vi.mock`
 
 ## SEO Maintenance
 
-When making changes that affect site content or structure, update the following SEO assets:
+Update when content/structure changes:
 
-- **`public/llms.txt`** - Edit `generateLlmsTxt` in `scripts/check-govuk-figures/templates.ts` (do not edit the file directly — it is auto-generated)
-- **`src/app/sitemap.xml`** - Add new routes
-- **JSON-LD schemas** - Update FAQPage answers if plan details change (in layout.tsx files)
-- **Metadata** - Update page titles/descriptions if content focus changes
-- **`src/lib/loans/plans.ts`** - Edit `generatePlansTs` in `scripts/check-govuk-figures/templates.ts` (do not edit the file directly — it is auto-generated)
+- `public/llms.txt` — edit `generateLlmsTxt` template (auto-generated)
+- `src/app/sitemap.xml` — add new routes
+- JSON-LD schemas in `layout.tsx` — update FAQPage answers if plan details change
+- Page metadata — update titles/descriptions if focus changes


### PR DESCRIPTION
## Summary

Rewrites CLAUDE.md from verbose prose (~100 lines) to concise sectioned bullet points (~65 lines). All existing rules are preserved — just shorter and easier to scan.

## Context

Merged 5 separate sections (UI Development, Design System, Tailwind CSS, Brand Colors, Theme Scoping) into a single "UI & Styling" section. Collapsed code examples to inline snippets, replaced the auto-generated files table with a bullet list, and removed generic advice that isn't repo-specific. Added a new lint auto-fix rule (`pnpm lint --fix` before manual fixes).