### PR TITLE
fix: make insight text respect inflation toggle

### DIFF
--- a/src/hooks/useResultSummary.test.tsx
+++ b/src/hooks/useResultSummary.test.tsx
@@ -219,6 +219,30 @@ describe("useResultSummary", () => {
     });
   });
 
+  it("insight description changes when showPresentValue is true", async () => {
+    const { result: nominalResult } = renderHook(() => useResultSummary(), {
+      wrapper: createWrapper({
+        showPresentValue: false,
+        discountRate: 0.05,
+      }),
+    });
+
+    const { result: pvResult } = renderHook(() => useResultSummary(), {
+      wrapper: createWrapper({
+        showPresentValue: true,
+        discountRate: 0.05,
+      }),
+    });
+
+    await waitFor(() => {
+      expect(nominalResult.current.insight).not.toBeNull();
+      expect(pvResult.current.insight).not.toBeNull();
+      expect(pvResult.current.insight?.description).not.toBe(
+        nominalResult.current.insight?.description,
+      );
+    });
+  });
+
   it("returns different results for different plan types", async () => {
     const { result: plan2Result } = renderHook(() => useResultSummary(), {
       wrapper: createWrapper({

--- a/src/utils/insights.test.ts
+++ b/src/utils/insights.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { generateInsight } from "./insights";
+import type { Loan } from "@/lib/loans/types";
+
+const plan2Loan: Loan = { planType: "PLAN_2", balance: 50_000 };
+
+describe("generateInsight", () => {
+  it("returns null for zero balance", () => {
+    const result = generateInsight(45_000, {
+      loans: [{ planType: "PLAN_2", balance: 0 }],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty loans array", () => {
+    const result = generateInsight(45_000, { loans: [] });
+    expect(result).toBeNull();
+  });
+
+  it("classifies middle-earner in peak repayment zone", () => {
+    const result = generateInsight(60_000, { loans: [plan2Loan] });
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("middle-earner");
+    expect(result?.title).toContain("peak repayment zone");
+    expect(result?.description).toContain("in total");
+  });
+
+  it("classifies low-earner whose loan gets written off", () => {
+    const result = generateInsight(22_000, { loans: [plan2Loan] });
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("low-earner");
+    expect(result?.title).toContain("written off");
+  });
+
+  it("classifies high-earner who pays off quickly", () => {
+    const result = generateInsight(100_000, {
+      loans: [{ planType: "PLAN_2", balance: 20_000 }],
+    });
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("high-earner");
+    expect(result?.title).toContain("pay off quickly");
+  });
+
+  it("uses custom rpiRate and boeBaseRate when provided", () => {
+    const withDefaults = generateInsight(60_000, { loans: [plan2Loan] });
+    const withCustomRates = generateInsight(60_000, {
+      loans: [plan2Loan],
+      rpiRate: 0.1,
+      boeBaseRate: 0.08,
+    });
+
+    expect(withDefaults).not.toBeNull();
+    expect(withCustomRates).not.toBeNull();
+    // With much higher rates, the description should differ
+    expect(withCustomRates?.description).not.toBe(withDefaults?.description);
+  });
+
+  it("shows lower figures when discountRate is applied", () => {
+    const nominal = generateInsight(60_000, { loans: [plan2Loan] });
+    const pvAdjusted = generateInsight(60_000, {
+      loans: [plan2Loan],
+      discountRate: 0.05,
+    });
+
+    expect(nominal).not.toBeNull();
+    expect(pvAdjusted).not.toBeNull();
+    // Both should be middle-earner (zone classification unchanged)
+    expect(nominal?.type).toBe("middle-earner");
+    expect(pvAdjusted?.type).toBe("middle-earner");
+    // PV-adjusted total should be lower — extract the GBP amount from description
+    const extractAmount = (desc: string) => {
+      const match = desc.match(/£([\d,]+)/);
+      return match ? parseInt(match[1].replace(/,/g, ""), 10) : 0;
+    };
+    const nominalAmount = extractAmount(nominal?.description ?? "");
+    const pvAmount = extractAmount(pvAdjusted?.description ?? "");
+    expect(pvAmount).toBeLessThan(nominalAmount);
+  });
+
+  it("zone classification is unchanged by discountRate", () => {
+    const nominal = generateInsight(60_000, { loans: [plan2Loan] });
+    const pvAdjusted = generateInsight(60_000, {
+      loans: [plan2Loan],
+      discountRate: 0.1,
+    });
+
+    expect(nominal?.type).toBe(pvAdjusted?.type);
+  });
+
+  it("discountRate of 0 behaves as no discount", () => {
+    const noDiscount = generateInsight(60_000, { loans: [plan2Loan] });
+    const zeroDiscount = generateInsight(60_000, {
+      loans: [plan2Loan],
+      discountRate: 0,
+    });
+
+    expect(noDiscount?.description).toBe(zeroDiscount?.description);
+  });
+
+  it("handles high-earner with negative displayOverpaymentRatio under PV", () => {
+    const result = generateInsight(120_000, {
+      loans: [{ planType: "PLAN_2", balance: 30_000 }],
+      discountRate: 0.15,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("high-earner");
+    expect(result?.description).toContain("less in today's money");
+  });
+
+  it("low-earner PV adjustment reduces paid percentage", () => {
+    const nominal = generateInsight(35_000, { loans: [plan2Loan] });
+    const pvAdjusted = generateInsight(35_000, {
+      loans: [plan2Loan],
+      discountRate: 0.05,
+    });
+
+    expect(nominal?.type).toBe("low-earner");
+    expect(pvAdjusted?.type).toBe("low-earner");
+    // PV should show lower percentage
+    const extractPercent = (desc: string) => {
+      const match = desc.match(/(\d+)%/);
+      return match ? parseInt(match[1], 10) : 0;
+    };
+    const nominalPercent = extractPercent(nominal?.description ?? "");
+    const pvPercent = extractPercent(pvAdjusted?.description ?? "");
+    expect(pvPercent).toBeLessThanOrEqual(nominalPercent);
+  });
+});

--- a/src/utils/insights.ts
+++ b/src/utils/insights.ts
@@ -1,6 +1,7 @@
 import type { Loan, SimulationTimeSeries } from "@/lib/loans/types";
 import { simulate } from "@/lib/loans/engine";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
+import { pvTotal } from "@/utils/present-value";
 
 export type InsightType = "low-earner" | "middle-earner" | "high-earner";
 
@@ -23,6 +24,9 @@ interface InsightConfig {
   loans: Loan[];
   salaryGrowthRate?: number;
   thresholdGrowthRate?: number;
+  rpiRate?: number;
+  boeBaseRate?: number;
+  discountRate?: number;
 }
 
 /**
@@ -45,16 +49,6 @@ function willBeWrittenOff(result: SimulationTimeSeries): boolean {
 }
 
 /**
- * Calculates amount overpaid compared to original loan balance.
- */
-function calculateOverpayment(
-  result: SimulationTimeSeries,
-  principal: number,
-): number {
-  return result.summary.totalPaid - principal;
-}
-
-/**
  * Generates a personalized insight based on salary and loan configuration.
  *
  * Categorizes the user into one of three zones:
@@ -66,7 +60,14 @@ export function generateInsight(
   salary: number,
   config: InsightConfig,
 ): Insight | null {
-  const { loans, salaryGrowthRate = 0, thresholdGrowthRate = 0 } = config;
+  const {
+    loans,
+    salaryGrowthRate = 0,
+    thresholdGrowthRate = 0,
+    rpiRate,
+    boeBaseRate,
+    discountRate,
+  } = config;
 
   const principal = loans.reduce((s, l) => s + l.balance, 0);
 
@@ -82,23 +83,42 @@ export function generateInsight(
     monthsElapsed: 0,
     salaryGrowthRate,
     thresholdGrowthRate,
+    rpiRate,
+    boeBaseRate,
+  });
+
+  // Nominal values used for zone classification (thresholds calibrated to nominal)
+  const nominalTotalPaid = result.summary.totalPaid;
+
+  // Display values: PV-adjusted when discount rate is active, nominal otherwise
+  const displayTotalPaid =
+    discountRate && discountRate > 0
+      ? pvTotal(
+          result.snapshots.map((s) => ({
+            month: s.month,
+            amount: s.totalRepayment,
+          })),
+          discountRate,
+        )
+      : nominalTotalPaid;
+  const displayOverpayment = displayTotalPaid - principal;
+  const displayOverpaymentRatio =
+    principal > 0 ? displayOverpayment / principal : 0;
+
+  const gbp = new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+    maximumFractionDigits: 0,
   });
 
   const writeOffYears = getWriteOffYears(loans);
-  const overpayment = calculateOverpayment(result, principal);
-  const overpaymentRatio = principal > 0 ? overpayment / principal : 0;
 
-  // Peak repayment zone: paying 70%+ more than what you borrowed
+  // Peak repayment zone: paying 70%+ more than what you borrowed (nominal classification)
   if (
     principal > 0 &&
-    result.summary.totalPaid > PEAK_ZONE_REPAYMENT_MULTIPLIER * principal
+    nominalTotalPaid > PEAK_ZONE_REPAYMENT_MULTIPLIER * principal
   ) {
-    const gbp = new Intl.NumberFormat("en-GB", {
-      style: "currency",
-      currency: "GBP",
-      maximumFractionDigits: 0,
-    });
-    const formattedTotalPaid = gbp.format(result.summary.totalPaid);
+    const formattedTotalPaid = gbp.format(displayTotalPaid);
     const formattedPrincipal = gbp.format(principal);
 
     return {
@@ -112,7 +132,7 @@ export function generateInsight(
     };
   }
 
-  // Low earner: loan will be written off with remaining balance
+  // Low earner: loan will be written off with remaining balance (nominal classification)
   if (willBeWrittenOff(result)) {
     const remaining = result.summary.perLoan.reduce(
       (sum, r) => sum + r.remainingBalance,
@@ -120,12 +140,12 @@ export function generateInsight(
     );
 
     if (remaining > 0) {
-      const paidPercent =
-        principal > 0 ? (result.summary.totalPaid / principal) * 100 : 0;
+      const displayPaidPercent =
+        principal > 0 ? (displayTotalPaid / principal) * 100 : 0;
       const description =
-        overpaymentRatio > 0
-          ? `You'll pay ${(overpaymentRatio * 100).toFixed(0)}% more than you borrowed, but it's written off after ${String(writeOffYears)} years — reasonable given inflation. Treat repayments as a graduate tax, not a debt.`
-          : `You'll only repay ${paidPercent.toFixed(0)}% of what you borrowed before the rest is written off after ${String(writeOffYears)} years. Treat repayments as a graduate tax, not a debt.`;
+        displayOverpaymentRatio > 0
+          ? `You'll pay ${(displayOverpaymentRatio * 100).toFixed(0)}% more than you borrowed, but it's written off after ${String(writeOffYears)} years — reasonable given inflation. Treat repayments as a graduate tax, not a debt.`
+          : `You'll only repay ${displayPaidPercent.toFixed(0)}% of what you borrowed before the rest is written off after ${String(writeOffYears)} years. Treat repayments as a graduate tax, not a debt.`;
 
       return {
         type: "low-earner",
@@ -135,14 +155,20 @@ export function generateInsight(
     }
   }
 
-  // High earner: pays off before write-off with reasonable interest
+  // High earner: pays off before write-off with reasonable interest (nominal classification)
   const yearsToPayoff = (result.summary.monthsToPayoff / 12).toFixed(1);
-  const interestPercent = (overpaymentRatio * 100).toFixed(0);
+
+  let interestDescription: string;
+  if (displayOverpaymentRatio < 0) {
+    interestDescription = `paying ${Math.abs(displayOverpaymentRatio * 100).toFixed(0)}% less in today's money`;
+  } else {
+    interestDescription = `paying ${(displayOverpaymentRatio * 100).toFixed(0)}% more than you borrowed`;
+  }
 
   return {
     type: "high-earner",
     title: "You'll pay off quickly",
-    description: `You'll clear your loan in about ${yearsToPayoff} years, paying ${interestPercent}% more than you borrowed.`,
+    description: `You'll clear your loan in about ${yearsToPayoff} years, ${interestDescription}.`,
     cta: {
       text: "See if overpaying saves you money",
       href: "/overpay",

--- a/src/workers/simulation.worker.ts
+++ b/src/workers/simulation.worker.ts
@@ -184,6 +184,9 @@ function handleInsight(payload: InsightPayload): {
     loans: payload.loans,
     salaryGrowthRate: payload.salaryGrowthRate,
     thresholdGrowthRate: payload.thresholdGrowthRate,
+    rpiRate: payload.rpiRate,
+    boeBaseRate: payload.boeBaseRate,
+    discountRate: payload.discountRate,
   });
 
   if (totalBalance <= 0) {


### PR DESCRIPTION
## Summary

The insight text below the Total Repayment stat ignored the "Adjust for inflation" toggle — it always showed nominal figures even when the stat above it was PV-adjusted. This fixes both sub-bugs: `generateInsight()` now receives the user's configured `rpiRate`/`boeBaseRate` (instead of falling back to engine defaults), and applies `pvTotal()` to compute display values when a discount rate is active.

## Context

Zone classification (middle/low/high earner) stays nominal — the 1.7x threshold was calibrated against nominal cash flows and describes a structural property of the loan. Only the display text (formatted currency, percentages) changes with PV. An edge case is handled where PV makes the high-earner overpayment ratio negative, using "paying X% less in today's money" wording instead.