### PR TITLE
ci: add dependabot group for tailwindcss packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,10 @@ updates:
           - "@vitest*"
           - "@vitejs/plugin-react"
           - "vite-plugin-babel"
+      tailwindcss:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/postcss"
       postcss:
         patterns:
           - "postcss-*"


### PR DESCRIPTION
## Summary
Groups `tailwindcss` and `@tailwindcss/postcss` into a single dependabot update group so they are bumped together in one PR rather than separately.