### PR TITLE
fix: resolve vitest setup files for git worktree compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ playwright-report/
 
 # GOV.UK checker results
 scripts/check-govuk-figures/results/
+
+# Claude Code worktrees
+.claude/worktrees/

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
+import { createRequire } from "node:module";
 import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
+
+// Resolve setup files to absolute paths so Vite doesn't misresolve bare
+// specifiers through the main repo's node_modules when running in a git
+// worktree (where .git is a file pointing back to the primary checkout).
+const require = createRequire(import.meta.url);
 
 export default defineConfig({
   plugins: [
@@ -9,7 +15,7 @@ export default defineConfig({
   ],
   test: {
     environment: "jsdom",
-    setupFiles: ["@vitest/web-worker", "./src/test/setup.ts"],
+    setupFiles: [require.resolve("@vitest/web-worker"), "./src/test/setup.ts"],
     exclude: ["e2e/**", "scripts/**", "node_modules/**"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary
Fixes vitest failing to resolve `@vitest/web-worker` when running tests from a git worktree. Vite follows the worktree's `.git` file back to the primary checkout and misresolves bare specifiers through the wrong `node_modules`. Using `require.resolve()` anchors resolution to the config file's own location.

Also adds `.claude/worktrees/` to `.gitignore` so worktree directories aren't tracked.

## Context
Git worktrees have a `.git` *file* (not directory) that points to the main repo's `.git/worktrees/<name>`. Vite uses this to infer the workspace root, which causes it to look for packages in the main repo's `node_modules` rather than the worktree's own. The `createRequire` + `require.resolve` pattern resolves the module to an absolute path at config-load time, sidestepping Vite's internal resolution entirely.