### PR TITLE
refactor: extract reusable PageLayout component

### DIFF
--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -1,8 +1,7 @@
 import { ArrowRight01Icon, BookOpen01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
-import { Footer } from "@/components/layout/Footer";
-import { Header } from "@/components/layout/Header";
+import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import {
   Breadcrumb,
@@ -16,64 +15,57 @@ import { GUIDES } from "@/lib/guides";
 
 export default function GuidesPage() {
   return (
-    <div className="flex min-h-screen flex-col">
-      <Header />
-      <main
-        id="main-content"
-        className="mx-auto w-full max-w-4xl flex-1 space-y-8 overflow-x-hidden px-3 pt-13 pb-6 md:pb-8"
-      >
-        <div className="space-y-4">
-          <Breadcrumb>
-            <BreadcrumbList>
-              <BreadcrumbItem>
-                <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
-              </BreadcrumbItem>
-              <BreadcrumbSeparator />
-              <BreadcrumbItem>
-                <BreadcrumbPage>Guides</BreadcrumbPage>
-              </BreadcrumbItem>
-            </BreadcrumbList>
-          </Breadcrumb>
+    <PageLayout>
+      <div className="space-y-4">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>Guides</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
 
-          <div className="space-y-2">
-            <Heading as="h1">Student Loan Guides</Heading>
-            <p className="text-muted-foreground">
-              In-depth guides to help you understand UK student loan repayment,
-              interest, and how it fits into your wider finances.
-            </p>
-          </div>
+        <div className="space-y-2">
+          <Heading as="h1">Student Loan Guides</Heading>
+          <p className="text-muted-foreground">
+            In-depth guides to help you understand UK student loan repayment,
+            interest, and how it fits into your wider finances.
+          </p>
         </div>
+      </div>
 
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {GUIDES.map((guide) => (
-            <Link
-              key={guide.slug}
-              href={`/guides/${guide.slug}`}
-              className="group block h-full"
-            >
-              <div className="flex h-full flex-col rounded-xl bg-card p-5 ring-1 ring-foreground/10 transition-all duration-200 hover:bg-accent hover:ring-primary/30">
-                <div className="mb-3 flex items-center gap-3">
-                  <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
-                    <HugeiconsIcon icon={BookOpen01Icon} className="size-5" />
-                  </div>
-                  <h2 className="font-medium">{guide.title}</h2>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {GUIDES.map((guide) => (
+          <Link
+            key={guide.slug}
+            href={`/guides/${guide.slug}`}
+            className="group block h-full"
+          >
+            <div className="flex h-full flex-col rounded-xl bg-card p-5 ring-1 ring-foreground/10 transition-all duration-200 hover:bg-accent hover:ring-primary/30">
+              <div className="mb-3 flex items-center gap-3">
+                <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
+                  <HugeiconsIcon icon={BookOpen01Icon} className="size-5" />
                 </div>
-                <p className="mb-4 flex-1 text-sm text-muted-foreground">
-                  {guide.description}
-                </p>
-                <div className="flex items-center gap-1 text-sm font-medium text-primary">
-                  Read Guide
-                  <HugeiconsIcon
-                    icon={ArrowRight01Icon}
-                    className="size-4 transition-transform group-hover:translate-x-0.5"
-                  />
-                </div>
+                <h2 className="font-medium">{guide.title}</h2>
               </div>
-            </Link>
-          ))}
-        </div>
-      </main>
-      <Footer />
-    </div>
+              <p className="mb-4 flex-1 text-sm text-muted-foreground">
+                {guide.description}
+              </p>
+              <div className="flex items-center gap-1 text-sm font-medium text-primary">
+                Read Guide
+                <HugeiconsIcon
+                  icon={ArrowRight01Icon}
+                  className="size-4 transition-transform group-hover:translate-x-0.5"
+                />
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </PageLayout>
   );
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,20 +1,15 @@
 import { HeroSection } from "./home/HeroSection";
 import { SecondaryCharts } from "./home/SecondaryCharts";
 import { ToolLinks } from "./home/ToolLinks";
-import { Footer } from "./layout/Footer";
-import { Header } from "./layout/Header";
+import { PageLayout } from "./layout/PageLayout";
 import { AssumptionsCallout } from "./shared/AssumptionsCallout";
 import { PlanFromQuery } from "./shared/PlanFromQuery";
 
 function App() {
   return (
-    <div className="flex min-h-screen flex-col">
+    <>
       <PlanFromQuery />
-      <Header />
-      <main
-        id="main-content"
-        className="mx-auto w-full max-w-4xl flex-1 space-y-8 px-3 pt-8 pb-6 sm:pt-18 md:pb-8"
-      >
+      <PageLayout>
         <HeroSection />
 
         <SecondaryCharts />
@@ -22,9 +17,8 @@ function App() {
         <AssumptionsCallout />
 
         <ToolLinks />
-      </main>
-      <Footer />
-    </div>
+      </PageLayout>
+    </>
   );
 }
 

--- a/src/components/brand/BrandGuidelinesPage.tsx
+++ b/src/components/brand/BrandGuidelinesPage.tsx
@@ -1,8 +1,7 @@
 import Link from "next/link";
 import { BrandIcon, BRAND_HEX } from "./BrandIcon";
 import { BrandLogo } from "./BrandLogo";
-import { Footer } from "@/components/layout/Footer";
-import { Header } from "@/components/layout/Header";
+import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import {
   Breadcrumb,
@@ -86,199 +85,195 @@ const LOGO_ANATOMY = [
 
 export function BrandGuidelinesPage() {
   return (
-    <div className="flex min-h-screen flex-col bg-background">
-      <Header />
-      <main className="mx-auto w-full max-w-4xl flex-1 px-4 py-6 md:px-6 md:py-8">
-        <div className="mb-8">
-          <Breadcrumb>
-            <BreadcrumbList>
-              <BreadcrumbItem>
-                <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
-              </BreadcrumbItem>
-              <BreadcrumbSeparator />
-              <BreadcrumbItem>
-                <BreadcrumbPage>Brand Guidelines</BreadcrumbPage>
-              </BreadcrumbItem>
-            </BreadcrumbList>
-          </Breadcrumb>
+    <PageLayout>
+      <div className="mb-8">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>Brand Guidelines</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      </div>
+
+      {/* Header */}
+      <header className="mb-12">
+        <Heading as="h1" className="text-3xl">
+          Brand Guidelines
+        </Heading>
+        <p className="mt-2 font-display text-base text-muted-foreground">
+          studentloanstudy.uk
+        </p>
+      </header>
+
+      {/* Divider */}
+      <Separator className="mb-12" />
+
+      {/* Section: Primary Logo */}
+      <Section title="PRIMARY LOGO">
+        <div className="grid gap-8 md:grid-cols-2">
+          {/* Dark background */}
+          <div className="flex flex-col gap-4">
+            <span className="text-xs text-muted-foreground">On Dark</span>
+            <Card className="dark flex items-center justify-center p-8">
+              <BrandLogo />
+            </Card>
+          </div>
+          {/* Light background */}
+          <div className="flex flex-col gap-4">
+            <span className="text-xs text-muted-foreground">On Light</span>
+            <Card className="light flex items-center justify-center p-8">
+              <BrandLogo />
+            </Card>
+          </div>
         </div>
+      </Section>
 
-        {/* Header */}
-        <header className="mb-12">
-          <Heading as="h1" className="text-3xl">
-            Brand Guidelines
-          </Heading>
-          <p className="mt-2 font-display text-base text-muted-foreground">
-            studentloanstudy.uk
-          </p>
-        </header>
-
-        {/* Divider */}
-        <Separator className="mb-12" />
-
-        {/* Section: Primary Logo */}
-        <Section title="PRIMARY LOGO">
-          <div className="grid gap-8 md:grid-cols-2">
-            {/* Dark background */}
-            <div className="flex flex-col gap-4">
-              <span className="text-xs text-muted-foreground">On Dark</span>
-              <Card className="dark flex items-center justify-center p-8">
-                <BrandLogo />
-              </Card>
+      {/* Section: Icon / Favicon */}
+      <Section title="ICON / FAVICON">
+        <div className="flex flex-wrap items-end gap-6">
+          {ICON_SIZES.map((size) => (
+            <div key={size} className="flex flex-col items-center gap-2">
+              <BrandIcon size={size} />
+              <span className="text-xs text-muted-foreground">{size}px</span>
             </div>
-            {/* Light background */}
-            <div className="flex flex-col gap-4">
-              <span className="text-xs text-muted-foreground">On Light</span>
-              <Card className="light flex items-center justify-center p-8">
-                <BrandLogo />
-              </Card>
+          ))}
+        </div>
+      </Section>
+
+      {/* Section: Colors (consolidated) */}
+      <Section title="COLORS">
+        <div className="space-y-10">
+          {/* Brand */}
+          <div>
+            <SubgroupLabel>Brand</SubgroupLabel>
+            <div className="grid grid-cols-2 gap-4">
+              {BRAND_SWATCHES.map((swatch) => (
+                <ColorSwatch
+                  key={swatch.name}
+                  name={swatch.name}
+                  hex={swatch.hex}
+                />
+              ))}
             </div>
           </div>
-        </Section>
 
-        {/* Section: Icon / Favicon */}
-        <Section title="ICON / FAVICON">
-          <div className="flex flex-wrap items-end gap-6">
-            {ICON_SIZES.map((size) => (
-              <div key={size} className="flex flex-col items-center gap-2">
-                <BrandIcon size={size} />
-                <span className="text-xs text-muted-foreground">{size}px</span>
-              </div>
-            ))}
-          </div>
-        </Section>
-
-        {/* Section: Colors (consolidated) */}
-        <Section title="COLORS">
-          <div className="space-y-10">
-            {/* Brand */}
-            <div>
-              <SubgroupLabel>Brand</SubgroupLabel>
-              <div className="grid grid-cols-2 gap-4">
-                {BRAND_SWATCHES.map((swatch) => (
-                  <ColorSwatch
-                    key={swatch.name}
-                    name={swatch.name}
-                    hex={swatch.hex}
+          {/* Core */}
+          <div>
+            <SubgroupLabel>Core</SubgroupLabel>
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+              {CORE_TOKENS.map((token) => (
+                <div key={token.var} className="flex flex-col gap-3">
+                  <div
+                    className="h-14 w-full rounded-lg ring-1 ring-border"
+                    style={{ backgroundColor: `var(${token.var})` }}
                   />
-                ))}
-              </div>
-            </div>
-
-            {/* Core */}
-            <div>
-              <SubgroupLabel>Core</SubgroupLabel>
-              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
-                {CORE_TOKENS.map((token) => (
-                  <div key={token.var} className="flex flex-col gap-3">
-                    <div
-                      className="h-14 w-full rounded-lg ring-1 ring-border"
-                      style={{ backgroundColor: `var(${token.var})` }}
-                    />
-                    <div className="flex flex-col gap-0.5">
-                      <span className="font-display text-sm font-semibold text-foreground">
-                        {token.name}
-                      </span>
-                      <span className="font-mono text-xs text-muted-foreground">
-                        {token.var}
-                      </span>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            {/* Status */}
-            <div>
-              <SubgroupLabel>Status</SubgroupLabel>
-              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-                {STATUS_GROUPS.map((group) => (
-                  <div key={group.name} className="space-y-3">
+                  <div className="flex flex-col gap-0.5">
                     <span className="font-display text-sm font-semibold text-foreground">
-                      {group.name}
+                      {token.name}
                     </span>
-                    <div className="grid grid-cols-3 gap-2">
-                      {group.tokens.map((token) => (
-                        <div key={token.label} className="flex flex-col gap-2">
-                          <div
-                            className="h-10 w-full rounded-md ring-1 ring-border"
-                            style={{ backgroundColor: `var(${token.var})` }}
-                          />
-                          <span className="text-xs text-muted-foreground">
-                            {token.label}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
+                    <span className="font-mono text-xs text-muted-foreground">
+                      {token.var}
+                    </span>
                   </div>
-                ))}
-              </div>
-            </div>
-
-            {/* Chart */}
-            <div>
-              <SubgroupLabel>Chart</SubgroupLabel>
-              <div className="grid grid-cols-5 gap-4">
-                {CHART_TOKENS.map((token) => (
-                  <div key={token.var} className="flex flex-col gap-3">
-                    <div
-                      className="h-14 w-full rounded-lg ring-1 ring-border"
-                      style={{ backgroundColor: `var(${token.var})` }}
-                    />
-                    <div className="flex flex-col gap-0.5">
-                      <span className="font-display text-sm font-semibold text-foreground">
-                        {token.name}
-                      </span>
-                      <span className="font-mono text-xs text-muted-foreground">
-                        {token.var}
-                      </span>
-                    </div>
-                  </div>
-                ))}
-              </div>
+                </div>
+              ))}
             </div>
           </div>
-        </Section>
 
-        {/* Section: Typography */}
-        <Section title="TYPOGRAPHY">
-          <div className="grid gap-8 md:grid-cols-2">
-            <FontShowcase
-              name="Space Grotesk"
-              usage="Logo, Headings"
-              weights="Weights: 400, 700"
-              fontFamily="var(--font-display), 'Space Grotesk', sans-serif"
-              sampleWeight={700}
-            />
-            <FontShowcase
-              name="Manrope"
-              usage="Body, UI Elements"
-              weights="Weights: 400, 500, 600, 700"
-              fontFamily="var(--font-sans), 'Manrope', sans-serif"
-              sampleWeight={600}
-            />
+          {/* Status */}
+          <div>
+            <SubgroupLabel>Status</SubgroupLabel>
+            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+              {STATUS_GROUPS.map((group) => (
+                <div key={group.name} className="space-y-3">
+                  <span className="font-display text-sm font-semibold text-foreground">
+                    {group.name}
+                  </span>
+                  <div className="grid grid-cols-3 gap-2">
+                    {group.tokens.map((token) => (
+                      <div key={token.label} className="flex flex-col gap-2">
+                        <div
+                          className="h-10 w-full rounded-md ring-1 ring-border"
+                          style={{ backgroundColor: `var(${token.var})` }}
+                        />
+                        <span className="text-xs text-muted-foreground">
+                          {token.label}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
-        </Section>
 
-        {/* Section: Logo Anatomy */}
-        <Section title="LOGO ANATOMY">
-          <Card className="flex items-center gap-3.5 p-8">
-            <BrandLogo size="large" />
-          </Card>
-          <ul className="mt-6 space-y-3">
-            {LOGO_ANATOMY.map((point, index) => (
-              <li key={index} className="flex items-start gap-3">
-                <span className="mt-1.5 size-1.5 shrink-0 rounded-sm bg-primary" />
-                <span className="text-sm/relaxed text-muted-foreground">
-                  {point}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </Section>
-      </main>
-      <Footer />
-    </div>
+          {/* Chart */}
+          <div>
+            <SubgroupLabel>Chart</SubgroupLabel>
+            <div className="grid grid-cols-5 gap-4">
+              {CHART_TOKENS.map((token) => (
+                <div key={token.var} className="flex flex-col gap-3">
+                  <div
+                    className="h-14 w-full rounded-lg ring-1 ring-border"
+                    style={{ backgroundColor: `var(${token.var})` }}
+                  />
+                  <div className="flex flex-col gap-0.5">
+                    <span className="font-display text-sm font-semibold text-foreground">
+                      {token.name}
+                    </span>
+                    <span className="font-mono text-xs text-muted-foreground">
+                      {token.var}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </Section>
+
+      {/* Section: Typography */}
+      <Section title="TYPOGRAPHY">
+        <div className="grid gap-8 md:grid-cols-2">
+          <FontShowcase
+            name="Space Grotesk"
+            usage="Logo, Headings"
+            weights="Weights: 400, 700"
+            fontFamily="var(--font-display), 'Space Grotesk', sans-serif"
+            sampleWeight={700}
+          />
+          <FontShowcase
+            name="Manrope"
+            usage="Body, UI Elements"
+            weights="Weights: 400, 500, 600, 700"
+            fontFamily="var(--font-sans), 'Manrope', sans-serif"
+            sampleWeight={600}
+          />
+        </div>
+      </Section>
+
+      {/* Section: Logo Anatomy */}
+      <Section title="LOGO ANATOMY">
+        <Card className="flex items-center gap-3.5 p-8">
+          <BrandLogo size="large" />
+        </Card>
+        <ul className="mt-6 space-y-3">
+          {LOGO_ANATOMY.map((point, index) => (
+            <li key={index} className="flex items-start gap-3">
+              <span className="mt-1.5 size-1.5 shrink-0 rounded-sm bg-primary" />
+              <span className="text-sm/relaxed text-muted-foreground">
+                {point}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </Section>
+    </PageLayout>
   );
 }
 

--- a/src/components/guides/how-interest-works/InterestGuide.tsx
+++ b/src/components/guides/how-interest-works/InterestGuide.tsx
@@ -1,8 +1,7 @@
 import Link from "next/link";
 import { InterestRateChart } from "./InterestRateChart";
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
-import { Footer } from "@/components/layout/Footer";
-import { Header } from "@/components/layout/Header";
+import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import {
   Breadcrumb,
@@ -24,185 +23,174 @@ const monthlyInterest = Math.round((EXAMPLE_BALANCE * maxRate) / 100 / 12);
 
 export function InterestGuide() {
   return (
-    <div className="flex min-h-screen flex-col">
-      <Header />
-      <main
-        id="main-content"
-        className="mx-auto w-full max-w-4xl flex-1 px-3 pt-13 pb-6 md:pb-8"
-      >
-        <article className="space-y-8">
-          <div className="space-y-4">
-            <Breadcrumb>
-              <BreadcrumbList>
-                <BreadcrumbItem>
-                  <BreadcrumbLink render={<Link href="/" />}>
-                    Home
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbLink render={<Link href="/guides" />}>
-                    Guides
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbPage>How Interest Works</BreadcrumbPage>
-                </BreadcrumbItem>
-              </BreadcrumbList>
-            </Breadcrumb>
+    <PageLayout>
+      <article className="space-y-8">
+        <div className="space-y-4">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/guides" />}>
+                  Guides
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>How Interest Works</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
 
-            <Heading as="h1">How Interest Works on UK Student Loans</Heading>
-            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
-              Interest is one of the most confusing parts of student loans. Each
-              plan type calculates it differently, which means the amount your
-              balance grows varies depending on when you started university and
-              how much you earn.
+          <Heading as="h1">How Interest Works on UK Student Loans</Heading>
+          <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+            Interest is one of the most confusing parts of student loans. Each
+            plan type calculates it differently, which means the amount your
+            balance grows varies depending on when you started university and
+            how much you earn.
+          </p>
+        </div>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Plan 2: The Sliding Scale
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              Plan 2 has the most complex interest calculation. It uses a
+              sliding scale tied to your income, ranging from RPI (currently{" "}
+              {formatPercent(rpi)}) up to RPI + 3% (currently{" "}
+              {formatPercent(maxRate)}).
+            </p>
+            <ul className="list-disc space-y-1 pl-6">
+              <li>
+                Earning below the lower threshold of{" "}
+                <strong className="text-foreground">
+                  {formatGBP(PLAN_CONFIGS.PLAN_2.interestLowerThreshold)}
+                </strong>
+                : you pay RPI only ({formatPercent(rpi)})
+              </li>
+              <li>
+                Earning above the upper threshold of{" "}
+                <strong className="text-foreground">
+                  {formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}
+                </strong>
+                : you pay the maximum of RPI + 3% ({formatPercent(maxRate)})
+              </li>
+              <li>
+                Earning between the two: the rate scales linearly from{" "}
+                {formatPercent(rpi)} up to {formatPercent(maxRate)}
+              </li>
+            </ul>
+            <p>
+              While studying, Plan 2 borrowers are charged the maximum rate of
+              RPI + 3%. This means your balance starts growing before you even
+              graduate.
             </p>
           </div>
+        </section>
 
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              Plan 2: The Sliding Scale
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <p>
-                Plan 2 has the most complex interest calculation. It uses a
-                sliding scale tied to your income, ranging from RPI (currently{" "}
-                {formatPercent(rpi)}) up to RPI + 3% (currently{" "}
-                {formatPercent(maxRate)}).
-              </p>
-              <ul className="list-disc space-y-1 pl-6">
-                <li>
-                  Earning below the lower threshold of{" "}
-                  <strong className="text-foreground">
-                    {formatGBP(PLAN_CONFIGS.PLAN_2.interestLowerThreshold)}
-                  </strong>
-                  : you pay RPI only ({formatPercent(rpi)})
-                </li>
-                <li>
-                  Earning above the upper threshold of{" "}
-                  <strong className="text-foreground">
-                    {formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}
-                  </strong>
-                  : you pay the maximum of RPI + 3% ({formatPercent(maxRate)})
-                </li>
-                <li>
-                  Earning between the two: the rate scales linearly from{" "}
-                  {formatPercent(rpi)} up to {formatPercent(maxRate)}
-                </li>
-              </ul>
-              <p>
-                While studying, Plan 2 borrowers are charged the maximum rate of
-                RPI + 3%. This means your balance starts growing before you even
-                graduate.
-              </p>
-            </div>
-          </section>
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Plan 5: RPI Only
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              Plan 5, introduced for students starting from September 2023, has
+              a much simpler formula. Regardless of how much you earn, the
+              interest rate is just RPI &mdash; currently {formatPercent(rpi)}.
+            </p>
+            <p>
+              This is a significant change from Plan 2. A high earner on Plan 2
+              could be paying {formatPercent(maxRate)} interest, while the same
+              earner on Plan 5 would pay only {formatPercent(rpi)}. The chart
+              below illustrates this difference clearly.
+            </p>
+          </div>
+        </section>
 
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              Plan 5: RPI Only
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <p>
-                Plan 5, introduced for students starting from September 2023,
-                has a much simpler formula. Regardless of how much you earn, the
-                interest rate is just RPI &mdash; currently {formatPercent(rpi)}
-                .
-              </p>
-              <p>
-                This is a significant change from Plan 2. A high earner on Plan
-                2 could be paying {formatPercent(maxRate)} interest, while the
-                same earner on Plan 5 would pay only {formatPercent(rpi)}. The
-                chart below illustrates this difference clearly.
-              </p>
-            </div>
-          </section>
+        <InterestRateChart />
 
-          <InterestRateChart />
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Plan 1 and Plan 4
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              Plan 1 (England, Wales &amp; Northern Ireland pre-2012) and Plan 4
+              (Scotland) use the same interest formula: the lesser of RPI or the
+              Bank of England base rate plus 1%.
+            </p>
+            <p>
+              With RPI at {formatPercent(rpi)} and the base rate at{" "}
+              {formatPercent(CURRENT_RATES.boeBaseRate)}, the current interest
+              rate for these plans is{" "}
+              <strong className="text-foreground">
+                {formatPercent(plan1Rate)}
+              </strong>{" "}
+              (the lower of {formatPercent(rpi)} and{" "}
+              {formatPercent(boeRatePlus1)}).
+            </p>
+          </div>
+        </section>
 
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              Plan 1 and Plan 4
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <p>
-                Plan 1 (England, Wales &amp; Northern Ireland pre-2012) and Plan
-                4 (Scotland) use the same interest formula: the lesser of RPI or
-                the Bank of England base rate plus 1%.
-              </p>
-              <p>
-                With RPI at {formatPercent(rpi)} and the base rate at{" "}
-                {formatPercent(CURRENT_RATES.boeBaseRate)}, the current interest
-                rate for these plans is{" "}
-                <strong className="text-foreground">
-                  {formatPercent(plan1Rate)}
-                </strong>{" "}
-                (the lower of {formatPercent(rpi)} and{" "}
-                {formatPercent(boeRatePlus1)}).
-              </p>
-            </div>
-          </section>
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Postgraduate Loans
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              Postgraduate (Master&apos;s and Doctoral) loans always charge RPI
+              + 3%, regardless of your income. At current rates, that means{" "}
+              <strong className="text-foreground">
+                {formatPercent(maxRate)}
+              </strong>{" "}
+              interest per year &mdash; the highest rate of any UK student loan
+              plan.
+            </p>
+          </div>
+        </section>
 
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              Postgraduate Loans
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <p>
-                Postgraduate (Master&apos;s and Doctoral) loans always charge
-                RPI + 3%, regardless of your income. At current rates, that
-                means{" "}
-                <strong className="text-foreground">
-                  {formatPercent(maxRate)}
-                </strong>{" "}
-                interest per year &mdash; the highest rate of any UK student
-                loan plan.
-              </p>
-            </div>
-          </section>
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Why Your Balance Grows
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              Many graduates are surprised to see their loan balance increase
+              despite making repayments. This happens when the interest added
+              each month exceeds what you repay.
+            </p>
+            <p>
+              For example, on a {formatGBP(EXAMPLE_BALANCE)} balance at{" "}
+              {formatPercent(maxRate)} interest, you would accrue roughly{" "}
+              {formatGBP(monthlyInterest)} per month in interest alone. If your
+              monthly repayment is less than that, the balance will keep
+              growing.
+            </p>
+            <p>
+              This is most common early in your career when salaries are lower
+              and balances are at their highest. Over time, salary growth
+              increases your repayments while the balance (hopefully) shrinks,
+              eventually tipping the scales. Use the{" "}
+              <Link
+                href="/"
+                className="text-primary underline underline-offset-4 hover:text-primary/80"
+              >
+                repayment calculator
+              </Link>{" "}
+              to see when this tipping point occurs at your salary.
+            </p>
+          </div>
+        </section>
 
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              Why Your Balance Grows
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <p>
-                Many graduates are surprised to see their loan balance increase
-                despite making repayments. This happens when the interest added
-                each month exceeds what you repay.
-              </p>
-              <p>
-                For example, on a {formatGBP(EXAMPLE_BALANCE)} balance at{" "}
-                {formatPercent(maxRate)} interest, you would accrue roughly{" "}
-                {formatGBP(monthlyInterest)} per month in interest alone. If
-                your monthly repayment is less than that, the balance will keep
-                growing.
-              </p>
-              <p>
-                This is most common early in your career when salaries are lower
-                and balances are at their highest. Over time, salary growth
-                increases your repayments while the balance (hopefully) shrinks,
-                eventually tipping the scales. Use the{" "}
-                <Link
-                  href="/"
-                  className="text-primary underline underline-offset-4 hover:text-primary/80"
-                >
-                  repayment calculator
-                </Link>{" "}
-                to see when this tipping point occurs at your salary.
-              </p>
-            </div>
-          </section>
-
-          <RelatedGuides
-            current="how-interest-works"
-            order={["rpi-vs-cpi", "plan-2-vs-plan-5"]}
-          />
-        </article>
-      </main>
-      <Footer />
-    </div>
+        <RelatedGuides
+          current="how-interest-works"
+          order={["rpi-vs-cpi", "plan-2-vs-plan-5"]}
+        />
+      </article>
+    </PageLayout>
   );
 }

--- a/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
+++ b/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
@@ -7,8 +7,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
-import { Footer } from "@/components/layout/Footer";
-import { Header } from "@/components/layout/Header";
+import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
@@ -32,314 +31,302 @@ const linkClasses =
 
 export function MovingAbroadGuide() {
   return (
-    <div className="flex min-h-screen flex-col">
-      <Header />
-      <main
-        id="main-content"
-        className="mx-auto w-full max-w-4xl flex-1 space-y-8 overflow-x-hidden px-3 pt-13 pb-6 md:pb-8"
-      >
-        <article className="space-y-8">
-          <div className="space-y-4">
-            <Breadcrumb>
-              <BreadcrumbList>
-                <BreadcrumbItem>
-                  <BreadcrumbLink render={<Link href="/" />}>
-                    Home
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbLink render={<Link href="/guides" />}>
-                    Guides
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbPage>Moving Abroad</BreadcrumbPage>
-                </BreadcrumbItem>
-              </BreadcrumbList>
-            </Breadcrumb>
+    <PageLayout>
+      <article className="space-y-8">
+        <div className="space-y-4">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/guides" />}>
+                  Guides
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>Moving Abroad</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
 
-            <div className="space-y-2">
-              <Heading as="h1">
-                What Happens to Your Student Loan If You Move Abroad?
-              </Heading>
-              <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
-                Moving overseas doesn&rsquo;t make your student loan disappear.
-                The Student Loans Company (SLC) continues to collect repayments
-                regardless of where you live, and the rules for how much you pay
-                change when you leave the UK.
-              </p>
-            </div>
-          </div>
-
-          <section className="space-y-4">
-            <Heading as="h2" size="section">
-              You Must Notify SLC
+          <div className="space-y-2">
+            <Heading as="h1">
+              What Happens to Your Student Loan If You Move Abroad?
             </Heading>
-            <p className="text-sm text-muted-foreground sm:text-base">
-              If you&rsquo;re planning to leave the UK for more than three
-              months, you are legally required to inform SLC. This applies
-              whether you&rsquo;re moving for work, travel, or any other reason.
+            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+              Moving overseas doesn&rsquo;t make your student loan disappear.
+              The Student Loans Company (SLC) continues to collect repayments
+              regardless of where you live, and the rules for how much you pay
+              change when you leave the UK.
             </p>
-            <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
-              <li>
-                Notify SLC <strong>within three months</strong> of moving abroad
-              </li>
-              <li>Provide your new overseas address and contact details</li>
-              <li>
-                Submit evidence of your income through the{" "}
+          </div>
+        </div>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            You Must Notify SLC
+          </Heading>
+          <p className="text-sm text-muted-foreground sm:text-base">
+            If you&rsquo;re planning to leave the UK for more than three months,
+            you are legally required to inform SLC. This applies whether
+            you&rsquo;re moving for work, travel, or any other reason.
+          </p>
+          <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+            <li>
+              Notify SLC <strong>within three months</strong> of moving abroad
+            </li>
+            <li>Provide your new overseas address and contact details</li>
+            <li>
+              Submit evidence of your income through the{" "}
+              <a
+                href={govUkAbroadLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={linkClasses}
+              >
+                overseas income assessment form
+              </a>
+            </li>
+            <li>
+              Continue providing income evidence annually to keep your
+              repayments accurate
+            </li>
+          </ul>
+        </section>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            How Repayments Work Abroad
+          </Heading>
+          <p className="text-sm text-muted-foreground sm:text-base">
+            When you live in the UK, repayments are automatically deducted from
+            your salary through PAYE. Abroad, the system works differently.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
+              <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
+                <HugeiconsIcon
+                  icon={Globe02Icon}
+                  className="size-5 text-primary"
+                />
+              </div>
+              <p className="font-medium">Country Thresholds</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                SLC sets{" "}
                 <a
                   href={govUkAbroadLink}
                   target="_blank"
                   rel="noopener noreferrer"
                   className={linkClasses}
                 >
-                  overseas income assessment form
-                </a>
-              </li>
-              <li>
-                Continue providing income evidence annually to keep your
-                repayments accurate
-              </li>
-            </ul>
-          </section>
-
-          <section className="space-y-4">
-            <Heading as="h2" size="section">
-              How Repayments Work Abroad
-            </Heading>
-            <p className="text-sm text-muted-foreground sm:text-base">
-              When you live in the UK, repayments are automatically deducted
-              from your salary through PAYE. Abroad, the system works
-              differently.
-            </p>
-            <div className="grid gap-3 sm:grid-cols-3">
-              <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
-                <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
-                  <HugeiconsIcon
-                    icon={Globe02Icon}
-                    className="size-5 text-primary"
-                  />
-                </div>
-                <p className="font-medium">Country Thresholds</p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  SLC sets{" "}
-                  <a
-                    href={govUkAbroadLink}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={linkClasses}
-                  >
-                    country-specific repayment thresholds
-                  </a>{" "}
-                  based on local cost of living — they may be higher or lower
-                  than the UK threshold.
-                </p>
-              </div>
-              <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
-                <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
-                  <HugeiconsIcon
-                    icon={CoinsPoundIcon}
-                    className="size-5 text-primary"
-                  />
-                </div>
-                <p className="font-medium">Repayment Rates</p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  You still repay {undergradRate} of income above the threshold
-                  for undergraduate loans ({postgradRate} for Postgraduate
-                  Loans).
-                </p>
-              </div>
-              <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
-                <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
-                  <HugeiconsIcon
-                    icon={CreditCardIcon}
-                    className="size-5 text-primary"
-                  />
-                </div>
-                <p className="font-medium">Direct Payments to SLC</p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  Repayments are made directly to SLC rather than through your
-                  employer.
-                </p>
-              </div>
-            </div>
-          </section>
-
-          <section className="space-y-4">
-            <Alert variant="destructive">
-              <HugeiconsIcon icon={AlertCircleIcon} className="size-4" />
-              <AlertTitle>
-                What If You Don&rsquo;t Provide Income Evidence?
-              </AlertTitle>
-              <AlertDescription>
-                <p>
-                  If you fail to complete the overseas income assessment, SLC
-                  doesn&rsquo;t simply stop collecting. Instead, they apply{" "}
-                  <strong>fixed repayment amounts</strong> that are not based on
-                  your actual earnings.
-                </p>
-                <ul className="mt-2 list-inside list-disc space-y-1">
-                  <li>
-                    Fixed amounts can be <strong>significantly higher</strong>{" "}
-                    than what you would pay based on your real income
-                  </li>
-                  <li>
-                    This effectively acts as a penalty for not engaging with the
-                    process
-                  </li>
-                  <li>
-                    You can avoid this by submitting your income evidence on
-                    time each year
-                  </li>
-                </ul>
-              </AlertDescription>
-            </Alert>
-          </section>
-
-          <section className="space-y-4">
-            <Heading as="h2" size="section">
-              Consequences of Non-Compliance
-            </Heading>
-            <div className="rounded-lg border-l-4 border-destructive bg-card p-4 ring-1 ring-foreground/10 sm:p-5">
-              <p className="mb-3 text-sm text-muted-foreground sm:text-base">
-                Ignoring your student loan obligations while abroad can have
-                serious consequences. SLC has several enforcement mechanisms
-                available.
+                  country-specific repayment thresholds
+                </a>{" "}
+                based on local cost of living — they may be higher or lower than
+                the UK threshold.
               </p>
-              <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+            </div>
+            <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
+              <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
+                <HugeiconsIcon
+                  icon={CoinsPoundIcon}
+                  className="size-5 text-primary"
+                />
+              </div>
+              <p className="font-medium">Repayment Rates</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                You still repay {undergradRate} of income above the threshold
+                for undergraduate loans ({postgradRate} for Postgraduate Loans).
+              </p>
+            </div>
+            <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
+              <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
+                <HugeiconsIcon
+                  icon={CreditCardIcon}
+                  className="size-5 text-primary"
+                />
+              </div>
+              <p className="font-medium">Direct Payments to SLC</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Repayments are made directly to SLC rather than through your
+                employer.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <Alert variant="destructive">
+            <HugeiconsIcon icon={AlertCircleIcon} className="size-4" />
+            <AlertTitle>
+              What If You Don&rsquo;t Provide Income Evidence?
+            </AlertTitle>
+            <AlertDescription>
+              <p>
+                If you fail to complete the overseas income assessment, SLC
+                doesn&rsquo;t simply stop collecting. Instead, they apply{" "}
+                <strong>fixed repayment amounts</strong> that are not based on
+                your actual earnings.
+              </p>
+              <ul className="mt-2 list-inside list-disc space-y-1">
                 <li>
-                  SLC can take <strong>legal action</strong> to recover the debt
+                  Fixed amounts can be <strong>significantly higher</strong>{" "}
+                  than what you would pay based on your real income
                 </li>
                 <li>
-                  Your debt may be passed to{" "}
-                  <strong>collection agencies</strong>
+                  This effectively acts as a penalty for not engaging with the
+                  process
                 </li>
                 <li>
-                  If you return to the UK, missed payments could{" "}
-                  <strong>affect your credit record</strong>
-                </li>
-                <li>
-                  Additional <strong>penalties and interest</strong> may be
-                  applied to your balance
-                </li>
-                <li>
-                  HMRC can resume automatic deductions from your salary if you
-                  return to UK employment
+                  You can avoid this by submitting your income evidence on time
+                  each year
                 </li>
               </ul>
-            </div>
-          </section>
+            </AlertDescription>
+          </Alert>
+        </section>
 
-          <section className="space-y-4">
-            <Heading as="h2" size="section">
-              Practical Steps Before You Move
-            </Heading>
-            <p className="text-sm text-muted-foreground sm:text-base">
-              If you&rsquo;re planning to move abroad, take these steps to stay
-              on top of your loan.
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Consequences of Non-Compliance
+          </Heading>
+          <div className="rounded-lg border-l-4 border-destructive bg-card p-4 ring-1 ring-foreground/10 sm:p-5">
+            <p className="mb-3 text-sm text-muted-foreground sm:text-base">
+              Ignoring your student loan obligations while abroad can have
+              serious consequences. SLC has several enforcement mechanisms
+              available.
             </p>
-            <div className="space-y-0 divide-y rounded-lg border bg-card ring-1 ring-foreground/10">
-              {[
-                {
-                  title: "Notify SLC",
-                  description:
-                    "Inform SLC of your move and new address as early as possible.",
-                },
-                {
-                  title: "Complete the overseas income assessment",
-                  description:
-                    "Submit the form to ensure your repayments are based on your actual income.",
-                },
-                {
-                  title: "Check your country\u2019s threshold",
-                  description:
-                    "Look up the SLC website so you know what to expect for your destination.",
-                },
-                {
-                  title: "Set up a payment method",
-                  description:
-                    "Arrange a way to make direct repayments to SLC from abroad.",
-                },
-                {
-                  title: "Keep records",
-                  description:
-                    "Save all correspondence and payment confirmations with SLC.",
-                },
-                {
-                  title: "Set annual reminders",
-                  description:
-                    "Resubmit income evidence before the deadline each year.",
-                },
-              ].map((step, i) => (
-                <div key={i} className="flex gap-4 p-4">
-                  <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
-                    {i + 1}
-                  </span>
-                  <div>
-                    <p className="font-medium">{step.title}</p>
-                    <p className="mt-0.5 text-sm text-muted-foreground">
-                      {step.description}
-                    </p>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </section>
-
-          <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
-            <Heading as="h2" size="subsection">
-              Key Takeaways
-            </Heading>
             <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
               <li>
-                Moving abroad does <strong>not</strong> cancel or pause your
-                student loan repayments.
+                SLC can take <strong>legal action</strong> to recover the debt
               </li>
               <li>
-                You must notify SLC within three months and provide annual
-                income evidence.
+                Your debt may be passed to <strong>collection agencies</strong>
               </li>
               <li>
-                Repayment thresholds vary by country based on local cost of
-                living.
+                If you return to the UK, missed payments could{" "}
+                <strong>affect your credit record</strong>
               </li>
               <li>
-                Failing to engage with SLC results in fixed repayment amounts
-                that are typically higher than income-based payments.
+                Additional <strong>penalties and interest</strong> may be
+                applied to your balance
               </li>
               <li>
-                Non-compliance can lead to legal action, collection agencies,
-                and credit impacts if you return to the UK.
-              </li>
-              <li>
-                Before you move, check your remaining balance and repayment
-                timeline with the{" "}
-                <Link
-                  href="/"
-                  className="text-primary underline underline-offset-4 hover:text-primary/80"
-                >
-                  repayment calculator
-                </Link>
-                .
+                HMRC can resume automatic deductions from your salary if you
+                return to UK employment
               </li>
             </ul>
-          </section>
+          </div>
+        </section>
 
-          <RelatedGuides
-            current="moving-abroad"
-            order={["self-employment", "plan-2-vs-plan-5"]}
-            extraLinks={[
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Practical Steps Before You Move
+          </Heading>
+          <p className="text-sm text-muted-foreground sm:text-base">
+            If you&rsquo;re planning to move abroad, take these steps to stay on
+            top of your loan.
+          </p>
+          <div className="space-y-0 divide-y rounded-lg border bg-card ring-1 ring-foreground/10">
+            {[
               {
-                href: "https://www.gov.uk/repaying-your-student-loan/repaying-from-abroad",
-                label: "GOV.UK: Repaying from Abroad",
+                title: "Notify SLC",
+                description:
+                  "Inform SLC of your move and new address as early as possible.",
               },
-            ]}
-          />
-        </article>
-      </main>
-      <Footer />
-    </div>
+              {
+                title: "Complete the overseas income assessment",
+                description:
+                  "Submit the form to ensure your repayments are based on your actual income.",
+              },
+              {
+                title: "Check your country\u2019s threshold",
+                description:
+                  "Look up the SLC website so you know what to expect for your destination.",
+              },
+              {
+                title: "Set up a payment method",
+                description:
+                  "Arrange a way to make direct repayments to SLC from abroad.",
+              },
+              {
+                title: "Keep records",
+                description:
+                  "Save all correspondence and payment confirmations with SLC.",
+              },
+              {
+                title: "Set annual reminders",
+                description:
+                  "Resubmit income evidence before the deadline each year.",
+              },
+            ].map((step, i) => (
+              <div key={i} className="flex gap-4 p-4">
+                <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
+                  {i + 1}
+                </span>
+                <div>
+                  <p className="font-medium">{step.title}</p>
+                  <p className="mt-0.5 text-sm text-muted-foreground">
+                    {step.description}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
+          <Heading as="h2" size="subsection">
+            Key Takeaways
+          </Heading>
+          <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+            <li>
+              Moving abroad does <strong>not</strong> cancel or pause your
+              student loan repayments.
+            </li>
+            <li>
+              You must notify SLC within three months and provide annual income
+              evidence.
+            </li>
+            <li>
+              Repayment thresholds vary by country based on local cost of
+              living.
+            </li>
+            <li>
+              Failing to engage with SLC results in fixed repayment amounts that
+              are typically higher than income-based payments.
+            </li>
+            <li>
+              Non-compliance can lead to legal action, collection agencies, and
+              credit impacts if you return to the UK.
+            </li>
+            <li>
+              Before you move, check your remaining balance and repayment
+              timeline with the{" "}
+              <Link
+                href="/"
+                className="text-primary underline underline-offset-4 hover:text-primary/80"
+              >
+                repayment calculator
+              </Link>
+              .
+            </li>
+          </ul>
+        </section>
+
+        <RelatedGuides
+          current="moving-abroad"
+          order={["self-employment", "plan-2-vs-plan-5"]}
+          extraLinks={[
+            {
+              href: "https://www.gov.uk/repaying-your-student-loan/repaying-from-abroad",
+              label: "GOV.UK: Repaying from Abroad",
+            },
+          ]}
+        />
+      </article>
+    </PageLayout>
   );
 }

--- a/src/components/guides/pay-upfront-or-take-loan/PayUpfrontGuide.tsx
+++ b/src/components/guides/pay-upfront-or-take-loan/PayUpfrontGuide.tsx
@@ -1,8 +1,7 @@
 import Link from "next/link";
 import { CostComparisonChart } from "./CostComparisonChart";
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
-import { Footer } from "@/components/layout/Footer";
-import { Header } from "@/components/layout/Header";
+import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import {
   Breadcrumb,
@@ -27,238 +26,226 @@ const feeCapFormatted = formatGBP(TUITION_FEE_CAP);
 
 export function PayUpfrontGuide() {
   return (
-    <div className="flex min-h-screen flex-col">
-      <Header />
-      <main
-        id="main-content"
-        className="mx-auto w-full max-w-4xl flex-1 px-3 pt-13 pb-6 md:pb-8"
-      >
-        <article className="space-y-8">
-          <div className="space-y-4">
-            <Breadcrumb>
-              <BreadcrumbList>
-                <BreadcrumbItem>
-                  <BreadcrumbLink render={<Link href="/" />}>
-                    Home
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbLink render={<Link href="/guides" />}>
-                    Guides
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbPage>Pay Upfront or Take the Loan?</BreadcrumbPage>
-                </BreadcrumbItem>
-              </BreadcrumbList>
-            </Breadcrumb>
+    <PageLayout>
+      <article className="space-y-8">
+        <div className="space-y-4">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/guides" />}>
+                  Guides
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>Pay Upfront or Take the Loan?</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
 
-            <Heading as="h1">
-              Should You Pay Tuition Upfront or Take the Loan?
-            </Heading>
-            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
-              The answer depends on how much the graduate will earn over their
-              career &mdash; and starting salary alone doesn&rsquo;t tell the
-              whole story.
+          <Heading as="h1">
+            Should You Pay Tuition Upfront or Take the Loan?
+          </Heading>
+          <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+            The answer depends on how much the graduate will earn over their
+            career &mdash; and starting salary alone doesn&rsquo;t tell the
+            whole story.
+          </p>
+        </div>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            The Cost of Paying Upfront
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              At the current maximum tuition fee of {feeCapFormatted} per year,
+              a standard three-year undergraduate degree costs{" "}
+              <strong className="text-foreground">{tuitionFormatted}</strong> in
+              tuition fees alone. Paying this upfront means handing over that
+              sum before the student even starts, with no possibility of getting
+              any of it back.
+            </p>
+            <p>
+              That money is gone regardless of what happens next &mdash; whether
+              the graduate earns &pound;25,000 or &pound;100,000 a year, the
+              cost is fixed at {tuitionFormatted}.
             </p>
           </div>
+        </section>
 
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              The Cost of Paying Upfront
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <p>
-                At the current maximum tuition fee of {feeCapFormatted} per
-                year, a standard three-year undergraduate degree costs{" "}
-                <strong className="text-foreground">{tuitionFormatted}</strong>{" "}
-                in tuition fees alone. Paying this upfront means handing over
-                that sum before the student even starts, with no possibility of
-                getting any of it back.
-              </p>
-              <p>
-                That money is gone regardless of what happens next &mdash;
-                whether the graduate earns &pound;25,000 or &pound;100,000 a
-                year, the cost is fixed at {tuitionFormatted}.
-              </p>
-            </div>
-          </section>
-
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              What Happens If You Take the Loan Instead
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <p>
-                Under Plan 5, tuition fee loans are written off{" "}
-                <strong className="text-foreground">
-                  {writeOffYears} years
-                </strong>{" "}
-                after the graduate becomes eligible to repay. Repayments are 9%
-                of earnings above the {threshold} threshold, and interest is
-                charged at RPI only.
-              </p>
-              <p>
-                The total you end up paying depends on your earning trajectory
-                over those {writeOffYears} years, and graduates broadly fall
-                into three groups:
-              </p>
-              <ul className="list-disc space-y-2 pl-6">
-                <li>
-                  <strong className="text-foreground">Low earners</strong>{" "}
-                  &mdash; repayments stay small and the loan is partially
-                  written off. Total cost ends up well below {tuitionFormatted}.
-                  The loan is clearly cheaper than paying upfront.
-                </li>
-                <li>
-                  <strong className="text-foreground">Middle earners</strong>{" "}
-                  &mdash; this is the trap. You earn enough to keep repaying for
-                  decades but not enough to clear the balance before interest
-                  compounds. Total repayments can exceed the upfront cost,
-                  sometimes significantly. This is the group that ends up paying
-                  the most.
-                </li>
-                <li>
-                  <strong className="text-foreground">High earners</strong>{" "}
-                  &mdash; clear the loan relatively quickly, so interest
-                  doesn&rsquo;t compound much. Total cost is close to or
-                  slightly above the upfront price, and you kept your capital in
-                  the meantime.
-                </li>
-              </ul>
-            </div>
-          </section>
-
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              The Salary Growth Trap
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <p>
-                A graduate starting on &pound;30,000 might think &ldquo;at this
-                salary I&rsquo;ll barely repay anything.&rdquo; But salaries
-                grow. At 4% annual growth &mdash; a typical career progression
-                &mdash; a &pound;30k starting salary reaches roughly &pound;65k
-                after 20 years.
-              </p>
-              <p>
-                As salary grows, repayments increase, and many graduates who
-                expected to be in the &ldquo;low earner&rdquo; category end up
-                firmly in the middle-earner zone, paying more than the upfront
-                cost over the life of the loan.
-              </p>
-              <p>
-                The chart below shows how this plays out. Notice the gap between
-                the flat-salary line and the growing-salary line &mdash; that
-                gap is the hidden cost of salary growth that a snapshot of your
-                starting salary won&rsquo;t reveal.
-              </p>
-            </div>
-          </section>
-
-          <CostComparisonChart />
-
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              When Paying Upfront Makes Sense
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <p>
-                Paying upfront can save money for graduates who will land in the
-                middle-earner zone &mdash; not just the highest earners.
-              </p>
-              <ul className="list-disc space-y-1 pl-6">
-                <li>
-                  The graduate expects moderate-to-high earnings over their
-                  career (the middle-earner zone where total repayments exceed
-                  the upfront cost)
-                </li>
-                <li>
-                  The family has the funds available without impacting their own
-                  financial security
-                </li>
-                <li>
-                  The graduate wants to avoid decades of repayments that end up
-                  exceeding the original tuition cost
-                </li>
-              </ul>
-            </div>
-          </section>
-
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              When Taking the Loan Makes Sense
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <p>
-                The loan works best at the extremes of the earning spectrum, and
-                as a safety net for uncertainty.
-              </p>
-              <ul className="list-disc space-y-1 pl-6">
-                <li>
-                  The graduate expects to stay on a lower salary &mdash; the
-                  loan will be partially written off, costing less than paying
-                  upfront
-                </li>
-                <li>
-                  The graduate expects very high earnings &mdash; they clear the
-                  loan quickly and kept their capital invested in the meantime
-                </li>
-                <li>
-                  The family would rather keep the {tuitionFormatted} as a
-                  financial safety net
-                </li>
-                <li>
-                  Repayments adjust automatically if earnings drop &mdash;
-                  built-in insurance that paying upfront doesn&rsquo;t offer
-                </li>
-              </ul>
-            </div>
-          </section>
-
-          <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
-            <Heading as="h2" size="subsection">
-              Key Takeaways
-            </Heading>
-            <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            What Happens If You Take the Loan Instead
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              Under Plan 5, tuition fee loans are written off{" "}
+              <strong className="text-foreground">{writeOffYears} years</strong>{" "}
+              after the graduate becomes eligible to repay. Repayments are 9% of
+              earnings above the {threshold} threshold, and interest is charged
+              at RPI only.
+            </p>
+            <p>
+              The total you end up paying depends on your earning trajectory
+              over those {writeOffYears} years, and graduates broadly fall into
+              three groups:
+            </p>
+            <ul className="list-disc space-y-2 pl-6">
               <li>
-                The loan is not universally cheaper than paying upfront &mdash;
-                it depends on earning trajectory
+                <strong className="text-foreground">Low earners</strong> &mdash;
+                repayments stay small and the loan is partially written off.
+                Total cost ends up well below {tuitionFormatted}. The loan is
+                clearly cheaper than paying upfront.
               </li>
               <li>
-                Starting salary is misleading; salary growth pushes many
-                graduates into higher repayment brackets over time
+                <strong className="text-foreground">Middle earners</strong>{" "}
+                &mdash; this is the trap. You earn enough to keep repaying for
+                decades but not enough to clear the balance before interest
+                compounds. Total repayments can exceed the upfront cost,
+                sometimes significantly. This is the group that ends up paying
+                the most.
               </li>
               <li>
-                Middle earners often end up paying the most due to interest
-                compounding over decades of repayments
-              </li>
-              <li>
-                The loan works best for genuine low earners (partial write-off)
-                or very high earners (fast repayment)
-              </li>
-              <li>
-                <Link
-                  href="/"
-                  className="text-primary underline underline-offset-4 hover:text-primary/80"
-                >
-                  Use the student loan repayment calculator
-                </Link>{" "}
-                to model your specific scenario with your expected salary and
-                growth rate
+                <strong className="text-foreground">High earners</strong>{" "}
+                &mdash; clear the loan relatively quickly, so interest
+                doesn&rsquo;t compound much. Total cost is close to or slightly
+                above the upfront price, and you kept your capital in the
+                meantime.
               </li>
             </ul>
-          </section>
+          </div>
+        </section>
 
-          <RelatedGuides
-            current="pay-upfront-or-take-loan"
-            order={["how-interest-works", "plan-2-vs-plan-5"]}
-          />
-        </article>
-      </main>
-      <Footer />
-    </div>
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            The Salary Growth Trap
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              A graduate starting on &pound;30,000 might think &ldquo;at this
+              salary I&rsquo;ll barely repay anything.&rdquo; But salaries grow.
+              At 4% annual growth &mdash; a typical career progression &mdash; a
+              &pound;30k starting salary reaches roughly &pound;65k after 20
+              years.
+            </p>
+            <p>
+              As salary grows, repayments increase, and many graduates who
+              expected to be in the &ldquo;low earner&rdquo; category end up
+              firmly in the middle-earner zone, paying more than the upfront
+              cost over the life of the loan.
+            </p>
+            <p>
+              The chart below shows how this plays out. Notice the gap between
+              the flat-salary line and the growing-salary line &mdash; that gap
+              is the hidden cost of salary growth that a snapshot of your
+              starting salary won&rsquo;t reveal.
+            </p>
+          </div>
+        </section>
+
+        <CostComparisonChart />
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            When Paying Upfront Makes Sense
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              Paying upfront can save money for graduates who will land in the
+              middle-earner zone &mdash; not just the highest earners.
+            </p>
+            <ul className="list-disc space-y-1 pl-6">
+              <li>
+                The graduate expects moderate-to-high earnings over their career
+                (the middle-earner zone where total repayments exceed the
+                upfront cost)
+              </li>
+              <li>
+                The family has the funds available without impacting their own
+                financial security
+              </li>
+              <li>
+                The graduate wants to avoid decades of repayments that end up
+                exceeding the original tuition cost
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            When Taking the Loan Makes Sense
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              The loan works best at the extremes of the earning spectrum, and
+              as a safety net for uncertainty.
+            </p>
+            <ul className="list-disc space-y-1 pl-6">
+              <li>
+                The graduate expects to stay on a lower salary &mdash; the loan
+                will be partially written off, costing less than paying upfront
+              </li>
+              <li>
+                The graduate expects very high earnings &mdash; they clear the
+                loan quickly and kept their capital invested in the meantime
+              </li>
+              <li>
+                The family would rather keep the {tuitionFormatted} as a
+                financial safety net
+              </li>
+              <li>
+                Repayments adjust automatically if earnings drop &mdash;
+                built-in insurance that paying upfront doesn&rsquo;t offer
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
+          <Heading as="h2" size="subsection">
+            Key Takeaways
+          </Heading>
+          <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+            <li>
+              The loan is not universally cheaper than paying upfront &mdash; it
+              depends on earning trajectory
+            </li>
+            <li>
+              Starting salary is misleading; salary growth pushes many graduates
+              into higher repayment brackets over time
+            </li>
+            <li>
+              Middle earners often end up paying the most due to interest
+              compounding over decades of repayments
+            </li>
+            <li>
+              The loan works best for genuine low earners (partial write-off) or
+              very high earners (fast repayment)
+            </li>
+            <li>
+              <Link
+                href="/"
+                className="text-primary underline underline-offset-4 hover:text-primary/80"
+              >
+                Use the student loan repayment calculator
+              </Link>{" "}
+              to model your specific scenario with your expected salary and
+              growth rate
+            </li>
+          </ul>
+        </section>
+
+        <RelatedGuides
+          current="pay-upfront-or-take-loan"
+          order={["how-interest-works", "plan-2-vs-plan-5"]}
+        />
+      </article>
+    </PageLayout>
   );
 }

--- a/src/components/guides/plan-2-vs-plan-5/Plan2VsPlan5Guide.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/Plan2VsPlan5Guide.tsx
@@ -3,8 +3,7 @@ import { BalanceComparisonChart } from "./BalanceComparisonChart";
 import { ComparisonTable } from "./ComparisonTable";
 import { TotalRepaymentBySalaryChart } from "./TotalRepaymentBySalaryChart";
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
-import { Footer } from "@/components/layout/Footer";
-import { Header } from "@/components/layout/Header";
+import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import {
   Breadcrumb,
@@ -31,250 +30,241 @@ const plan5Annual = Math.round(
 
 export function Plan2VsPlan5Guide() {
   return (
-    <div className="flex min-h-screen flex-col">
-      <Header />
-      <main
-        id="main-content"
-        className="mx-auto w-full max-w-4xl flex-1 space-y-8 overflow-x-hidden px-3 pt-13 pb-6 md:pb-8"
-      >
-        <article className="space-y-8">
-          <div className="space-y-4">
-            <Breadcrumb>
-              <BreadcrumbList>
-                <BreadcrumbItem>
-                  <BreadcrumbLink render={<Link href="/" />}>
-                    Home
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbLink render={<Link href="/guides" />}>
-                    Guides
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbPage>Plan 2 vs Plan 5</BreadcrumbPage>
-                </BreadcrumbItem>
-              </BreadcrumbList>
-            </Breadcrumb>
+    <PageLayout>
+      <article className="space-y-8">
+        <div className="space-y-4">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/guides" />}>
+                  Guides
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>Plan 2 vs Plan 5</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
 
-            <div className="space-y-2">
-              <Heading as="h1">Plan 2 vs Plan 5: Which Is Better?</Heading>
-              <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
-                Plan 2 and Plan 5 are the two loan types most English university
-                students will encounter. Plan 2 covers those who started between
-                2012 and 2023, while Plan 5 applies from 2023 onwards. They
-                differ in repayment threshold, interest rate, and write-off
-                period — and these differences can mean tens of thousands of
-                pounds more or less repaid over your career.
-              </p>
-            </div>
+          <div className="space-y-2">
+            <Heading as="h1">Plan 2 vs Plan 5: Which Is Better?</Heading>
+            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+              Plan 2 and Plan 5 are the two loan types most English university
+              students will encounter. Plan 2 covers those who started between
+              2012 and 2023, while Plan 5 applies from 2023 onwards. They differ
+              in repayment threshold, interest rate, and write-off period — and
+              these differences can mean tens of thousands of pounds more or
+              less repaid over your career.
+            </p>
           </div>
+        </div>
 
-          <section className="space-y-4">
-            <Heading as="h2" size="section">
-              Side-by-Side Comparison
-            </Heading>
-            <p className="text-sm text-muted-foreground sm:text-base">
-              The key terms of each plan at a glance. Plan 5 has a lower
-              threshold and longer write-off, but simpler (and lower) interest.
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Side-by-Side Comparison
+          </Heading>
+          <p className="text-sm text-muted-foreground sm:text-base">
+            The key terms of each plan at a glance. Plan 5 has a lower threshold
+            and longer write-off, but simpler (and lower) interest.
+          </p>
+          <ComparisonTable />
+        </section>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Total Repayment by Salary
+          </Heading>
+          <p className="text-sm text-muted-foreground sm:text-base">
+            How much you repay in total depends heavily on your salary. This
+            chart shows the total amount repaid over the life of each loan for a
+            range of starting salaries, assuming a balance of
+            {"\u00a0"}
+            {formatGBP(EXAMPLE_BALANCE)}.
+          </p>
+          <div className="h-75 sm:h-95">
+            <TotalRepaymentBySalaryChart />
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Balance Over Time
+          </Heading>
+          <p className="text-sm text-muted-foreground sm:text-base">
+            See how the outstanding balance changes month by month. Toggle
+            between salary levels to see how income affects the repayment
+            trajectory for each plan.
+          </p>
+          <div className="h-85 sm:h-105">
+            <BalanceComparisonChart />
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Which Plan Do I Have?
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              You cannot choose between Plan 2 and Plan 5 &mdash; your plan is
+              determined by when and where you started your course. Plan 2
+              covers English and Welsh students who started university between
+              September 2012 and July 2023. Plan 5 applies to English students
+              who started from September 2023 onwards.
             </p>
-            <ComparisonTable />
-          </section>
-
-          <section className="space-y-4">
-            <Heading as="h2" size="section">
-              Total Repayment by Salary
-            </Heading>
-            <p className="text-sm text-muted-foreground sm:text-base">
-              How much you repay in total depends heavily on your salary. This
-              chart shows the total amount repaid over the life of each loan for
-              a range of starting salaries, assuming a balance of
-              {"\u00a0"}
-              {formatGBP(EXAMPLE_BALANCE)}.
+            <p>
+              The cutoff is August 2023. If you started in the 2022&ndash;23
+              academic year, you are on Plan 2. If you started in September 2023
+              or later, you are on Plan 5. Note that Plan 5 is England-only
+              &mdash; Welsh students who started after August 2023 remain on
+              Plan 2.
             </p>
-            <div className="h-75 sm:h-95">
-              <TotalRepaymentBySalaryChart />
-            </div>
-          </section>
-
-          <section className="space-y-4">
-            <Heading as="h2" size="section">
-              Balance Over Time
-            </Heading>
-            <p className="text-sm text-muted-foreground sm:text-base">
-              See how the outstanding balance changes month by month. Toggle
-              between salary levels to see how income affects the repayment
-              trajectory for each plan.
+            <p>
+              Not sure?{" "}
+              <Link
+                href="/which-plan"
+                className="text-primary underline underline-offset-4 hover:text-primary/80"
+              >
+                Take the which plan quiz
+              </Link>{" "}
+              to find out.
             </p>
-            <div className="h-85 sm:h-105">
-              <BalanceComparisonChart />
-            </div>
-          </section>
+          </div>
+        </section>
 
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              Which Plan Do I Have?
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <p>
-                You cannot choose between Plan 2 and Plan 5 &mdash; your plan is
-                determined by when and where you started your course. Plan 2
-                covers English and Welsh students who started university between
-                September 2012 and July 2023. Plan 5 applies to English students
-                who started from September 2023 onwards.
-              </p>
-              <p>
-                The cutoff is August 2023. If you started in the 2022&ndash;23
-                academic year, you are on Plan 2. If you started in September
-                2023 or later, you are on Plan 5. Note that Plan 5 is
-                England-only &mdash; Welsh students who started after August
-                2023 remain on Plan 2.
-              </p>
-              <p>
-                Not sure?{" "}
-                <Link
-                  href="/which-plan"
-                  className="text-primary underline underline-offset-4 hover:text-primary/80"
-                >
-                  Take the which plan quiz
-                </Link>{" "}
-                to find out.
-              </p>
-            </div>
-          </section>
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            How the Threshold Difference Affects You
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              Plan 5&rsquo;s lower repayment threshold means you start repaying
+              sooner and pay more each month at the same salary. Both plans
+              charge 9% on income above the threshold, but the thresholds are
+              different: {formatGBP(plan2Threshold)} for Plan 2 versus{" "}
+              {formatGBP(plan5Threshold)} for Plan 5.
+            </p>
+            <p>
+              For example, at a {formatGBP(EXAMPLE_SALARY)} salary, a Plan 2
+              borrower repays just {formatGBP(plan2Annual)} per year, while a
+              Plan 5 borrower repays {formatGBP(plan5Annual)} per year &mdash;
+              over three times as much. This gap narrows at higher salaries
+              where both plans collect substantial repayments, but at lower
+              salaries the threshold difference is the dominant factor.
+            </p>
+          </div>
+        </section>
 
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              How the Threshold Difference Affects You
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <p>
-                Plan 5&rsquo;s lower repayment threshold means you start
-                repaying sooner and pay more each month at the same salary. Both
-                plans charge 9% on income above the threshold, but the
-                thresholds are different: {formatGBP(plan2Threshold)} for Plan 2
-                versus {formatGBP(plan5Threshold)} for Plan 5.
-              </p>
-              <p>
-                For example, at a {formatGBP(EXAMPLE_SALARY)} salary, a Plan 2
-                borrower repays just {formatGBP(plan2Annual)} per year, while a
-                Plan 5 borrower repays {formatGBP(plan5Annual)} per year &mdash;
-                over three times as much. This gap narrows at higher salaries
-                where both plans collect substantial repayments, but at lower
-                salaries the threshold difference is the dominant factor.
-              </p>
-            </div>
-          </section>
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Can You Switch Plans?
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              No. Your plan is permanently determined by your course start date.
+              There is no mechanism to switch between Plan 2 and Plan 5.
+            </p>
+            <p>
+              If you take out a second degree after August 2023, the new loan
+              will be on Plan 5, but your original Plan 2 loan stays on Plan 2.
+              The two loans are repaid separately under their own terms.
+            </p>
+          </div>
+        </section>
 
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              Can You Switch Plans?
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <p>
-                No. Your plan is permanently determined by your course start
-                date. There is no mechanism to switch between Plan 2 and Plan 5.
-              </p>
-              <p>
-                If you take out a second degree after August 2023, the new loan
-                will be on Plan 5, but your original Plan 2 loan stays on Plan
-                2. The two loans are repaid separately under their own terms.
-              </p>
-            </div>
-          </section>
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Which Plan Should You Worry About?
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              For most borrowers, repayments are automatic through PAYE &mdash;
+              you do not need to do anything. The real question is whether it
+              makes sense to{" "}
+              <Link
+                href="/overpay"
+                className="text-primary underline underline-offset-4 hover:text-primary/80"
+              >
+                overpay your loan
+              </Link>
+              .
+            </p>
+            <p>
+              Plan 2 middle earners are hit hardest. They earn too much for the
+              30-year write-off to help significantly, but not enough to pay off
+              the balance quickly before{" "}
+              <Link
+                href="/guides/how-interest-works"
+                className="text-primary underline underline-offset-4 hover:text-primary/80"
+              >
+                interest
+              </Link>{" "}
+              (up to RPI + 3%) compounds over decades. These borrowers often end
+              up repaying more in total than Plan 5 borrowers on the same
+              salary.
+            </p>
+            <p>
+              Use the{" "}
+              <Link
+                href="/"
+                className="text-primary underline underline-offset-4 hover:text-primary/80"
+              >
+                student loan repayment calculator
+              </Link>{" "}
+              to model your specific scenario and see exactly how much
+              you&rsquo;ll repay under your plan.
+            </p>
+          </div>
+        </section>
 
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              Which Plan Should You Worry About?
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <p>
-                For most borrowers, repayments are automatic through PAYE
-                &mdash; you do not need to do anything. The real question is
-                whether it makes sense to{" "}
-                <Link
-                  href="/overpay"
-                  className="text-primary underline underline-offset-4 hover:text-primary/80"
-                >
-                  overpay your loan
-                </Link>
-                .
-              </p>
-              <p>
-                Plan 2 middle earners are hit hardest. They earn too much for
-                the 30-year write-off to help significantly, but not enough to
-                pay off the balance quickly before{" "}
-                <Link
-                  href="/guides/how-interest-works"
-                  className="text-primary underline underline-offset-4 hover:text-primary/80"
-                >
-                  interest
-                </Link>{" "}
-                (up to RPI + 3%) compounds over decades. These borrowers often
-                end up repaying more in total than Plan 5 borrowers on the same
-                salary.
-              </p>
-              <p>
-                Use the{" "}
-                <Link
-                  href="/"
-                  className="text-primary underline underline-offset-4 hover:text-primary/80"
-                >
-                  student loan repayment calculator
-                </Link>{" "}
-                to model your specific scenario and see exactly how much
-                you&rsquo;ll repay under your plan.
-              </p>
-            </div>
-          </section>
+        <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
+          <Heading as="h2" size="subsection">
+            Key Takeaways
+          </Heading>
+          <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+            <li>
+              Lower earners often pay <strong>more</strong> on Plan 5 because
+              the 40-year term and lower threshold mean more months of
+              repayments.
+            </li>
+            <li>
+              Middle earners may pay <strong>more</strong> on Plan 2 because
+              interest can reach RPI + 3%, and they earn too much for write-off
+              to help but not enough to pay off the balance quickly.
+            </li>
+            <li>
+              Plan 5&rsquo;s simpler interest (RPI only) makes the balance more
+              predictable, but the longer write-off window is the real cost
+              driver.
+            </li>
+            <li>
+              Plan 5&rsquo;s lower threshold ({formatGBP(plan5Threshold)} vs{" "}
+              {formatGBP(plan2Threshold)}) means earlier and larger repayments
+              at the same salary.
+            </li>
+            <li>
+              Model your own salary in the{" "}
+              <Link
+                href="/"
+                className="text-primary underline underline-offset-4 hover:text-primary/80"
+              >
+                student loan calculator
+              </Link>{" "}
+              to see the total cost under each plan.
+            </li>
+          </ul>
+        </section>
 
-          <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
-            <Heading as="h2" size="subsection">
-              Key Takeaways
-            </Heading>
-            <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
-              <li>
-                Lower earners often pay <strong>more</strong> on Plan 5 because
-                the 40-year term and lower threshold mean more months of
-                repayments.
-              </li>
-              <li>
-                Middle earners may pay <strong>more</strong> on Plan 2 because
-                interest can reach RPI + 3%, and they earn too much for
-                write-off to help but not enough to pay off the balance quickly.
-              </li>
-              <li>
-                Plan 5&rsquo;s simpler interest (RPI only) makes the balance
-                more predictable, but the longer write-off window is the real
-                cost driver.
-              </li>
-              <li>
-                Plan 5&rsquo;s lower threshold ({formatGBP(plan5Threshold)} vs{" "}
-                {formatGBP(plan2Threshold)}) means earlier and larger repayments
-                at the same salary.
-              </li>
-              <li>
-                Model your own salary in the{" "}
-                <Link
-                  href="/"
-                  className="text-primary underline underline-offset-4 hover:text-primary/80"
-                >
-                  student loan calculator
-                </Link>{" "}
-                to see the total cost under each plan.
-              </li>
-            </ul>
-          </section>
-
-          <RelatedGuides
-            current="plan-2-vs-plan-5"
-            order={["how-interest-works", "pay-upfront-or-take-loan"]}
-          />
-        </article>
-      </main>
-      <Footer />
-    </div>
+        <RelatedGuides
+          current="plan-2-vs-plan-5"
+          order={["how-interest-works", "pay-upfront-or-take-loan"]}
+        />
+      </article>
+    </PageLayout>
   );
 }

--- a/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
+++ b/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
@@ -1,8 +1,7 @@
 import Link from "next/link";
 import { InflationComparisonChart } from "./InflationComparisonChart";
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
-import { Footer } from "@/components/layout/Footer";
-import { Header } from "@/components/layout/Header";
+import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import {
   Breadcrumb,
@@ -23,265 +22,254 @@ const plan1Rate = Math.min(rpi, CURRENT_RATES.boeBaseRate + 1);
 
 export function RpiVsCpiGuide() {
   return (
-    <div className="flex min-h-screen flex-col">
-      <Header />
-      <main
-        id="main-content"
-        className="mx-auto w-full max-w-4xl flex-1 px-3 pt-13 pb-6 md:pb-8"
-      >
-        <article className="space-y-8">
-          <div className="space-y-4">
-            <Breadcrumb>
-              <BreadcrumbList>
-                <BreadcrumbItem>
-                  <BreadcrumbLink render={<Link href="/" />}>
-                    Home
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbLink render={<Link href="/guides" />}>
-                    Guides
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbPage>RPI vs CPI</BreadcrumbPage>
-                </BreadcrumbItem>
-              </BreadcrumbList>
-            </Breadcrumb>
+    <PageLayout>
+      <article className="space-y-8">
+        <div className="space-y-4">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/guides" />}>
+                  Guides
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>RPI vs CPI</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
 
-            <Heading as="h1">
-              RPI vs CPI: Why Your Student Loan Interest Outpaces Inflation
-            </Heading>
-            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
-              Your student loan interest is tied to RPI, but when the calculator
-              shows &ldquo;adjusted for inflation,&rdquo; it uses CPI. RPI
-              typically runs 0.5&ndash;1% higher. That gap means your balance
-              grows faster than the general cost of living.
+          <Heading as="h1">
+            RPI vs CPI: Why Your Student Loan Interest Outpaces Inflation
+          </Heading>
+          <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+            Your student loan interest is tied to RPI, but when the calculator
+            shows &ldquo;adjusted for inflation,&rdquo; it uses CPI. RPI
+            typically runs 0.5&ndash;1% higher. That gap means your balance
+            grows faster than the general cost of living.
+          </p>
+        </div>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            What Are RPI and CPI?
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <ul className="list-disc space-y-2 pl-6">
+              <li>
+                <strong className="text-foreground">
+                  RPI (Retail Prices Index)
+                </strong>
+                : includes housing costs such as mortgage interest and council
+                tax. The Student Loans Company uses RPI to set loan interest
+                rates. Currently {formatPercent(rpi)}.
+              </li>
+              <li>
+                <strong className="text-foreground">
+                  CPI (Consumer Prices Index)
+                </strong>
+                : the Bank of England&apos;s target measure with a 2% target.
+                Excludes housing costs. This is what the calculator&apos;s
+                &ldquo;Adjust for inflation&rdquo; toggle uses.
+              </li>
+              <li>
+                <strong className="text-foreground">
+                  CPIH (CPI including Housing)
+                </strong>
+                : the ONS&apos;s preferred headline measure since 2017. Not used
+                for student loans.
+              </li>
+            </ul>
+            <p>
+              The government stopped using RPI for most purposes because it
+              overstates inflation, but student loans remain tied to it.
             </p>
           </div>
+        </section>
 
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              What Are RPI and CPI?
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <ul className="list-disc space-y-2 pl-6">
-                <li>
-                  <strong className="text-foreground">
-                    RPI (Retail Prices Index)
-                  </strong>
-                  : includes housing costs such as mortgage interest and council
-                  tax. The Student Loans Company uses RPI to set loan interest
-                  rates. Currently {formatPercent(rpi)}.
-                </li>
-                <li>
-                  <strong className="text-foreground">
-                    CPI (Consumer Prices Index)
-                  </strong>
-                  : the Bank of England&apos;s target measure with a 2% target.
-                  Excludes housing costs. This is what the calculator&apos;s
-                  &ldquo;Adjust for inflation&rdquo; toggle uses.
-                </li>
-                <li>
-                  <strong className="text-foreground">
-                    CPIH (CPI including Housing)
-                  </strong>
-                  : the ONS&apos;s preferred headline measure since 2017. Not
-                  used for student loans.
-                </li>
-              </ul>
-              <p>
-                The government stopped using RPI for most purposes because it
-                overstates inflation, but student loans remain tied to it.
-              </p>
-            </div>
-          </section>
-
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              Why Student Loans Use RPI
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <p>
-                Plan 2 was introduced in 2012 when RPI was still widely used
-                across government policy. The government has since acknowledged
-                that RPI overstates inflation due to the &ldquo;formula
-                effect&rdquo; &mdash; it uses an arithmetic mean rather than a
-                geometric mean, which systematically produces higher figures.
-              </p>
-              <p>
-                Plans exist to align RPI with CPIH by 2030, but current loan
-                terms are unlikely to change retroactively. Each plan uses RPI
-                in its interest formula:
-              </p>
-              <ul className="list-disc space-y-1 pl-6">
-                <li>
-                  <strong className="text-foreground">Plan 5</strong>: RPI only
-                  ({formatPercent(rpi)})
-                </li>
-                <li>
-                  <strong className="text-foreground">Plan 2</strong>: RPI to
-                  RPI + 3% ({formatPercent(rpi)} &ndash;{" "}
-                  {formatPercent(maxRate)}) depending on income
-                </li>
-                <li>
-                  <strong className="text-foreground">Plan 1 &amp; 4</strong>:
-                  lesser of RPI or base rate + 1% (currently{" "}
-                  {formatPercent(plan1Rate)})
-                </li>
-                <li>
-                  <strong className="text-foreground">Postgraduate</strong>: RPI
-                  + 3% ({formatPercent(maxRate)})
-                </li>
-              </ul>
-            </div>
-          </section>
-
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              The Gap Between RPI and CPI
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <p>
-                RPI historically exceeds CPI by roughly 0.5&ndash;1 percentage
-                points. With RPI at {formatPercent(rpi)} and the CPI target at{" "}
-                {formatPercent(cpiTarget)}, the current gap is {gap} percentage
-                points.
-              </p>
-              <p>
-                Two factors drive the gap: RPI includes housing costs that CPI
-                excludes, and RPI uses an arithmetic mean formula while CPI uses
-                a geometric mean. The arithmetic mean always produces a higher
-                result when prices are changing, which is why statisticians call
-                it the &ldquo;formula effect.&rdquo;
-              </p>
-              <p>
-                The chart below shows what this gap looks like over the life of
-                a Plan 5 loan.
-              </p>
-            </div>
-          </section>
-
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              Inflation Comparison
-            </Heading>
-            <div className="h-85 sm:h-105">
-              <InflationComparisonChart />
-            </div>
-            <p className="text-sm text-muted-foreground">
-              Plan 5, {"\u00a3"}45,000 balance. The gap between the CPI-adjusted
-              and RPI-adjusted lines is the real above-inflation cost.
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Why Student Loans Use RPI
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              Plan 2 was introduced in 2012 when RPI was still widely used
+              across government policy. The government has since acknowledged
+              that RPI overstates inflation due to the &ldquo;formula
+              effect&rdquo; &mdash; it uses an arithmetic mean rather than a
+              geometric mean, which systematically produces higher figures.
             </p>
-          </section>
+            <p>
+              Plans exist to align RPI with CPIH by 2030, but current loan terms
+              are unlikely to change retroactively. Each plan uses RPI in its
+              interest formula:
+            </p>
+            <ul className="list-disc space-y-1 pl-6">
+              <li>
+                <strong className="text-foreground">Plan 5</strong>: RPI only (
+                {formatPercent(rpi)})
+              </li>
+              <li>
+                <strong className="text-foreground">Plan 2</strong>: RPI to RPI
+                + 3% ({formatPercent(rpi)} &ndash; {formatPercent(maxRate)})
+                depending on income
+              </li>
+              <li>
+                <strong className="text-foreground">Plan 1 &amp; 4</strong>:
+                lesser of RPI or base rate + 1% (currently{" "}
+                {formatPercent(plan1Rate)})
+              </li>
+              <li>
+                <strong className="text-foreground">Postgraduate</strong>: RPI +
+                3% ({formatPercent(maxRate)})
+              </li>
+            </ul>
+          </div>
+        </section>
 
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              Nominal, CPI-Adjusted, and RPI-Adjusted: Three Ways to See Your
-              Loan
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            The Gap Between RPI and CPI
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              RPI historically exceeds CPI by roughly 0.5&ndash;1 percentage
+              points. With RPI at {formatPercent(rpi)} and the CPI target at{" "}
+              {formatPercent(cpiTarget)}, the current gap is {gap} percentage
+              points.
+            </p>
+            <p>
+              Two factors drive the gap: RPI includes housing costs that CPI
+              excludes, and RPI uses an arithmetic mean formula while CPI uses a
+              geometric mean. The arithmetic mean always produces a higher
+              result when prices are changing, which is why statisticians call
+              it the &ldquo;formula effect.&rdquo;
+            </p>
+            <p>
+              The chart below shows what this gap looks like over the life of a
+              Plan 5 loan.
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Inflation Comparison
+          </Heading>
+          <div className="h-85 sm:h-105">
+            <InflationComparisonChart />
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Plan 5, {"\u00a3"}45,000 balance. The gap between the CPI-adjusted
+            and RPI-adjusted lines is the real above-inflation cost.
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Nominal, CPI-Adjusted, and RPI-Adjusted: Three Ways to See Your Loan
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <ul className="list-disc space-y-2 pl-6">
+              <li>
+                <strong className="text-foreground">Nominal</strong>: the raw
+                balance on your SLC account. Grows at the loan interest rate.
+              </li>
+              <li>
+                <strong className="text-foreground">CPI-adjusted</strong>:
+                discounted by CPI &mdash; this is what the calculator&apos;s
+                &ldquo;Adjust for inflation&rdquo; toggle shows. It tells you
+                what the balance is worth in today&apos;s money.
+              </li>
+              <li>
+                <strong className="text-foreground">RPI-adjusted</strong>:
+                discounted by RPI. The balance appears roughly flat because RPI
+                is close to the interest rate itself. But this is misleading
+                because RPI overstates general inflation.
+              </li>
+            </ul>
+            <p>
+              The key insight: the gap between the CPI-adjusted and RPI-adjusted
+              lines is the real above-inflation cost of the loan.
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            What This Means for Your Plan
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <ul className="list-disc space-y-2 pl-6">
+              <li>
+                <strong className="text-foreground">Plan 5</strong>: &ldquo;RPI
+                only&rdquo; sounds gentle, but since RPI runs higher than CPI,
+                the loan still grows faster than general prices.
+              </li>
+              <li>
+                <strong className="text-foreground">Plan 2</strong>: the sliding
+                scale starts at RPI (already above CPI). High earners face RPI +
+                3%.
+              </li>
+              <li>
+                <strong className="text-foreground">Plan 1 &amp; 4</strong>:
+                capped at the lesser of RPI or base rate + 1%, so these
+                borrowers are somewhat shielded.
+              </li>
+              <li>
+                <strong className="text-foreground">Postgraduate</strong>: RPI +
+                3% means the largest gap above CPI of any plan.
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <div className="rounded-xl border bg-muted/50 p-5">
+            <Heading as="h2" size="subsection" className="mb-3">
+              Key Takeaways
             </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <ul className="list-disc space-y-2 pl-6">
-                <li>
-                  <strong className="text-foreground">Nominal</strong>: the raw
-                  balance on your SLC account. Grows at the loan interest rate.
-                </li>
-                <li>
-                  <strong className="text-foreground">CPI-adjusted</strong>:
-                  discounted by CPI &mdash; this is what the calculator&apos;s
-                  &ldquo;Adjust for inflation&rdquo; toggle shows. It tells you
-                  what the balance is worth in today&apos;s money.
-                </li>
-                <li>
-                  <strong className="text-foreground">RPI-adjusted</strong>:
-                  discounted by RPI. The balance appears roughly flat because
-                  RPI is close to the interest rate itself. But this is
-                  misleading because RPI overstates general inflation.
-                </li>
-              </ul>
-              <p>
-                The key insight: the gap between the CPI-adjusted and
-                RPI-adjusted lines is the real above-inflation cost of the loan.
-              </p>
-            </div>
-          </section>
+            <ul className="list-disc space-y-2 pl-6 text-muted-foreground">
+              <li>
+                RPI typically runs 0.5&ndash;1% higher than CPI &mdash; your
+                loan interest is tied to the higher measure.
+              </li>
+              <li>
+                &ldquo;Adjusted for inflation&rdquo; in the calculator uses CPI,
+                not RPI. Remaining growth after toggling is real above-inflation
+                cost.
+              </li>
+              <li>
+                Plan 5&apos;s &ldquo;inflation-only&rdquo; interest is
+                RPI-inflation, not CPI-inflation.
+              </li>
+              <li>
+                RPI may align with CPIH by 2030, but current borrowers are
+                unlikely to benefit.
+              </li>
+              <li>
+                See how inflation affects your total repayment with the{" "}
+                <Link
+                  href="/"
+                  className="text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  student loan calculator
+                </Link>
+                .
+              </li>
+            </ul>
+          </div>
+        </section>
 
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              What This Means for Your Plan
-            </Heading>
-            <div className="space-y-2 text-muted-foreground">
-              <ul className="list-disc space-y-2 pl-6">
-                <li>
-                  <strong className="text-foreground">Plan 5</strong>:
-                  &ldquo;RPI only&rdquo; sounds gentle, but since RPI runs
-                  higher than CPI, the loan still grows faster than general
-                  prices.
-                </li>
-                <li>
-                  <strong className="text-foreground">Plan 2</strong>: the
-                  sliding scale starts at RPI (already above CPI). High earners
-                  face RPI + 3%.
-                </li>
-                <li>
-                  <strong className="text-foreground">Plan 1 &amp; 4</strong>:
-                  capped at the lesser of RPI or base rate + 1%, so these
-                  borrowers are somewhat shielded.
-                </li>
-                <li>
-                  <strong className="text-foreground">Postgraduate</strong>: RPI
-                  + 3% means the largest gap above CPI of any plan.
-                </li>
-              </ul>
-            </div>
-          </section>
-
-          <section className="space-y-3">
-            <div className="rounded-xl border bg-muted/50 p-5">
-              <Heading as="h2" size="subsection" className="mb-3">
-                Key Takeaways
-              </Heading>
-              <ul className="list-disc space-y-2 pl-6 text-muted-foreground">
-                <li>
-                  RPI typically runs 0.5&ndash;1% higher than CPI &mdash; your
-                  loan interest is tied to the higher measure.
-                </li>
-                <li>
-                  &ldquo;Adjusted for inflation&rdquo; in the calculator uses
-                  CPI, not RPI. Remaining growth after toggling is real
-                  above-inflation cost.
-                </li>
-                <li>
-                  Plan 5&apos;s &ldquo;inflation-only&rdquo; interest is
-                  RPI-inflation, not CPI-inflation.
-                </li>
-                <li>
-                  RPI may align with CPIH by 2030, but current borrowers are
-                  unlikely to benefit.
-                </li>
-                <li>
-                  See how inflation affects your total repayment with the{" "}
-                  <Link
-                    href="/"
-                    className="text-primary underline underline-offset-4 hover:text-primary/80"
-                  >
-                    student loan calculator
-                  </Link>
-                  .
-                </li>
-              </ul>
-            </div>
-          </section>
-
-          <RelatedGuides
-            current="rpi-vs-cpi"
-            order={["how-interest-works", "plan-2-vs-plan-5"]}
-          />
-        </article>
-      </main>
-      <Footer />
-    </div>
+        <RelatedGuides
+          current="rpi-vs-cpi"
+          order={["how-interest-works", "plan-2-vs-plan-5"]}
+        />
+      </article>
+    </PageLayout>
   );
 }

--- a/src/components/guides/self-employment/SelfEmploymentGuide.tsx
+++ b/src/components/guides/self-employment/SelfEmploymentGuide.tsx
@@ -8,8 +8,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
-import { Footer } from "@/components/layout/Footer";
-import { Header } from "@/components/layout/Header";
+import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import {
   Breadcrumb,
@@ -29,380 +28,367 @@ const linkClasses =
 
 export function SelfEmploymentGuide() {
   return (
-    <div className="flex min-h-screen flex-col">
-      <Header />
-      <main
-        id="main-content"
-        className="mx-auto w-full max-w-4xl flex-1 space-y-8 overflow-x-hidden px-3 pt-13 pb-6 md:pb-8"
-      >
-        <article className="space-y-8">
-          <div className="space-y-4">
-            <Breadcrumb>
-              <BreadcrumbList>
-                <BreadcrumbItem>
-                  <BreadcrumbLink render={<Link href="/" />}>
-                    Home
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbLink render={<Link href="/guides" />}>
-                    Guides
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbPage>Self-Employment</BreadcrumbPage>
-                </BreadcrumbItem>
-              </BreadcrumbList>
-            </Breadcrumb>
+    <PageLayout>
+      <article className="space-y-8">
+        <div className="space-y-4">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/guides" />}>
+                  Guides
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>Self-Employment</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
 
-            <div className="space-y-2">
-              <Heading as="h1">Student Loans and Self-Employment</Heading>
-              <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
-                If you&rsquo;re self-employed, your student loan repayments work
-                differently from PAYE. Instead of automatic monthly deductions
-                from your payslip, you repay through your annual{" "}
-                <a
-                  href="https://www.gov.uk/self-assessment-tax-returns"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={linkClasses}
-                >
-                  Self Assessment tax return
-                </a>{" "}
-                — and that changes how you need to plan your finances.
+          <div className="space-y-2">
+            <Heading as="h1">Student Loans and Self-Employment</Heading>
+            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+              If you&rsquo;re self-employed, your student loan repayments work
+              differently from PAYE. Instead of automatic monthly deductions
+              from your payslip, you repay through your annual{" "}
+              <a
+                href="https://www.gov.uk/self-assessment-tax-returns"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={linkClasses}
+              >
+                Self Assessment tax return
+              </a>{" "}
+              — and that changes how you need to plan your finances.
+            </p>
+          </div>
+        </div>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            How Repayments Work Through Self Assessment
+          </Heading>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
+              <p className="mb-2 text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                PAYE (Employed)
               </p>
+              <ul className="space-y-1.5 text-sm text-muted-foreground">
+                <li className="flex gap-2">
+                  <span className="text-primary">&#x2022;</span>Monthly
+                  deductions from payslip
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-primary">&#x2022;</span>Automatic —
+                  employer handles it
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-primary">&#x2022;</span>Based on salary
+                  each pay period
+                </li>
+              </ul>
+            </div>
+            <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
+              <p className="mb-2 text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                Self Assessment (Self-employed)
+              </p>
+              <ul className="space-y-1.5 text-sm text-muted-foreground">
+                <li className="flex gap-2">
+                  <span className="text-primary">&#x2022;</span>Annual lump sums
+                  (Jan &amp; Jul)
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-primary">&#x2022;</span>You calculate
+                  and submit
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-primary">&#x2022;</span>Based on net
+                  profit for the year
+                </li>
+              </ul>
             </div>
           </div>
 
-          <section className="space-y-4">
-            <Heading as="h2" size="section">
-              How Repayments Work Through Self Assessment
-            </Heading>
-
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
-                <p className="mb-2 text-xs font-semibold tracking-wider text-muted-foreground uppercase">
-                  PAYE (Employed)
-                </p>
-                <ul className="space-y-1.5 text-sm text-muted-foreground">
-                  <li className="flex gap-2">
-                    <span className="text-primary">&#x2022;</span>Monthly
-                    deductions from payslip
-                  </li>
-                  <li className="flex gap-2">
-                    <span className="text-primary">&#x2022;</span>Automatic —
-                    employer handles it
-                  </li>
-                  <li className="flex gap-2">
-                    <span className="text-primary">&#x2022;</span>Based on
-                    salary each pay period
-                  </li>
-                </ul>
-              </div>
-              <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
-                <p className="mb-2 text-xs font-semibold tracking-wider text-muted-foreground uppercase">
-                  Self Assessment (Self-employed)
-                </p>
-                <ul className="space-y-1.5 text-sm text-muted-foreground">
-                  <li className="flex gap-2">
-                    <span className="text-primary">&#x2022;</span>Annual lump
-                    sums (Jan &amp; Jul)
-                  </li>
-                  <li className="flex gap-2">
-                    <span className="text-primary">&#x2022;</span>You calculate
-                    and submit
-                  </li>
-                  <li className="flex gap-2">
-                    <span className="text-primary">&#x2022;</span>Based on net
-                    profit for the year
-                  </li>
-                </ul>
-              </div>
-            </div>
-
-            <div className="space-y-3 text-sm text-muted-foreground sm:text-base">
-              <p>
-                When you&rsquo;re employed, your employer deducts student loan
-                repayments from your salary each month via PAYE. When
-                you&rsquo;re self-employed, there is no employer to do this —
-                HMRC calculates your repayment based on your{" "}
-                <a
-                  href="https://www.gov.uk/self-assessment-tax-returns"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={linkClasses}
-                >
-                  Self Assessment tax return
-                </a>{" "}
-                instead.
-              </p>
-              <p>
-                This means your repayments are <strong>annual</strong>, not
-                monthly. You typically pay in two lump sums: one in January and
-                one in July (as part of HMRC&rsquo;s{" "}
-                <a
-                  href="https://www.gov.uk/understand-self-assessment-bill/payments-on-account"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={linkClasses}
-                >
-                  payment on account
-                </a>{" "}
-                system). The repayment is {undergradRate} of your net profit
-                above the repayment threshold for Plan 2 and Plan 5, or{" "}
-                {postgradRate} for Postgraduate Loans.
-              </p>
-              <p>
-                Because payments are based on your <strong>profit</strong> — not
-                your total revenue — business expenses you claim directly reduce
-                your student loan repayment as well as your tax bill.
-              </p>
-            </div>
-          </section>
-
-          <section className="space-y-4">
-            <Heading as="h2" size="section">
-              What Counts as Income?
-            </Heading>
-            <p className="text-sm text-muted-foreground sm:text-base">
-              HMRC looks at your total taxable income when calculating student
-              loan repayments. For the self-employed, this includes:
+          <div className="space-y-3 text-sm text-muted-foreground sm:text-base">
+            <p>
+              When you&rsquo;re employed, your employer deducts student loan
+              repayments from your salary each month via PAYE. When you&rsquo;re
+              self-employed, there is no employer to do this — HMRC calculates
+              your repayment based on your{" "}
+              <a
+                href="https://www.gov.uk/self-assessment-tax-returns"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={linkClasses}
+              >
+                Self Assessment tax return
+              </a>{" "}
+              instead.
             </p>
-            <div className="grid gap-3 sm:grid-cols-3">
-              <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
-                <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
-                  <HugeiconsIcon
-                    icon={Calculator01Icon}
-                    className="size-5 text-primary"
-                  />
-                </div>
-                <p className="font-medium">Net Profit</p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  Revenue minus allowable business expenses from
-                  self-employment.
-                </p>
-              </div>
-              <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
-                <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
-                  <HugeiconsIcon
-                    icon={Briefcase01Icon}
-                    className="size-5 text-primary"
-                  />
-                </div>
-                <p className="font-medium">Employment Income</p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  Salary from a PAYE job if you also have one alongside
-                  freelancing.
-                </p>
-              </div>
-              <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
-                <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
-                  <HugeiconsIcon
-                    icon={Coins01Icon}
-                    className="size-5 text-primary"
-                  />
-                </div>
-                <p className="font-medium">Other Taxable Income</p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  Rental income, dividends, interest above your personal savings
-                  allowance, etc.
-                </p>
-              </div>
-            </div>
-            <p className="text-sm text-muted-foreground sm:text-base">
-              All of these sources are combined to determine whether you exceed
-              the repayment threshold and how much you owe.
+            <p>
+              This means your repayments are <strong>annual</strong>, not
+              monthly. You typically pay in two lump sums: one in January and
+              one in July (as part of HMRC&rsquo;s{" "}
+              <a
+                href="https://www.gov.uk/understand-self-assessment-bill/payments-on-account"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={linkClasses}
+              >
+                payment on account
+              </a>{" "}
+              system). The repayment is {undergradRate} of your net profit above
+              the repayment threshold for Plan 2 and Plan 5, or {postgradRate}{" "}
+              for Postgraduate Loans.
             </p>
-          </section>
+            <p>
+              Because payments are based on your <strong>profit</strong> — not
+              your total revenue — business expenses you claim directly reduce
+              your student loan repayment as well as your tax bill.
+            </p>
+          </div>
+        </section>
 
-          <section className="space-y-4">
-            <Heading as="h2" size="section">
-              Mixed Employment
-            </Heading>
-            <div className="space-y-3 text-sm text-muted-foreground sm:text-base">
-              <p>
-                Many freelancers also have a part-time or full-time PAYE job. If
-                this applies to you, HMRC collects repayments through both
-                mechanisms:
-              </p>
-              <ul className="list-inside list-disc space-y-2">
-                <li>
-                  Your employer deducts repayments from your salary
-                  automatically via PAYE
-                </li>
-                <li>
-                  Your Self Assessment tops up the difference based on your
-                  combined total income
-                </li>
-              </ul>
-              <p>
-                For example, if your PAYE salary is below the threshold but your
-                combined income (salary + freelance profit) is above it,
-                you&rsquo;ll owe the full repayment through Self Assessment. If
-                your PAYE income alone exceeds the threshold, your employer
-                already deducts repayments — and Self Assessment adds further
-                repayments on your self-employment profit.
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            What Counts as Income?
+          </Heading>
+          <p className="text-sm text-muted-foreground sm:text-base">
+            HMRC looks at your total taxable income when calculating student
+            loan repayments. For the self-employed, this includes:
+          </p>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
+              <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
+                <HugeiconsIcon
+                  icon={Calculator01Icon}
+                  className="size-5 text-primary"
+                />
+              </div>
+              <p className="font-medium">Net Profit</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Revenue minus allowable business expenses from self-employment.
               </p>
             </div>
-          </section>
-
-          <section className="space-y-4">
-            <Heading as="h2" size="section">
-              Common Mistakes to Avoid
-            </Heading>
-            <div className="grid gap-3 sm:grid-cols-2">
-              {[
-                {
-                  title: "Not budgeting for annual payments",
-                  description:
-                    "Unlike monthly PAYE deductions, Self Assessment repayments arrive as large lump sums. A sudden bill of several thousand pounds in January can catch freelancers off guard.",
-                },
-                {
-                  title: "Late filing penalties",
-                  description:
-                    "Missing the 31 January Self Assessment deadline means a \u00A3100 penalty \u2014 plus your student loan repayment is delayed, which can lead to estimated charges from HMRC.",
-                },
-                {
-                  title: "Underestimating income",
-                  description:
-                    "If your payments on account are based on a lower previous year, you may face a balancing payment when your actual profit is higher than expected.",
-                },
-                {
-                  title: "Not claiming legitimate expenses",
-                  description:
-                    "Every pound of allowable business expense you miss increases your net profit \u2014 and therefore your student loan repayment. Common overlooked expenses include home office costs, professional subscriptions, and travel.",
-                },
-              ].map((mistake, i) => (
-                <div
-                  key={i}
-                  className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10"
-                >
-                  <div className="mb-2 flex items-center gap-2.5">
-                    <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-destructive/10 text-sm font-semibold text-destructive">
-                      <HugeiconsIcon
-                        icon={AlertCircleIcon}
-                        className="size-4"
-                      />
-                    </span>
-                    <p className="font-medium">{mistake.title}</p>
-                  </div>
-                  <p className="text-sm text-muted-foreground">
-                    {mistake.description}
-                  </p>
-                </div>
-              ))}
+            <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
+              <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
+                <HugeiconsIcon
+                  icon={Briefcase01Icon}
+                  className="size-5 text-primary"
+                />
+              </div>
+              <p className="font-medium">Employment Income</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Salary from a PAYE job if you also have one alongside
+                freelancing.
+              </p>
             </div>
-          </section>
-
-          <section className="space-y-4">
-            <Heading as="h2" size="section">
-              Practical Tips for Freelancers
-            </Heading>
-            <div className="grid gap-3 sm:grid-cols-2">
-              {[
-                {
-                  title: `Set aside ${undergradRate} monthly`,
-                  description: `Calculate ${undergradRate} of your profit above the repayment threshold each month and put it in a separate savings account. This avoids a nasty surprise when your tax bill arrives.`,
-                },
-                {
-                  title: "Register for Self Assessment early",
-                  description: (
-                    <>
-                      You must{" "}
-                      <a
-                        href="https://www.gov.uk/register-for-self-assessment"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className={linkClasses}
-                      >
-                        register with HMRC by 5 October
-                      </a>{" "}
-                      following the end of the tax year in which you became
-                      self-employed. Registering late can result in penalties.
-                    </>
-                  ),
-                },
-                {
-                  title: "Keep good records",
-                  description:
-                    "Track all income and expenses throughout the year. Good record-keeping makes filing easier and ensures you claim every expense you\u2019re entitled to.",
-                },
-                {
-                  title: "Consider an accountant",
-                  description:
-                    "An accountant familiar with student loans can help you optimise your expenses, avoid mistakes, and ensure your repayments are calculated correctly.",
-                },
-              ].map((tip, i) => (
-                <div
-                  key={i}
-                  className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10"
-                >
-                  <div className="mb-2 flex items-center gap-2.5">
-                    <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/10">
-                      <HugeiconsIcon
-                        icon={BulbIcon}
-                        className="size-4 text-primary"
-                      />
-                    </span>
-                    <p className="font-medium">{tip.title}</p>
-                  </div>
-                  <p className="text-sm text-muted-foreground">
-                    {tip.description}
-                  </p>
-                </div>
-              ))}
+            <div className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10">
+              <div className="mb-2 flex size-9 items-center justify-center rounded-full bg-primary/10">
+                <HugeiconsIcon
+                  icon={Coins01Icon}
+                  className="size-5 text-primary"
+                />
+              </div>
+              <p className="font-medium">Other Taxable Income</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Rental income, dividends, interest above your personal savings
+                allowance, etc.
+              </p>
             </div>
-          </section>
+          </div>
+          <p className="text-sm text-muted-foreground sm:text-base">
+            All of these sources are combined to determine whether you exceed
+            the repayment threshold and how much you owe.
+          </p>
+        </section>
 
-          <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
-            <Heading as="h2" size="subsection">
-              Key Takeaways
-            </Heading>
-            <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Mixed Employment
+          </Heading>
+          <div className="space-y-3 text-sm text-muted-foreground sm:text-base">
+            <p>
+              Many freelancers also have a part-time or full-time PAYE job. If
+              this applies to you, HMRC collects repayments through both
+              mechanisms:
+            </p>
+            <ul className="list-inside list-disc space-y-2">
               <li>
-                Self-employed borrowers repay through Self Assessment, not PAYE
-                — expect annual lump-sum payments, not monthly deductions.
+                Your employer deducts repayments from your salary automatically
+                via PAYE
               </li>
               <li>
-                Repayments are based on <strong>net profit</strong>, so claiming
-                all legitimate business expenses directly reduces what you owe.
-              </li>
-              <li>
-                If you have mixed income (PAYE + freelance), HMRC collects
-                through both mechanisms based on your combined total income.
-              </li>
-              <li>
-                Budget monthly by setting aside {undergradRate} of profit above
-                the threshold to avoid being caught out by large tax bills.
-              </li>
-              <li>
-                Estimate your annual repayments with the{" "}
-                <Link
-                  href="/"
-                  className="text-primary underline underline-offset-4 hover:text-primary/80"
-                >
-                  student loan calculator
-                </Link>
-                .
+                Your Self Assessment tops up the difference based on your
+                combined total income
               </li>
             </ul>
-          </section>
+            <p>
+              For example, if your PAYE salary is below the threshold but your
+              combined income (salary + freelance profit) is above it,
+              you&rsquo;ll owe the full repayment through Self Assessment. If
+              your PAYE income alone exceeds the threshold, your employer
+              already deducts repayments — and Self Assessment adds further
+              repayments on your self-employment profit.
+            </p>
+          </div>
+        </section>
 
-          <RelatedGuides
-            current="self-employment"
-            order={["moving-abroad", "plan-2-vs-plan-5"]}
-            extraLinks={[
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Common Mistakes to Avoid
+          </Heading>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {[
               {
-                href: "https://www.gov.uk/repaying-your-student-loan/repaying-student-loans-overview",
-                label: "GOV.UK: Repaying Your Student Loan",
+                title: "Not budgeting for annual payments",
+                description:
+                  "Unlike monthly PAYE deductions, Self Assessment repayments arrive as large lump sums. A sudden bill of several thousand pounds in January can catch freelancers off guard.",
               },
-            ]}
-          />
-        </article>
-      </main>
-      <Footer />
-    </div>
+              {
+                title: "Late filing penalties",
+                description:
+                  "Missing the 31 January Self Assessment deadline means a \u00A3100 penalty \u2014 plus your student loan repayment is delayed, which can lead to estimated charges from HMRC.",
+              },
+              {
+                title: "Underestimating income",
+                description:
+                  "If your payments on account are based on a lower previous year, you may face a balancing payment when your actual profit is higher than expected.",
+              },
+              {
+                title: "Not claiming legitimate expenses",
+                description:
+                  "Every pound of allowable business expense you miss increases your net profit \u2014 and therefore your student loan repayment. Common overlooked expenses include home office costs, professional subscriptions, and travel.",
+              },
+            ].map((mistake, i) => (
+              <div
+                key={i}
+                className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10"
+              >
+                <div className="mb-2 flex items-center gap-2.5">
+                  <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-destructive/10 text-sm font-semibold text-destructive">
+                    <HugeiconsIcon icon={AlertCircleIcon} className="size-4" />
+                  </span>
+                  <p className="font-medium">{mistake.title}</p>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  {mistake.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Practical Tips for Freelancers
+          </Heading>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {[
+              {
+                title: `Set aside ${undergradRate} monthly`,
+                description: `Calculate ${undergradRate} of your profit above the repayment threshold each month and put it in a separate savings account. This avoids a nasty surprise when your tax bill arrives.`,
+              },
+              {
+                title: "Register for Self Assessment early",
+                description: (
+                  <>
+                    You must{" "}
+                    <a
+                      href="https://www.gov.uk/register-for-self-assessment"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={linkClasses}
+                    >
+                      register with HMRC by 5 October
+                    </a>{" "}
+                    following the end of the tax year in which you became
+                    self-employed. Registering late can result in penalties.
+                  </>
+                ),
+              },
+              {
+                title: "Keep good records",
+                description:
+                  "Track all income and expenses throughout the year. Good record-keeping makes filing easier and ensures you claim every expense you\u2019re entitled to.",
+              },
+              {
+                title: "Consider an accountant",
+                description:
+                  "An accountant familiar with student loans can help you optimise your expenses, avoid mistakes, and ensure your repayments are calculated correctly.",
+              },
+            ].map((tip, i) => (
+              <div
+                key={i}
+                className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10"
+              >
+                <div className="mb-2 flex items-center gap-2.5">
+                  <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/10">
+                    <HugeiconsIcon
+                      icon={BulbIcon}
+                      className="size-4 text-primary"
+                    />
+                  </span>
+                  <p className="font-medium">{tip.title}</p>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  {tip.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
+          <Heading as="h2" size="subsection">
+            Key Takeaways
+          </Heading>
+          <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+            <li>
+              Self-employed borrowers repay through Self Assessment, not PAYE —
+              expect annual lump-sum payments, not monthly deductions.
+            </li>
+            <li>
+              Repayments are based on <strong>net profit</strong>, so claiming
+              all legitimate business expenses directly reduces what you owe.
+            </li>
+            <li>
+              If you have mixed income (PAYE + freelance), HMRC collects through
+              both mechanisms based on your combined total income.
+            </li>
+            <li>
+              Budget monthly by setting aside {undergradRate} of profit above
+              the threshold to avoid being caught out by large tax bills.
+            </li>
+            <li>
+              Estimate your annual repayments with the{" "}
+              <Link
+                href="/"
+                className="text-primary underline underline-offset-4 hover:text-primary/80"
+              >
+                student loan calculator
+              </Link>
+              .
+            </li>
+          </ul>
+        </section>
+
+        <RelatedGuides
+          current="self-employment"
+          order={["moving-abroad", "plan-2-vs-plan-5"]}
+          extraLinks={[
+            {
+              href: "https://www.gov.uk/repaying-your-student-loan/repaying-student-loans-overview",
+              label: "GOV.UK: Repaying Your Student Loan",
+            },
+          ]}
+        />
+      </article>
+    </PageLayout>
   );
 }

--- a/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
+++ b/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
@@ -1,8 +1,7 @@
 import Link from "next/link";
 import { RepaymentImpactChart } from "./RepaymentImpactChart";
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
-import { Footer } from "@/components/layout/Footer";
-import { Header } from "@/components/layout/Header";
+import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import {
   Breadcrumb,
@@ -36,173 +35,163 @@ const example60kMortgageReduction = Math.round(example60kAnnual * 4.5);
 
 export function MortgageGuide() {
   return (
-    <div className="flex min-h-screen flex-col">
-      <Header />
-      <main
-        id="main-content"
-        className="mx-auto w-full max-w-4xl flex-1 space-y-8 px-3 pt-13 pb-6 md:pb-8"
-      >
-        <article className="space-y-8">
-          <div className="space-y-4">
-            <Breadcrumb>
-              <BreadcrumbList>
-                <BreadcrumbItem>
-                  <BreadcrumbLink render={<Link href="/" />}>
-                    Home
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbLink render={<Link href="/guides" />}>
-                    Guides
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbPage>Student Loans & Mortgages</BreadcrumbPage>
-                </BreadcrumbItem>
-              </BreadcrumbList>
-            </Breadcrumb>
+    <PageLayout>
+      <article className="space-y-8">
+        <div className="space-y-4">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/guides" />}>
+                  Guides
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>Student Loans & Mortgages</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
 
-            <Heading as="h1">
-              Does Your Student Loan Affect Your Mortgage?
-            </Heading>
+          <Heading as="h1">
+            Does Your Student Loan Affect Your Mortgage?
+          </Heading>
 
-            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
-              Your student loan won&rsquo;t stop you getting a mortgage, but the
-              monthly repayments reduce how much lenders think you can afford.
-              Here&rsquo;s how it works.
+          <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+            Your student loan won&rsquo;t stop you getting a mortgage, but the
+            monthly repayments reduce how much lenders think you can afford.
+            Here&rsquo;s how it works.
+          </p>
+        </div>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            How Lenders See Your Student Loan
+          </Heading>
+          <div className="space-y-3 text-muted-foreground">
+            <p>
+              Unlike credit cards or car finance, a UK student loan is not
+              treated as conventional debt. It doesn&rsquo;t appear on your
+              credit report and won&rsquo;t lower your credit score.
+            </p>
+            <p>
+              However, mortgage lenders do factor in the monthly repayment. When
+              they assess your affordability, they look at your net disposable
+              income after tax, National Insurance, pension contributions, and
+              student loan repayments. A higher repayment means less income
+              available for mortgage payments.
             </p>
           </div>
+        </section>
 
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              How Lenders See Your Student Loan
-            </Heading>
-            <div className="space-y-3 text-muted-foreground">
-              <p>
-                Unlike credit cards or car finance, a UK student loan is not
-                treated as conventional debt. It doesn&rsquo;t appear on your
-                credit report and won&rsquo;t lower your credit score.
-              </p>
-              <p>
-                However, mortgage lenders do factor in the monthly repayment.
-                When they assess your affordability, they look at your net
-                disposable income after tax, National Insurance, pension
-                contributions, and student loan repayments. A higher repayment
-                means less income available for mortgage payments.
-              </p>
-            </div>
-          </section>
-
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              The Repayment &ldquo;Tax&rdquo;
-            </Heading>
-            <div className="space-y-3 text-muted-foreground">
-              <p>
-                Student loan repayments work like an extra income tax. You pay{" "}
-                {repaymentRateDisplay} of everything you earn above your
-                plan&rsquo;s repayment threshold. The higher your salary, the
-                more you repay each month, and the bigger the impact on your
-                mortgage affordability.
-              </p>
-              <p>
-                Plan 5 has a lower threshold than Plan 2, so repayments start
-                sooner and are slightly higher at every salary level. The chart
-                below shows exactly how much you&rsquo;d repay each month.
-              </p>
-            </div>
-          </section>
-
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              Monthly Repayment by Salary
-            </Heading>
-            <div className="h-75 sm:h-90">
-              <RepaymentImpactChart />
-            </div>
-            <p className="text-sm text-muted-foreground">
-              Based on current thresholds: Plan 2 at {formatGBP(plan2Threshold)}{" "}
-              and Plan 5 at {formatGBP(plan5Threshold)} per year. Both charge{" "}
-              {repaymentRateDisplay} on income above the threshold.
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            The Repayment &ldquo;Tax&rdquo;
+          </Heading>
+          <div className="space-y-3 text-muted-foreground">
+            <p>
+              Student loan repayments work like an extra income tax. You pay{" "}
+              {repaymentRateDisplay} of everything you earn above your
+              plan&rsquo;s repayment threshold. The higher your salary, the more
+              you repay each month, and the bigger the impact on your mortgage
+              affordability.
             </p>
-          </section>
+            <p>
+              Plan 5 has a lower threshold than Plan 2, so repayments start
+              sooner and are slightly higher at every salary level. The chart
+              below shows exactly how much you&rsquo;d repay each month.
+            </p>
+          </div>
+        </section>
 
-          <section className="space-y-3">
-            <Heading as="h2" size="section">
-              What This Means for Your Borrowing Capacity
-            </Heading>
-            <div className="space-y-3 text-muted-foreground">
-              <p>
-                Most lenders offer roughly 4 to 4.5 times your annual income as
-                a mortgage. But they calculate that multiple based on your
-                income after committed expenditure, including student loan
-                repayments.
-              </p>
-              <p>
-                For example, someone earning &pound;40,000 on Plan 2 repays
-                about {formatGBP(example40kMonthly)} per month. Annualised,
-                that&rsquo;s around {formatGBP(example40kAnnual)} which a lender
-                might effectively subtract from income before applying their
-                multiplier. On a 4.5x basis, that reduces the maximum mortgage
-                by roughly {formatGBP(example40kMortgageReduction)}.
-              </p>
-              <p>
-                At higher salaries the gap grows. At &pound;60,000 the monthly
-                repayment is roughly {formatGBP(example60kMonthly)}, trimming
-                potential borrowing by about{" "}
-                {formatGBP(example60kMortgageReduction)} on the same multiplier.
-                Use the{" "}
-                <Link
-                  href="/"
-                  className="text-primary underline underline-offset-4 hover:text-primary/80"
-                >
-                  student loan repayment calculator
-                </Link>{" "}
-                to see your exact monthly repayment at your salary.
-              </p>
-            </div>
-          </section>
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Monthly Repayment by Salary
+          </Heading>
+          <div className="h-75 sm:h-90">
+            <RepaymentImpactChart />
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Based on current thresholds: Plan 2 at {formatGBP(plan2Threshold)}{" "}
+            and Plan 5 at {formatGBP(plan5Threshold)} per year. Both charge{" "}
+            {repaymentRateDisplay} on income above the threshold.
+          </p>
+        </section>
 
-          <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
-            <Heading as="h2" size="subsection">
-              Key Takeaways
-            </Heading>
-            <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
-              <li>
-                A student loan is <strong>not</strong> conventional debt &mdash;
-                it won&rsquo;t appear on your credit report.
-              </li>
-              <li>
-                Lenders deduct your monthly repayment when calculating how much
-                you can borrow, reducing your affordability.
-              </li>
-              <li>
-                Your credit score is <strong>not</strong> affected by having a
-                student loan.
-              </li>
-              <li>
-                Any remaining balance is written off after{" "}
-                {PLAN_CONFIGS.PLAN_2.writeOffYears} years (Plan 2) or{" "}
-                {PLAN_CONFIGS.PLAN_5.writeOffYears} years (Plan 5) &mdash; you
-                are never chased for unpaid amounts.
-              </li>
-              <li>
-                Overpaying your student loan to boost mortgage affordability
-                rarely makes sense &mdash; the reduction in borrowing power is
-                modest compared to deposit savings.
-              </li>
-            </ul>
-          </section>
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            What This Means for Your Borrowing Capacity
+          </Heading>
+          <div className="space-y-3 text-muted-foreground">
+            <p>
+              Most lenders offer roughly 4 to 4.5 times your annual income as a
+              mortgage. But they calculate that multiple based on your income
+              after committed expenditure, including student loan repayments.
+            </p>
+            <p>
+              For example, someone earning &pound;40,000 on Plan 2 repays about{" "}
+              {formatGBP(example40kMonthly)} per month. Annualised, that&rsquo;s
+              around {formatGBP(example40kAnnual)} which a lender might
+              effectively subtract from income before applying their multiplier.
+              On a 4.5x basis, that reduces the maximum mortgage by roughly{" "}
+              {formatGBP(example40kMortgageReduction)}.
+            </p>
+            <p>
+              At higher salaries the gap grows. At &pound;60,000 the monthly
+              repayment is roughly {formatGBP(example60kMonthly)}, trimming
+              potential borrowing by about{" "}
+              {formatGBP(example60kMortgageReduction)} on the same multiplier.
+              Use the{" "}
+              <Link
+                href="/"
+                className="text-primary underline underline-offset-4 hover:text-primary/80"
+              >
+                student loan repayment calculator
+              </Link>{" "}
+              to see your exact monthly repayment at your salary.
+            </p>
+          </div>
+        </section>
 
-          <RelatedGuides
-            current="student-loan-vs-mortgage"
-            order={["plan-2-vs-plan-5", "how-interest-works"]}
-          />
-        </article>
-      </main>
-      <Footer />
-    </div>
+        <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
+          <Heading as="h2" size="subsection">
+            Key Takeaways
+          </Heading>
+          <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+            <li>
+              A student loan is <strong>not</strong> conventional debt &mdash;
+              it won&rsquo;t appear on your credit report.
+            </li>
+            <li>
+              Lenders deduct your monthly repayment when calculating how much
+              you can borrow, reducing your affordability.
+            </li>
+            <li>
+              Your credit score is <strong>not</strong> affected by having a
+              student loan.
+            </li>
+            <li>
+              Any remaining balance is written off after{" "}
+              {PLAN_CONFIGS.PLAN_2.writeOffYears} years (Plan 2) or{" "}
+              {PLAN_CONFIGS.PLAN_5.writeOffYears} years (Plan 5) &mdash; you are
+              never chased for unpaid amounts.
+            </li>
+            <li>
+              Overpaying your student loan to boost mortgage affordability
+              rarely makes sense &mdash; the reduction in borrowing power is
+              modest compared to deposit savings.
+            </li>
+          </ul>
+        </section>
+
+        <RelatedGuides
+          current="student-loan-vs-mortgage"
+          order={["plan-2-vs-plan-5", "how-interest-works"]}
+        />
+      </article>
+    </PageLayout>
   );
 }

--- a/src/components/layout/PageLayout.tsx
+++ b/src/components/layout/PageLayout.tsx
@@ -1,0 +1,31 @@
+import { Footer } from "@/components/layout/Footer";
+import { Header } from "@/components/layout/Header";
+import { cn } from "@/lib/utils";
+
+interface PageLayoutProps {
+  children: React.ReactNode;
+  repaymentYear?: number;
+  mainClassName?: string;
+}
+
+export function PageLayout({
+  children,
+  repaymentYear,
+  mainClassName,
+}: PageLayoutProps) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header repaymentYear={repaymentYear} />
+      <main
+        id="main-content"
+        className={cn(
+          "mx-auto w-full max-w-4xl flex-1 space-y-8 px-3 pt-8 pb-6 sm:pt-18 md:pb-8",
+          mainClassName,
+        )}
+      >
+        {children}
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/our-data/OurDataPage.tsx
+++ b/src/components/our-data/OurDataPage.tsx
@@ -10,8 +10,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
-import { Footer } from "@/components/layout/Footer";
-import { Header } from "@/components/layout/Header";
+import { PageLayout } from "@/components/layout/PageLayout";
 import { ScrollFadeWrapper } from "@/components/shared/ScrollFadeWrapper";
 import { Heading } from "@/components/typography/Heading";
 import {
@@ -153,188 +152,172 @@ const formattedLastUpdated = new Intl.DateTimeFormat("en-GB", {
 
 export function OurDataPage() {
   return (
-    <div className="flex min-h-screen flex-col">
-      <Header />
-      <main
-        id="main-content"
-        className="mx-auto w-full max-w-4xl flex-1 px-3 pt-13 pb-6 md:pb-8"
-      >
-        <article className="space-y-10">
-          {/* Hero */}
-          <div className="space-y-4">
-            <Breadcrumb>
-              <BreadcrumbList>
-                <BreadcrumbItem>
-                  <BreadcrumbLink render={<Link href="/" />}>
-                    Home
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbPage>Our Data</BreadcrumbPage>
-                </BreadcrumbItem>
-              </BreadcrumbList>
-            </Breadcrumb>
-            <div className="space-y-3">
-              <Heading as="h1">
-                Every figure comes straight from the source
-              </Heading>
-              <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
-                Our calculators use official figures from GOV.UK, the Bank of
-                England, and the ONS. They&rsquo;re checked every day by an
-                automated system&nbsp;&mdash; if anything changes, we update
-                within 24 hours.
-              </p>
-            </div>
-            <div className="flex items-center gap-2 rounded-xl bg-muted/30 px-4 py-3">
-              <HugeiconsIcon
-                icon={Tick02Icon}
-                className="size-4 text-primary"
-              />
-              <p className="text-sm text-muted-foreground">
-                Figures last updated{" "}
-                <span className="font-medium text-foreground">
-                  {formattedLastUpdated}
-                </span>
-              </p>
-            </div>
+    <PageLayout>
+      <article className="space-y-10">
+        {/* Hero */}
+        <div className="space-y-4">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>Our Data</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+          <div className="space-y-3">
+            <Heading as="h1">
+              Every figure comes straight from the source
+            </Heading>
+            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+              Our calculators use official figures from GOV.UK, the Bank of
+              England, and the ONS. They&rsquo;re checked every day by an
+              automated system&nbsp;&mdash; if anything changes, we update
+              within 24 hours.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 rounded-xl bg-muted/30 px-4 py-3">
+            <HugeiconsIcon icon={Tick02Icon} className="size-4 text-primary" />
+            <p className="text-sm text-muted-foreground">
+              Figures last updated{" "}
+              <span className="font-medium text-foreground">
+                {formattedLastUpdated}
+              </span>
+            </p>
+          </div>
+        </div>
+
+        {/* What we track */}
+        <section className="space-y-5">
+          <Heading as="h2" size="section">
+            What we track
+          </Heading>
+
+          {/* Rate cards */}
+          <div className="grid gap-3 sm:grid-cols-3">
+            {RATES.map((rate) => (
+              <div
+                key={rate.label}
+                className="rounded-xl bg-card p-4 ring-1 ring-foreground/10"
+              >
+                <p className="text-xs font-medium tracking-widest text-muted-foreground uppercase">
+                  {rate.label}
+                </p>
+                <p className="mt-2 font-mono text-3xl font-semibold tracking-tight text-primary tabular-nums">
+                  {rate.value}%
+                </p>
+                <p className="mt-1.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <HugeiconsIcon icon={rate.icon} className="size-3" />
+                  {rate.source}
+                </p>
+              </div>
+            ))}
           </div>
 
-          {/* What we track */}
-          <section className="space-y-5">
-            <Heading as="h2" size="section">
-              What we track
-            </Heading>
+          {/* Plan table */}
+          <ScrollFadeWrapper className="rounded-xl ring-1 ring-foreground/10">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Plan</TableHead>
+                  <TableHead>Annual threshold</TableHead>
+                  <TableHead>Rate</TableHead>
+                  <TableHead>Write-off</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {plans.map((p) => (
+                  <TableRow key={p.label}>
+                    <TableCell className="font-medium">{p.label}</TableCell>
+                    <TableCell className="font-mono tabular-nums">
+                      {formatGBP(p.threshold)}
+                    </TableCell>
+                    <TableCell className="font-mono tabular-nums">
+                      {Math.round(p.rate * 100)}%
+                    </TableCell>
+                    <TableCell>{p.writeOff} years</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </ScrollFadeWrapper>
+        </section>
 
-            {/* Rate cards */}
-            <div className="grid gap-3 sm:grid-cols-3">
-              {RATES.map((rate) => (
+        {/* How it stays current */}
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            How it stays current
+          </Heading>
+          <p className="text-sm text-muted-foreground sm:text-base">
+            We run an automatic check every day so you never have to wonder if
+            our numbers are current.
+          </p>
+          <div>
+            {PIPELINE_STEPS.map((step, i) => (
+              <div key={step.title} className="flex gap-4">
+                <div className="flex flex-col items-center">
+                  <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary ring-4 ring-background">
+                    <HugeiconsIcon icon={step.icon} className="size-4" />
+                  </div>
+                  {i < PIPELINE_STEPS.length - 1 && (
+                    <div className="my-1.5 w-px flex-1 bg-border" />
+                  )}
+                </div>
                 <div
-                  key={rate.label}
-                  className="rounded-xl bg-card p-4 ring-1 ring-foreground/10"
+                  className={i < PIPELINE_STEPS.length - 1 ? "pb-5" : undefined}
                 >
-                  <p className="text-xs font-medium tracking-widest text-muted-foreground uppercase">
-                    {rate.label}
-                  </p>
-                  <p className="mt-2 font-mono text-3xl font-semibold tracking-tight text-primary tabular-nums">
-                    {rate.value}%
-                  </p>
-                  <p className="mt-1.5 flex items-center gap-1.5 text-xs text-muted-foreground">
-                    <HugeiconsIcon icon={rate.icon} className="size-3" />
-                    {rate.source}
+                  <p className="mt-1 text-sm font-medium">{step.title}</p>
+                  <p className="mt-0.5 text-sm text-muted-foreground">
+                    {step.description}
                   </p>
                 </div>
-              ))}
-            </div>
+              </div>
+            ))}
+          </div>
+        </section>
 
-            {/* Plan table */}
-            <ScrollFadeWrapper className="rounded-xl ring-1 ring-foreground/10">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Plan</TableHead>
-                    <TableHead>Annual threshold</TableHead>
-                    <TableHead>Rate</TableHead>
-                    <TableHead>Write-off</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {plans.map((p) => (
-                    <TableRow key={p.label}>
-                      <TableCell className="font-medium">{p.label}</TableCell>
-                      <TableCell className="font-mono tabular-nums">
-                        {formatGBP(p.threshold)}
-                      </TableCell>
-                      <TableCell className="font-mono tabular-nums">
-                        {Math.round(p.rate * 100)}%
-                      </TableCell>
-                      <TableCell>{p.writeOff} years</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </ScrollFadeWrapper>
-          </section>
-
-          {/* How it stays current */}
-          <section className="space-y-4">
-            <Heading as="h2" size="section">
-              How it stays current
-            </Heading>
-            <p className="text-sm text-muted-foreground sm:text-base">
-              We run an automatic check every day so you never have to wonder if
-              our numbers are current.
-            </p>
-            <div>
-              {PIPELINE_STEPS.map((step, i) => (
-                <div key={step.title} className="flex gap-4">
-                  <div className="flex flex-col items-center">
-                    <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary ring-4 ring-background">
-                      <HugeiconsIcon icon={step.icon} className="size-4" />
-                    </div>
-                    {i < PIPELINE_STEPS.length - 1 && (
-                      <div className="my-1.5 w-px flex-1 bg-border" />
-                    )}
+        {/* Cross-check yourself */}
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Cross-check yourself
+          </Heading>
+          <p className="text-sm text-muted-foreground sm:text-base">
+            You don&rsquo;t have to take our word for it. Here are the primary
+            sources we pull from:
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {CROSS_CHECK_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group"
+              >
+                <div className="flex h-full items-start gap-3 rounded-xl bg-card p-4 ring-1 ring-foreground/10 transition-all hover:bg-accent hover:ring-primary/30">
+                  <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
+                    <HugeiconsIcon icon={link.icon} className="size-4" />
                   </div>
-                  <div
-                    className={
-                      i < PIPELINE_STEPS.length - 1 ? "pb-5" : undefined
-                    }
-                  >
-                    <p className="mt-1 text-sm font-medium">{step.title}</p>
-                    <p className="mt-0.5 text-sm text-muted-foreground">
-                      {step.description}
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-1">
+                      <span className="text-sm font-medium">{link.label}</span>
+                      <HugeiconsIcon
+                        icon={ArrowUpRight01Icon}
+                        className="size-3.5 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+                      />
+                    </div>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      {link.source} &mdash; {link.description}
                     </p>
                   </div>
                 </div>
-              ))}
-            </div>
-          </section>
-
-          {/* Cross-check yourself */}
-          <section className="space-y-4">
-            <Heading as="h2" size="section">
-              Cross-check yourself
-            </Heading>
-            <p className="text-sm text-muted-foreground sm:text-base">
-              You don&rsquo;t have to take our word for it. Here are the primary
-              sources we pull from:
-            </p>
-            <div className="grid gap-3 sm:grid-cols-2">
-              {CROSS_CHECK_LINKS.map((link) => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group"
-                >
-                  <div className="flex h-full items-start gap-3 rounded-xl bg-card p-4 ring-1 ring-foreground/10 transition-all hover:bg-accent hover:ring-primary/30">
-                    <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
-                      <HugeiconsIcon icon={link.icon} className="size-4" />
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-1">
-                        <span className="text-sm font-medium">
-                          {link.label}
-                        </span>
-                        <HugeiconsIcon
-                          icon={ArrowUpRight01Icon}
-                          className="size-3.5 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
-                        />
-                      </div>
-                      <p className="mt-0.5 text-xs text-muted-foreground">
-                        {link.source} &mdash; {link.description}
-                      </p>
-                    </div>
-                  </div>
-                </Link>
-              ))}
-            </div>
-          </section>
-        </article>
-      </main>
-      <Footer />
-    </div>
+              </Link>
+            ))}
+          </div>
+        </section>
+      </article>
+    </PageLayout>
   );
 }

--- a/src/components/overpay/OverpayPage.tsx
+++ b/src/components/overpay/OverpayPage.tsx
@@ -9,8 +9,7 @@ import { OverpayVerdict } from "./OverpayVerdict";
 import type { InputMode } from "@/components/home/InputPanel";
 import type { Preset } from "@/lib/presets";
 import { InputPanel } from "@/components/home/InputPanel";
-import { Footer } from "@/components/layout/Footer";
-import { Header } from "@/components/layout/Header";
+import { PageLayout } from "@/components/layout/PageLayout";
 import { AssumptionsCallout } from "@/components/shared/AssumptionsCallout";
 import { PlanFromQuery } from "@/components/shared/PlanFromQuery";
 import { Heading } from "@/components/typography/Heading";
@@ -102,13 +101,9 @@ export function OverpayPage() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <>
       <PlanFromQuery onRepaymentYearChange={handleRepaymentYearChange} />
-      <Header repaymentYear={repaymentDate.getFullYear()} />
-      <main
-        id="main-content"
-        className="mx-auto w-full max-w-4xl flex-1 space-y-6 overflow-x-hidden px-3 pt-13 pb-6 md:pb-8"
-      >
+      <PageLayout repaymentYear={repaymentDate.getFullYear()}>
         <div className="space-y-4">
           <Breadcrumb>
             <BreadcrumbList>
@@ -165,8 +160,7 @@ export function OverpayPage() {
         />
 
         <AssumptionsCallout />
-      </main>
-      <Footer />
-    </div>
+      </PageLayout>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
Every page manually duplicated the same layout wrapper (`div > Header > main > Footer`) with inconsistent spacing across 12 pages. This extracts a single `PageLayout` component that standardises the shell and spacing, using the home page as the canonical standard (`pt-8 sm:pt-18`, `space-y-8`, `px-3`, `pb-6 md:pb-8`).

## Context
Pages had drifted — guides used `pt-13`, overpay had `space-y-6`, brand guidelines used different horizontal padding and was missing `id="main-content"`, and several pages had unnecessary `overflow-x-hidden`. The new component accepts an optional `mainClassName` escape hatch via `cn()`/`twMerge` for pages that genuinely need overrides, and a `repaymentYear` prop forwarded to `Header` (used by the overpay page). No content, logic, or visual changes beyond the spacing standardisation.