### PR TITLE
fix: prevent layout shift in insight callouts on mobile

### DIFF
--- a/src/components/home/ResultSummary.tsx
+++ b/src/components/home/ResultSummary.tsx
@@ -76,7 +76,7 @@ export function ResultSummary() {
             <StatBlockSkeleton />
           </div>
         </div>
-        <div className="relative flex min-h-26.5 items-center gap-2.5 border-t border-border px-4 py-3 xs:px-5 sm:min-h-21.5 lg:min-h-16.5">
+        <div className="relative flex min-h-37 items-center gap-2.5 border-t border-border px-4 py-3 xs:min-h-32 xs:px-5 sm:min-h-21.5 lg:min-h-16.5">
           <Skeleton className="h-4 w-full max-w-md" />
         </div>
       </div>
@@ -138,7 +138,7 @@ export function ResultSummary() {
       </div>
 
       {/* Personalized insight footer — fixed min-h to prevent layout shift */}
-      <div className="relative flex min-h-26.5 items-center gap-2.5 border-t border-border px-4 py-3 xs:px-5 sm:min-h-21.5 lg:min-h-16.5">
+      <div className="relative flex min-h-37 items-center gap-2.5 border-t border-border px-4 py-3 xs:min-h-32 xs:px-5 sm:min-h-21.5 lg:min-h-16.5">
         {insight ? (
           <>
             <HugeiconsIcon

--- a/src/components/overpay/OverpayPage.tsx
+++ b/src/components/overpay/OverpayPage.tsx
@@ -37,7 +37,7 @@ function OverpayPageSkeleton() {
   return (
     <>
       {/* Verdict skeleton */}
-      <Skeleton className="h-28 w-full rounded-lg" />
+      <Skeleton className="min-h-43 w-full rounded-lg xs:min-h-38 sm:min-h-29 md:min-h-0" />
 
       {/* Chart + cards grid skeleton */}
       <div className="grid gap-6 md:flex">

--- a/src/components/overpay/OverpayVerdict.tsx
+++ b/src/components/overpay/OverpayVerdict.tsx
@@ -51,20 +51,26 @@ export function OverpayVerdict({
   const isIdle = recommendation === "idle";
 
   return (
-    <Alert className={config.className} role="status" aria-live="polite">
-      <HugeiconsIcon
-        icon={config.icon}
-        className="size-5 text-foreground/70"
-        strokeWidth={2}
-      />
-      <AlertTitle>{config.title}</AlertTitle>
-      <AlertDescription>{reason}</AlertDescription>
-      <p className="col-span-full mt-2 text-xs text-muted-foreground">
-        {isIdle
-          ? "Adjust the inputs below to explore different scenarios."
-          : "This is an estimate, not financial advice. Consider speaking to a financial adviser."}
-      </p>
-    </Alert>
+    <div className="-mb-4 min-h-43 xs:min-h-38 sm:min-h-29 md:mb-0 md:min-h-0">
+      <Alert
+        className={`${config.className} py-3`}
+        role="status"
+        aria-live="polite"
+      >
+        <HugeiconsIcon
+          icon={config.icon}
+          className="size-5 text-foreground/70"
+          strokeWidth={2}
+        />
+        <AlertTitle>{config.title}</AlertTitle>
+        <AlertDescription>{reason}</AlertDescription>
+        <p className="col-span-full mt-2 text-xs text-muted-foreground">
+          {isIdle
+            ? "Adjust the inputs below to explore different scenarios."
+            : "This is an estimate, not financial advice. Consider speaking to a financial adviser."}
+        </p>
+      </Alert>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
The recent mobile font size increase (19px below sm breakpoint) caused insight callouts on both the home page and overpay page to shift in height when content changed — up to 48px of layout shift as different verdict/insight types produced different text lengths.

Fixes this by reserving space with responsive `min-h` values at each breakpoint, calibrated to the tallest content variant. Skeletons are updated to match.

## Context
- **ResultSummary** (home page): increased `min-h` on the insight footer from `min-h-26.5` to `min-h-37` and added `xs:min-h-32` to account for the larger font rendering.
- **OverpayVerdict** (overpay page): wrapped the Alert in a container div with `min-h` instead of putting it on the Alert itself, so the Alert sizes naturally and the reserved space sits invisibly below it. Added `py-3` for balanced padding and `-mb-4` to compensate for the extra reserved space on mobile.
- All `min-h` constraints are removed at `md` (768px+) where heights are naturally stable.