### PR TITLE
perf: use useOptimistic + startTransition for slider INP

### DIFF
--- a/src/components/home/SalaryExplorer.tsx
+++ b/src/components/home/SalaryExplorer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { startTransition, useOptimistic } from "react";
 import { TotalRepaymentChart } from "@/components/charts/TotalRepaymentChart";
 import { SalaryGrowthBadge } from "@/components/shared/SalaryGrowthBadge";
 import { Slider } from "@/components/ui/slider";
@@ -17,6 +18,7 @@ export function SalaryExplorer() {
   const { salary } = useLoanFrequentState();
   const { updateField } = useLoanActions();
   const showPresentValue = useShowPresentValue();
+  const [optimisticSalary, setOptimisticSalary] = useOptimistic(salary);
 
   return (
     <div>
@@ -29,7 +31,7 @@ export function SalaryExplorer() {
         <div className="flex items-center gap-1 text-sm text-muted-foreground">
           Your salary:{" "}
           <span className="font-mono font-semibold text-foreground tabular-nums">
-            {currencyFormatter.format(salary)}
+            {currencyFormatter.format(optimisticSalary)}
           </span>
           <SalaryGrowthBadge />
         </div>
@@ -42,13 +44,16 @@ export function SalaryExplorer() {
       {/* Padding aligns slider track with chart plot area (25px margin + ~60px YAxis) */}
       <div className="-mt-1 pr-6 pl-21">
         <Slider
-          value={salary}
+          value={optimisticSalary}
           min={MIN_SALARY}
           max={MAX_SALARY}
           step={SALARY_STEP}
           onValueChange={(value) => {
             const v = typeof value === "number" ? value : value[0];
-            updateField("salary", v);
+            startTransition(() => {
+              setOptimisticSalary(v);
+              updateField("salary", v);
+            });
           }}
           onValueCommitted={(value) => {
             const v = typeof value === "number" ? value : value[0];

--- a/src/components/overpay/OverpayPrimaryInputs.tsx
+++ b/src/components/overpay/OverpayPrimaryInputs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { startTransition, useOptimistic } from "react";
 import { YearSelector } from "./YearSelector";
 import { SalaryGrowthBadge } from "@/components/shared/SalaryGrowthBadge";
 import { Input } from "@/components/ui/input";
@@ -35,15 +36,24 @@ export function OverpayPrimaryInputs({
   const { salary, monthlyOverpayment, lumpSumPayment } = useLoanFrequentState();
   const { underGradBalance, postGradBalance } = useLoanConfig();
   const totalBalance = underGradBalance + postGradBalance;
+  const [optimisticSalary, setOptimisticSalary] = useOptimistic(salary);
+  const [optimisticOverpayment, setOptimisticOverpayment] =
+    useOptimistic(monthlyOverpayment);
 
   const handleSalaryChange = (value: number | readonly number[]) => {
     const newValue = typeof value === "number" ? value : value[0];
-    updateField("salary", newValue);
+    startTransition(() => {
+      setOptimisticSalary(newValue);
+      updateField("salary", newValue);
+    });
   };
 
   const handleOverpaymentChange = (value: number | readonly number[]) => {
     const newValue = typeof value === "number" ? value : value[0];
-    updateField("monthlyOverpayment", newValue);
+    startTransition(() => {
+      setOptimisticOverpayment(newValue);
+      updateField("monthlyOverpayment", newValue);
+    });
   };
 
   const handleLumpSumChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -97,12 +107,12 @@ export function OverpayPrimaryInputs({
           <div className="flex items-center justify-between">
             <Label htmlFor="overpayment-slider">Monthly Overpayment</Label>
             <span className="text-sm font-medium tabular-nums">
-              {currencyFormatter.format(monthlyOverpayment)}
+              {currencyFormatter.format(optimisticOverpayment)}
             </span>
           </div>
           <Slider
             id="overpayment-slider"
-            value={[monthlyOverpayment]}
+            value={[optimisticOverpayment]}
             onValueChange={handleOverpaymentChange}
             onValueCommitted={(value) => {
               const overpayValue = typeof value === "number" ? value : value[0];
@@ -126,14 +136,14 @@ export function OverpayPrimaryInputs({
             <Label htmlFor="salary-slider">Current Salary</Label>
             <div className="flex items-center gap-1">
               <span className="text-sm font-medium tabular-nums">
-                {currencyFormatter.format(salary)}
+                {currencyFormatter.format(optimisticSalary)}
               </span>
               <SalaryGrowthBadge />
             </div>
           </div>
           <Slider
             id="salary-slider"
-            value={[salary]}
+            value={[optimisticSalary]}
             onValueChange={handleSalaryChange}
             onValueCommitted={(value) => {
               const salaryValue = typeof value === "number" ? value : value[0];


### PR DESCRIPTION
## Summary

Fixes mobile INP (Interaction to Next Paint) on slider interactions by using React 19's `useOptimistic` hook paired with `startTransition`. Slider thumb and label now update instantly via optimistic state, while the expensive downstream cascade (context → worker → charts) is deferred as a low-priority transition that React can interrupt and coalesce during rapid drags.

## Context

Field data showed slider interactions as the worst INP offenders on mobile — up to 4.5s on the overpayment slider. The root cause was every `onValueChange` tick synchronously dispatching to the React context, triggering immediate re-renders of all subscribers (Recharts trees, ResultSummary, worker hooks). With `useOptimistic`, the browser paints after only the slider thumb + label re-render (~16ms), and rapid ticks are coalesced so only the final value propagates to context. No changes to the context layer, worker, or chart components were needed.