### PR TITLE
ci: shard Playwright e2e tests into 2 parallel jobs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -54,6 +54,11 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2]
+        shardTotal: [2]
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
@@ -67,11 +72,11 @@ jobs:
       - name: Build app
         run: pnpm build
       - name: Run e2e tests
-        run: pnpm test:e2e
+        run: pnpm test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - name: Upload test report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v6
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.shardIndex }}
           path: playwright-report/
           retention-days: 7


### PR DESCRIPTION
## Summary
Splits the e2e job into 2 parallel shards using Playwright's built-in `--shard` flag and a GitHub Actions matrix strategy. This halves the wall-clock time for e2e tests on PRs.

## Context
Each shard uploads its own artifact (`playwright-report-1`, `playwright-report-2`) to avoid collisions. `fail-fast: false` ensures both shards run to completion even if one fails, so you always get the full picture.