### PR TITLE
feat: add overpay page links to guide pages

### DIFF
--- a/src/components/guides/how-interest-works/InterestGuide.tsx
+++ b/src/components/guides/how-interest-works/InterestGuide.tsx
@@ -181,7 +181,15 @@ export function InterestGuide() {
               >
                 repayment calculator
               </Link>{" "}
-              to see when this tipping point occurs at your salary.
+              to see when this tipping point occurs at your salary, or explore
+              whether{" "}
+              <Link
+                href="/overpay"
+                className="text-primary underline underline-offset-4 hover:text-primary/80"
+              >
+                overpaying your loan
+              </Link>{" "}
+              could reduce the total cost.
             </p>
           </div>
         </section>

--- a/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
+++ b/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
@@ -225,6 +225,17 @@ export function RpiVsCpiGuide() {
                 3% means the largest gap above CPI of any plan.
               </li>
             </ul>
+            <p>
+              If your loan is growing faster than general prices, explore
+              whether{" "}
+              <Link
+                href="/overpay"
+                className="text-primary underline underline-offset-4 hover:text-primary/80"
+              >
+                overpaying
+              </Link>{" "}
+              could reduce the above-inflation cost.
+            </p>
           </div>
         </section>
 

--- a/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
+++ b/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
@@ -180,9 +180,15 @@ export function MortgageGuide() {
               never chased for unpaid amounts.
             </li>
             <li>
-              Overpaying your student loan to boost mortgage affordability
-              rarely makes sense &mdash; the reduction in borrowing power is
-              modest compared to deposit savings.
+              <Link
+                href="/overpay"
+                className="text-primary underline underline-offset-4 hover:text-primary/80"
+              >
+                Overpaying your student loan
+              </Link>{" "}
+              to boost mortgage affordability rarely makes sense &mdash; the
+              reduction in borrowing power is modest compared to deposit
+              savings.
             </li>
           </ul>
         </section>


### PR DESCRIPTION
## Summary

Adds internal links to the `/overpay` page from three guide pages where overpayment is contextually relevant, improving discoverability of the overpay tool.

- **How Interest Works** — extends the "tipping point" paragraph to suggest exploring overpayment when interest outpaces repayments
- **RPI vs CPI** — adds a paragraph after the plan-by-plan breakdown, linking to overpay for readers concerned about above-inflation growth
- **Student Loan vs Mortgage** — turns the existing "Overpaying your student loan" text into a link so readers can see the full analysis