### PR TITLE
perf: extend useOptimistic to all inputs, presets, toggle, and wizard steps

### DIFF
--- a/src/components/home/PresentValueToggle.tsx
+++ b/src/components/home/PresentValueToggle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Field } from "@base-ui/react/field";
+import { startTransition, useOptimistic } from "react";
 import { Switch } from "@/components/ui/switch";
 import { useAssumptionsWizard } from "@/context/AssumptionsWizardContext";
 import { useLoanActions, useLoanConfigState } from "@/context/LoanContext";
@@ -30,6 +31,8 @@ export function PresentValueToggle() {
   const { showPresentValue, discountRate } = useLoanConfigState();
   const { updateField } = useLoanActions();
   const { openAssumptions } = useAssumptionsWizard();
+  const [optimisticShowPresentValue, setOptimisticShowPresentValue] =
+    useOptimistic(showPresentValue);
 
   const discountLabel = `${(discountRate * 100).toFixed(0)}%`;
 
@@ -41,29 +44,34 @@ export function PresentValueToggle() {
     <Field.Root>
       <div
         className={`flex items-center rounded-lg px-2 py-1 transition-colors ${
-          showPresentValue ? "bg-primary/5 dark:bg-primary/10" : ""
+          optimisticShowPresentValue ? "bg-primary/5 dark:bg-primary/10" : ""
         }`}
       >
         {/* Desktop: rate slides in to the left of the switch */}
         <div
           className={`hidden overflow-hidden motion-safe:transition-all motion-safe:duration-300 motion-safe:ease-out sm:block ${
-            showPresentValue ? "max-w-20 opacity-100" : "max-w-0 opacity-0"
+            optimisticShowPresentValue
+              ? "max-w-20 opacity-100"
+              : "max-w-0 opacity-0"
           }`}
         >
           <span className="flex items-center pr-2">
             <RateLink
               discountLabel={discountLabel}
               onOpen={handleOpenRate}
-              tabIndex={showPresentValue ? 0 : -1}
+              tabIndex={optimisticShowPresentValue ? 0 : -1}
             />
             <span className="pl-1 text-xs text-muted-foreground">&middot;</span>
           </span>
         </div>
         <Switch
           size="sm"
-          checked={showPresentValue}
+          checked={optimisticShowPresentValue}
           onCheckedChange={(checked) => {
-            updateField("showPresentValue", checked);
+            startTransition(() => {
+              setOptimisticShowPresentValue(checked);
+              updateField("showPresentValue", checked);
+            });
           }}
         />
         <Field.Label className="flex-1 cursor-pointer pl-1.5 text-xs text-muted-foreground">
@@ -72,7 +80,9 @@ export function PresentValueToggle() {
         {/* Mobile: rate appears on the far right */}
         <div
           className={`overflow-hidden motion-safe:transition-all motion-safe:duration-300 motion-safe:ease-out sm:hidden ${
-            showPresentValue ? "max-w-20 opacity-100" : "max-w-0 opacity-0"
+            optimisticShowPresentValue
+              ? "max-w-20 opacity-100"
+              : "max-w-0 opacity-0"
           }`}
         >
           <span className="flex items-center pl-2">
@@ -80,7 +90,7 @@ export function PresentValueToggle() {
             <RateLink
               discountLabel={discountLabel}
               onOpen={handleOpenRate}
-              tabIndex={showPresentValue ? 0 : -1}
+              tabIndex={optimisticShowPresentValue ? 0 : -1}
             />
           </span>
         </div>

--- a/src/components/home/PresetPills.tsx
+++ b/src/components/home/PresetPills.tsx
@@ -2,6 +2,7 @@
 
 import { PreferenceHorizontalIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { startTransition, useOptimistic } from "react";
 import { PresentValueToggle } from "./PresentValueToggle";
 import type { Preset } from "@/lib/presets";
 import { useLoanConfigState } from "@/context/LoanContext";
@@ -33,8 +34,12 @@ export function PresetPills({
       ),
   );
 
+  const [optimisticActiveId, setOptimisticActiveId] = useOptimistic(
+    activePreset?.id ?? null,
+  );
+
   // Show "Edit configuration" active state only when personalized with custom (non-preset) config
-  const isCustomConfig = hasPersonalized && !activePreset;
+  const isCustomConfig = hasPersonalized && !optimisticActiveId;
 
   return (
     <div className="space-y-2">
@@ -56,13 +61,16 @@ export function PresetPills({
           aria-label="Preset profiles"
         >
           {PRESETS.map((preset) => {
-            const isActive = activePreset?.id === preset.id;
+            const isActive = optimisticActiveId === preset.id;
             return (
               <button
                 key={preset.id}
                 type="button"
                 onClick={() => {
-                  onPresetApplied(preset);
+                  startTransition(() => {
+                    setOptimisticActiveId(preset.id);
+                    onPresetApplied(preset);
+                  });
                 }}
                 aria-pressed={isActive}
                 className={cn(

--- a/src/components/overpay/OverpayPrimaryInputs.tsx
+++ b/src/components/overpay/OverpayPrimaryInputs.tsx
@@ -39,6 +39,8 @@ export function OverpayPrimaryInputs({
   const [optimisticSalary, setOptimisticSalary] = useOptimistic(salary);
   const [optimisticOverpayment, setOptimisticOverpayment] =
     useOptimistic(monthlyOverpayment);
+  const [optimisticLumpSum, setOptimisticLumpSum] =
+    useOptimistic(lumpSumPayment);
 
   const handleSalaryChange = (value: number | readonly number[]) => {
     const newValue = typeof value === "number" ? value : value[0];
@@ -60,7 +62,10 @@ export function OverpayPrimaryInputs({
     const value = e.target.value.replace(/[^0-9]/g, "");
     const numValue = value === "" ? 0 : parseInt(value, 10);
     const clampedValue = Math.min(Math.max(0, numValue), totalBalance);
-    updateField("lumpSumPayment", clampedValue);
+    startTransition(() => {
+      setOptimisticLumpSum(clampedValue);
+      updateField("lumpSumPayment", clampedValue);
+    });
   };
 
   return (
@@ -79,9 +84,9 @@ export function OverpayPrimaryInputs({
                   type="text"
                   inputMode="numeric"
                   value={
-                    lumpSumPayment === 0
+                    optimisticLumpSum === 0
                       ? ""
-                      : lumpSumPayment.toLocaleString("en-GB")
+                      : optimisticLumpSum.toLocaleString("en-GB")
                   }
                   onChange={handleLumpSumChange}
                   onBlur={() => {

--- a/src/components/quiz/QuizProgress.tsx
+++ b/src/components/quiz/QuizProgress.tsx
@@ -2,6 +2,7 @@
 
 import { ArrowLeft01Icon, Cancel01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import type { IconSvgElement } from "@hugeicons/react";
 import { Button } from "@/components/ui/button";
 
 interface QuizProgressProps {
@@ -9,6 +10,8 @@ interface QuizProgressProps {
   totalSteps: number;
   onBack?: () => void;
   onClose?: () => void;
+  closeIcon?: IconSvgElement;
+  closeLabel?: string;
 }
 
 export function QuizProgress({
@@ -16,6 +19,8 @@ export function QuizProgress({
   totalSteps,
   onBack,
   onClose,
+  closeIcon = Cancel01Icon,
+  closeLabel = "Exit quiz",
 }: QuizProgressProps) {
   return (
     <header className="sticky top-0 z-10 border-b border-border/50 bg-background/80 backdrop-blur-sm">
@@ -57,9 +62,9 @@ export function QuizProgress({
               variant="ghost"
               size="icon-sm"
               onClick={onClose}
-              aria-label="Exit quiz"
+              aria-label={closeLabel}
             >
-              <HugeiconsIcon icon={Cancel01Icon} className="size-5" />
+              <HugeiconsIcon icon={closeIcon} className="size-5" />
             </Button>
           )}
         </div>

--- a/src/components/wizard/AssumptionsWizard.tsx
+++ b/src/components/wizard/AssumptionsWizard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Tick02Icon } from "@hugeicons/core-free-icons";
 import { useReducer } from "react";
 import { BoeBaseRateStep } from "./BoeBaseRateStep";
 import { DiscountRateStep } from "./DiscountRateStep";
@@ -113,6 +114,8 @@ export function AssumptionsWizard({
         totalSteps={stepOrder.length}
         onBack={canGoBack ? goBack : undefined}
         onClose={onClose}
+        closeIcon={Tick02Icon}
+        closeLabel="Done"
       />
 
       <main className="flex flex-1 flex-col items-center justify-center px-4 py-8">

--- a/src/components/wizard/BoeBaseRateStep.tsx
+++ b/src/components/wizard/BoeBaseRateStep.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { startTransition, useOptimistic } from "react";
 import { NumericFormat } from "react-number-format";
 import { OptionCard } from "@/components/quiz/OptionCard";
 import { QuestionStep } from "@/components/quiz/QuestionStep";
@@ -31,9 +32,11 @@ export function BoeBaseRateStep({
 }: BoeBaseRateStepProps) {
   const { updateField } = useLoanActions();
   const { boeBaseRate } = useLoanConfigState();
+  const [optimisticBoeBaseRate, setOptimisticBoeBaseRate] =
+    useOptimistic(boeBaseRate);
 
-  const isPreset = presetValues.has(boeBaseRate);
-  const customDisplayValue = isPreset ? "" : boeBaseRate;
+  const isPreset = presetValues.has(optimisticBoeBaseRate);
+  const customDisplayValue = isPreset ? "" : optimisticBoeBaseRate;
 
   return (
     <QuestionStep
@@ -49,10 +52,13 @@ export function BoeBaseRateStep({
                 key={option.label}
                 label={option.label}
                 sublabel={option.description}
-                isSelected={boeBaseRate === option.value}
+                isSelected={optimisticBoeBaseRate === option.value}
                 onClick={() => {
                   trackBoeBaseRateSelected(option.value);
-                  updateField("boeBaseRate", option.value);
+                  startTransition(() => {
+                    setOptimisticBoeBaseRate(option.value);
+                    updateField("boeBaseRate", option.value);
+                  });
                 }}
               />
             ))}
@@ -66,8 +72,12 @@ export function BoeBaseRateStep({
               <NumericFormat
                 value={customDisplayValue}
                 onValueChange={(values) => {
-                  if (typeof values.floatValue === "number") {
-                    updateField("boeBaseRate", values.floatValue);
+                  const v = values.floatValue;
+                  if (typeof v === "number") {
+                    startTransition(() => {
+                      setOptimisticBoeBaseRate(v);
+                      updateField("boeBaseRate", v);
+                    });
                   }
                 }}
                 customInput={CustomInput}

--- a/src/components/wizard/DiscountRateStep.tsx
+++ b/src/components/wizard/DiscountRateStep.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { startTransition, useOptimistic } from "react";
 import { NumericFormat } from "react-number-format";
 import { OptionCard } from "@/components/quiz/OptionCard";
 import { QuestionStep } from "@/components/quiz/QuestionStep";
@@ -30,9 +31,11 @@ export function DiscountRateStep({
 }: DiscountRateStepProps) {
   const { updateField } = useLoanActions();
   const { discountRate } = useLoanConfigState();
+  const [optimisticDiscountRate, setOptimisticDiscountRate] =
+    useOptimistic(discountRate);
 
-  const isPreset = presetValues.has(discountRate);
-  const customDisplayValue = isPreset ? "" : discountRate * 100;
+  const isPreset = presetValues.has(optimisticDiscountRate);
+  const customDisplayValue = isPreset ? "" : optimisticDiscountRate * 100;
 
   return (
     <QuestionStep
@@ -52,9 +55,12 @@ export function DiscountRateStep({
                 key={option.label}
                 label={option.label}
                 sublabel={option.description}
-                isSelected={discountRate === option.value}
+                isSelected={optimisticDiscountRate === option.value}
                 onClick={() => {
-                  updateField("discountRate", option.value);
+                  startTransition(() => {
+                    setOptimisticDiscountRate(option.value);
+                    updateField("discountRate", option.value);
+                  });
                 }}
               />
             ))}
@@ -68,8 +74,12 @@ export function DiscountRateStep({
               <NumericFormat
                 value={customDisplayValue}
                 onValueChange={(values) => {
-                  if (typeof values.floatValue === "number") {
-                    updateField("discountRate", values.floatValue / 100);
+                  const v = values.floatValue;
+                  if (typeof v === "number") {
+                    startTransition(() => {
+                      setOptimisticDiscountRate(v / 100);
+                      updateField("discountRate", v / 100);
+                    });
                   }
                 }}
                 customInput={CustomInput}

--- a/src/components/wizard/RpiStep.tsx
+++ b/src/components/wizard/RpiStep.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { startTransition, useOptimistic } from "react";
 import { NumericFormat } from "react-number-format";
 import { OptionCard } from "@/components/quiz/OptionCard";
 import { QuestionStep } from "@/components/quiz/QuestionStep";
@@ -27,9 +28,10 @@ function CustomInput({
 export function RpiStep({ direction, onNext, done }: RpiStepProps) {
   const { updateField } = useLoanActions();
   const { rpiRate } = useLoanConfigState();
+  const [optimisticRpiRate, setOptimisticRpiRate] = useOptimistic(rpiRate);
 
-  const isPreset = presetValues.has(rpiRate);
-  const customDisplayValue = isPreset ? "" : rpiRate;
+  const isPreset = presetValues.has(optimisticRpiRate);
+  const customDisplayValue = isPreset ? "" : optimisticRpiRate;
 
   return (
     <QuestionStep
@@ -45,10 +47,13 @@ export function RpiStep({ direction, onNext, done }: RpiStepProps) {
                 key={option.label}
                 label={option.label}
                 sublabel={option.description}
-                isSelected={rpiRate === option.value}
+                isSelected={optimisticRpiRate === option.value}
                 onClick={() => {
                   trackRpiRateSelected(option.value);
-                  updateField("rpiRate", option.value);
+                  startTransition(() => {
+                    setOptimisticRpiRate(option.value);
+                    updateField("rpiRate", option.value);
+                  });
                 }}
               />
             ))}
@@ -67,8 +72,12 @@ export function RpiStep({ direction, onNext, done }: RpiStepProps) {
               <NumericFormat
                 value={customDisplayValue}
                 onValueChange={(values) => {
-                  if (typeof values.floatValue === "number") {
-                    updateField("rpiRate", values.floatValue);
+                  const v = values.floatValue;
+                  if (typeof v === "number") {
+                    startTransition(() => {
+                      setOptimisticRpiRate(v);
+                      updateField("rpiRate", v);
+                    });
                   }
                 }}
                 customInput={CustomInput}

--- a/src/components/wizard/SalaryGrowthStep.tsx
+++ b/src/components/wizard/SalaryGrowthStep.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { startTransition, useOptimistic } from "react";
 import { NumericFormat } from "react-number-format";
 import { OptionCard } from "@/components/quiz/OptionCard";
 import { QuestionStep } from "@/components/quiz/QuestionStep";
@@ -26,9 +27,11 @@ function CustomInput({
 export function SalaryGrowthStep({ direction, onNext }: SalaryGrowthStepProps) {
   const { updateField } = useLoanActions();
   const { salaryGrowthRate } = useLoanConfigState();
+  const [optimisticSalaryGrowthRate, setOptimisticSalaryGrowthRate] =
+    useOptimistic(salaryGrowthRate);
 
-  const isPreset = presetValues.has(salaryGrowthRate);
-  const customDisplayValue = isPreset ? "" : salaryGrowthRate * 100;
+  const isPreset = presetValues.has(optimisticSalaryGrowthRate);
+  const customDisplayValue = isPreset ? "" : optimisticSalaryGrowthRate * 100;
 
   return (
     <QuestionStep
@@ -44,10 +47,13 @@ export function SalaryGrowthStep({ direction, onNext }: SalaryGrowthStepProps) {
                 key={option.label}
                 label={option.label}
                 sublabel={option.description}
-                isSelected={salaryGrowthRate === option.value}
+                isSelected={optimisticSalaryGrowthRate === option.value}
                 onClick={() => {
                   trackSalaryGrowthSelected(option.value);
-                  updateField("salaryGrowthRate", option.value);
+                  startTransition(() => {
+                    setOptimisticSalaryGrowthRate(option.value);
+                    updateField("salaryGrowthRate", option.value);
+                  });
                 }}
               />
             ))}
@@ -61,10 +67,12 @@ export function SalaryGrowthStep({ direction, onNext }: SalaryGrowthStepProps) {
               <NumericFormat
                 value={customDisplayValue}
                 onValueChange={(values) => {
-                  if (typeof values.floatValue === "number") {
-                    updateField("salaryGrowthRate", values.floatValue / 100);
-                  } else if (values.value === "" || values.value === "-") {
-                    // Keep current value while user is clearing/typing
+                  const v = values.floatValue;
+                  if (typeof v === "number") {
+                    startTransition(() => {
+                      setOptimisticSalaryGrowthRate(v / 100);
+                      updateField("salaryGrowthRate", v / 100);
+                    });
                   }
                 }}
                 customInput={CustomInput}

--- a/src/components/wizard/ThresholdGrowthStep.tsx
+++ b/src/components/wizard/ThresholdGrowthStep.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { startTransition, useOptimistic } from "react";
 import { NumericFormat } from "react-number-format";
 import { OptionCard } from "@/components/quiz/OptionCard";
 import { QuestionStep } from "@/components/quiz/QuestionStep";
@@ -29,9 +30,13 @@ export function ThresholdGrowthStep({
 }: ThresholdGrowthStepProps) {
   const { updateField } = useLoanActions();
   const { thresholdGrowthRate } = useLoanConfigState();
+  const [optimisticThresholdGrowthRate, setOptimisticThresholdGrowthRate] =
+    useOptimistic(thresholdGrowthRate);
 
-  const isPreset = presetValues.has(thresholdGrowthRate);
-  const customDisplayValue = isPreset ? "" : thresholdGrowthRate * 100;
+  const isPreset = presetValues.has(optimisticThresholdGrowthRate);
+  const customDisplayValue = isPreset
+    ? ""
+    : optimisticThresholdGrowthRate * 100;
 
   return (
     <QuestionStep
@@ -47,10 +52,13 @@ export function ThresholdGrowthStep({
                 key={option.label}
                 label={option.label}
                 sublabel={option.description}
-                isSelected={thresholdGrowthRate === option.value}
+                isSelected={optimisticThresholdGrowthRate === option.value}
                 onClick={() => {
                   trackThresholdGrowthSelected(option.value);
-                  updateField("thresholdGrowthRate", option.value);
+                  startTransition(() => {
+                    setOptimisticThresholdGrowthRate(option.value);
+                    updateField("thresholdGrowthRate", option.value);
+                  });
                 }}
               />
             ))}
@@ -64,10 +72,12 @@ export function ThresholdGrowthStep({
               <NumericFormat
                 value={customDisplayValue}
                 onValueChange={(values) => {
-                  if (typeof values.floatValue === "number") {
-                    updateField("thresholdGrowthRate", values.floatValue / 100);
-                  } else if (values.value === "" || values.value === "-") {
-                    // Keep current value while user is clearing/typing
+                  const v = values.floatValue;
+                  if (typeof v === "number") {
+                    startTransition(() => {
+                      setOptimisticThresholdGrowthRate(v / 100);
+                      updateField("thresholdGrowthRate", v / 100);
+                    });
                   }
                 }}
                 customInput={CustomInput}


### PR DESCRIPTION
## Summary

Extends the `useOptimistic` + `startTransition` pattern from #211 to every remaining interaction that synchronously dispatches to the loan context: lump sum input, preset pill selection, inflation toggle, and all five assumptions wizard steps (RPI, BoE base rate, salary growth, threshold growth, discount rate). Each component now renders from an optimistic value for instant visual feedback while deferring the expensive context cascade via `startTransition`.

Also swaps the assumptions wizard close button from a cross icon to a tick — since the wizard writes config changes immediately, closing isn't "cancelling" anything.

## Context

The previous PR addressed sliders specifically, but every `updateField` call without a transition has the same INP problem on mobile. This covers the remaining call sites: text inputs firing per-keystroke, preset buttons, the inflation switch, and the wizard's option cards + custom numeric inputs. The `QuizProgress` component gains optional `closeIcon`/`closeLabel` props so the wizard can use a tick without affecting the quiz flow.