### PR TITLE
test: temporary figure tweak to trigger govuk workflow

### DIFF
--- a/src/lib/loans/plans.ts
+++ b/src/lib/loans/plans.ts
@@ -15,7 +15,7 @@ export const LAST_UPDATED = "2026-02-21T01:53:41.000Z";
  */
 export const PLAN_CONFIGS = {
   PLAN_1: {
-    monthlyThreshold: 2172, // £26,065/12
+    monthlyThreshold: 2173, // £26,066/12
     repaymentRate: 0.09, // 9%
     writeOffYears: 25,
   },


### PR DESCRIPTION
## Summary

Temporarily tweaks the Plan 1 threshold by £1 to trigger a mismatch in the GOV.UK figure checker workflow. This tests the new `gh` CLI-based PR creation step from #206.

**Revert this immediately after testing.**