### PR TITLE
refactor: replace custom dividers with shadcn Separator

### DIFF
--- a/src/components/brand/BrandGuidelinesPage.tsx
+++ b/src/components/brand/BrandGuidelinesPage.tsx
@@ -4,6 +4,7 @@ import { Breadcrumb } from "@/components/layout/Breadcrumb";
 import { Footer } from "@/components/layout/Footer";
 import { Header } from "@/components/layout/Header";
 import { Card } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
 
 const BRAND_SWATCHES = [
   { name: "Primary Green", hex: BRAND_HEX.green },
@@ -94,7 +95,7 @@ export function BrandGuidelinesPage() {
         </header>
 
         {/* Divider */}
-        <hr className="mb-12 border-border" />
+        <Separator className="mb-12" />
 
         {/* Section: Primary Logo */}
         <Section title="PRIMARY LOGO">

--- a/src/components/home/LoanConfigPanel.tsx
+++ b/src/components/home/LoanConfigPanel.tsx
@@ -18,6 +18,7 @@ import {
   PopoverTitle,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { Separator } from "@/components/ui/separator";
 import { useLoanActions, useLoanConfigState } from "@/context/LoanContext";
 import { trackLoanToggled, trackBalanceChanged } from "@/lib/analytics";
 import {
@@ -334,11 +335,11 @@ export function LoanConfigPanel({
 
           {/* Divider with centered "or" */}
           <div className="flex items-center gap-3">
-            <div className="h-px flex-1 bg-border" />
+            <Separator className="flex-1" />
             <span className="text-xs font-medium tracking-widest text-muted-foreground uppercase">
               or
             </span>
-            <div className="h-px flex-1 bg-border" />
+            <Separator className="flex-1" />
           </div>
 
           {/* Quiz CTA button */}

--- a/src/components/our-data/OurDataPage.tsx
+++ b/src/components/our-data/OurDataPage.tsx
@@ -13,6 +13,7 @@ import Link from "next/link";
 import { Breadcrumb } from "@/components/layout/Breadcrumb";
 import { Footer } from "@/components/layout/Footer";
 import { Header } from "@/components/layout/Header";
+import { Separator } from "@/components/ui/separator";
 import { formatGBP } from "@/lib/format";
 import { CURRENT_RATES, LAST_UPDATED, PLAN_CONFIGS } from "@/lib/loans/plans";
 
@@ -257,7 +258,10 @@ export function OurDataPage() {
                       <HugeiconsIcon icon={step.icon} className="size-4" />
                     </div>
                     {i < PIPELINE_STEPS.length - 1 && (
-                      <div className="my-1.5 w-px flex-1 bg-border" />
+                      <Separator
+                        orientation="vertical"
+                        className="my-1.5 flex-1"
+                      />
                     )}
                   </div>
                   <div

--- a/src/components/quiz/ResultScreen.tsx
+++ b/src/components/quiz/ResultScreen.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect } from "react";
 import type { PlanType } from "@/lib/loans/types";
 import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
 import { currencyFormatter } from "@/constants";
 import { useLoanActions } from "@/context/LoanContext";
 import { trackQuizCompleted, trackQuizRestarted } from "@/lib/analytics";
@@ -83,7 +84,7 @@ export function ResultScreen({
                   </dd>
                 </div>
 
-                <div className="h-px bg-border" />
+                <Separator />
 
                 <div className="flex items-center justify-between">
                   <dt className="text-muted-foreground">Repayment rate</dt>
@@ -93,7 +94,7 @@ export function ResultScreen({
                   </dd>
                 </div>
 
-                <div className="h-px bg-border" />
+                <Separator />
 
                 <div className="flex items-center justify-between">
                   <dt className="text-muted-foreground">Write-off period</dt>

--- a/src/components/shared/SalaryGrowthBadge.tsx
+++ b/src/components/shared/SalaryGrowthBadge.tsx
@@ -8,6 +8,7 @@ import {
   PopoverTrigger,
   PopoverContent,
 } from "@/components/ui/popover";
+import { Separator } from "@/components/ui/separator";
 import { SALARY_GROWTH_OPTIONS, currencyFormatter } from "@/constants";
 import { useAssumptionsWizard } from "@/context/AssumptionsWizardContext";
 import {
@@ -69,7 +70,7 @@ export function SalaryGrowthBadge() {
           ) : null}
           .
         </p>
-        <div className="my-2 h-px bg-border" />
+        <Separator className="my-2" />
         <button
           type="button"
           onClick={() => {

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
+import { cn } from "@/lib/utils";
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };


### PR DESCRIPTION
## Summary
Replace 7 hand-written divider elements (`<div class="h-px bg-border">`, `<hr>`, etc.) across 5 components with the shadcn `Separator` component. This adds proper `role="separator"` semantics and consolidates divider styling into a single reusable component.

## Context
The codebase had multiple ad-hoc divider patterns. The shadcn `Separator` (backed by `@base-ui/react`) provides the same visual result with correct ARIA semantics. The component was added via `npx shadcn@latest add separator` and supports both horizontal (default) and vertical orientations.