### PR TITLE
feat: add shadcn Table component and dynamic scroll fade for tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,7 @@ Local steps:
 - Barrel files — import from source modules directly
 - Default exports (exception: `page.tsx` / `layout.tsx`)
 - `Context.Provider` / `useContext` — use `<Context value={...}>` and `use(Context)` (React 19)
-
-**Lint errors:** Run `pnpm lint --fix` before manual fixes.
+- Manually fix lint error that could have been fixed with `--fix`.
 
 ## Testing
 

--- a/src/components/guides/plan-2-vs-plan-5/ComparisonTable.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/ComparisonTable.tsx
@@ -1,3 +1,12 @@
+import { ScrollFadeWrapper } from "@/components/shared/ScrollFadeWrapper";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
 
 const plan2 = PLAN_DISPLAY_INFO.PLAN_2;
@@ -37,39 +46,25 @@ const rows = [
 
 export function ComparisonTable() {
   return (
-    <div className="overflow-x-auto rounded-lg border">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b bg-muted/50">
-            <th
-              scope="col"
-              className="px-4 py-3 text-left font-medium text-muted-foreground"
-            >
-              Feature
-            </th>
-            <th scope="col" className="px-4 py-3 text-left font-medium">
-              Plan 2
-            </th>
-            <th scope="col" className="px-4 py-3 text-left font-medium">
-              Plan 5
-            </th>
-          </tr>
-        </thead>
-        <tbody>
+    <ScrollFadeWrapper className="rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead scope="col">Feature</TableHead>
+            <TableHead scope="col">Plan 2</TableHead>
+            <TableHead scope="col">Plan 5</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
           {rows.map((row) => (
-            <tr key={row.label} className="border-b last:border-b-0">
-              <th
-                scope="row"
-                className="px-4 py-3 text-left font-medium text-muted-foreground"
-              >
-                {row.label}
-              </th>
-              <td className="px-4 py-3">{row.plan2}</td>
-              <td className="px-4 py-3">{row.plan5}</td>
-            </tr>
+            <TableRow key={row.label}>
+              <TableHead scope="row">{row.label}</TableHead>
+              <TableCell>{row.plan2}</TableCell>
+              <TableCell>{row.plan5}</TableCell>
+            </TableRow>
           ))}
-        </tbody>
-      </table>
-    </div>
+        </TableBody>
+      </Table>
+    </ScrollFadeWrapper>
   );
 }

--- a/src/components/our-data/OurDataPage.tsx
+++ b/src/components/our-data/OurDataPage.tsx
@@ -12,6 +12,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { Footer } from "@/components/layout/Footer";
 import { Header } from "@/components/layout/Header";
+import { ScrollFadeWrapper } from "@/components/shared/ScrollFadeWrapper";
 import { Heading } from "@/components/typography/Heading";
 import {
   Breadcrumb,
@@ -21,6 +22,14 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { formatGBP } from "@/lib/format";
 import { CURRENT_RATES, LAST_UPDATED, PLAN_CONFIGS } from "@/lib/loans/plans";
 
@@ -219,45 +228,32 @@ export function OurDataPage() {
             </div>
 
             {/* Plan table */}
-            <div className="overflow-x-auto rounded-xl ring-1 ring-foreground/10">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b bg-muted/50 text-left">
-                    <th className="px-4 py-3 text-xs font-medium tracking-widest text-muted-foreground uppercase">
-                      Plan
-                    </th>
-                    <th className="px-4 py-3 text-xs font-medium tracking-widest text-muted-foreground uppercase">
-                      Annual threshold
-                    </th>
-                    <th className="px-4 py-3 text-xs font-medium tracking-widest text-muted-foreground uppercase">
-                      Rate
-                    </th>
-                    <th className="px-4 py-3 text-xs font-medium tracking-widest text-muted-foreground uppercase">
-                      Write-off
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-border">
+            <ScrollFadeWrapper className="rounded-xl ring-1 ring-foreground/10">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Plan</TableHead>
+                    <TableHead>Annual threshold</TableHead>
+                    <TableHead>Rate</TableHead>
+                    <TableHead>Write-off</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
                   {plans.map((p) => (
-                    <tr
-                      key={p.label}
-                      className="transition-colors hover:bg-muted/30"
-                    >
-                      <td className="px-4 py-3 font-medium">{p.label}</td>
-                      <td className="px-4 py-3 font-mono text-muted-foreground tabular-nums">
+                    <TableRow key={p.label}>
+                      <TableCell className="font-medium">{p.label}</TableCell>
+                      <TableCell className="font-mono tabular-nums">
                         {formatGBP(p.threshold)}
-                      </td>
-                      <td className="px-4 py-3 font-mono text-muted-foreground tabular-nums">
+                      </TableCell>
+                      <TableCell className="font-mono tabular-nums">
                         {Math.round(p.rate * 100)}%
-                      </td>
-                      <td className="px-4 py-3 text-muted-foreground">
-                        {p.writeOff} years
-                      </td>
-                    </tr>
+                      </TableCell>
+                      <TableCell>{p.writeOff} years</TableCell>
+                    </TableRow>
                   ))}
-                </tbody>
-              </table>
-            </div>
+                </TableBody>
+              </Table>
+            </ScrollFadeWrapper>
           </section>
 
           {/* How it stays current */}

--- a/src/components/shared/ScrollFadeWrapper.tsx
+++ b/src/components/shared/ScrollFadeWrapper.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRef, useState, useEffect, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+function ScrollFadeWrapper({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [showFade, setShowFade] = useState(false);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const scrollable = container.querySelector<HTMLElement>(
+      '[data-slot="table-container"]',
+    );
+    if (!scrollable) return;
+
+    const update = () => {
+      const { scrollLeft, scrollWidth, clientWidth } = scrollable;
+      setShowFade(scrollLeft + clientWidth < scrollWidth - 1);
+    };
+
+    update();
+    scrollable.addEventListener("scroll", update, { passive: true });
+    const observer = new ResizeObserver(update);
+    observer.observe(scrollable);
+
+    return () => {
+      scrollable.removeEventListener("scroll", update);
+      observer.disconnect();
+    };
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn("relative overflow-hidden", className)}
+    >
+      <div
+        className={cn(
+          "pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-linear-to-l from-background to-transparent transition-opacity",
+          showFade ? "opacity-100" : "opacity-0",
+        )}
+      />
+      {children}
+    </div>
+  );
+}
+
+export { ScrollFadeWrapper };

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  );
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  );
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+// Changed from shadcn default `text-foreground` to `text-muted-foreground`
+// so header cells are visually subordinate to body content.
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-muted-foreground [&:has([role=checkbox])]:pr-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+};


### PR DESCRIPTION
## Summary
Adds a shadcn `Table` component and a `ScrollFadeWrapper` that dynamically shows/hides a right-edge fade gradient based on horizontal scroll position. Both existing tables (Plan 2 vs Plan 5 comparison and Our Data plan summary) are migrated to use these shared components.

## Context
The previous static fade overlay was always visible on mobile via `sm:hidden`, even when the table was scrolled fully right. Since tables have row borders, a padding-based approach (like PresetPills) wasn't viable. The new `ScrollFadeWrapper` uses a scroll listener + `ResizeObserver` to detect overflow and toggle the fade with a smooth opacity transition — no breakpoint media query needed, as the JS naturally hides the fade when there's no overflow on wider screens.

`TableHead` uses `text-muted-foreground` instead of shadcn's default `text-foreground` so header cells are visually subordinate to body content (noted with a comment in the component).