### PR TITLE
revert: undo temporary figure tweak

### DIFF
--- a/src/lib/loans/plans.ts
+++ b/src/lib/loans/plans.ts
@@ -15,7 +15,7 @@ export const LAST_UPDATED = "2026-02-21T01:53:41.000Z";
  */
 export const PLAN_CONFIGS = {
   PLAN_1: {
-    monthlyThreshold: 2173, // £26,066/12
+    monthlyThreshold: 2172, // £26,065/12
     repaymentRate: 0.09, // 9%
     writeOffYears: 25,
   },


### PR DESCRIPTION
## Summary

Reverts #208 which temporarily tweaked the Plan 1 threshold to test the GOV.UK workflow's new `gh` CLI PR creation step (#206). The test was successful (PR #209 was created correctly).