### PR TITLE
perf: lazy-load ChartBase with next/dynamic to reduce initial bundle

### DIFF
--- a/src/components/charts/BalanceOverTimeChart.tsx
+++ b/src/components/charts/BalanceOverTimeChart.tsx
@@ -1,11 +1,25 @@
 "use client";
 
-import { ChartBase } from "./ChartBase";
+import dynamic from "next/dynamic";
 import type { ChartConfig } from "@/components/ui/chart";
 import { Skeleton } from "@/components/ui/skeleton";
 import { currencyFormatter } from "@/constants";
 import { useBalanceOverTimeData } from "@/hooks/useChartData";
 import { useShowPresentValue } from "@/hooks/useStoreSelectors";
+
+const ChartBase = dynamic(
+  () => import("./ChartBase").then((m) => m.ChartBase),
+  {
+    ssr: false,
+    loading: () => (
+      <Skeleton
+        className="size-full"
+        role="status"
+        aria-label="Loading chart"
+      />
+    ),
+  },
+);
 
 const chartConfig = {
   balance: {
@@ -25,13 +39,11 @@ export function BalanceOverTimeChart() {
 
   if (data.length === 0) {
     return (
-      <div
-        className="flex h-full items-center justify-center"
+      <Skeleton
+        className="size-full"
         role="status"
         aria-label="Loading student loan repayment chart showing how long to pay off your loan"
-      >
-        <Skeleton className="size-full" />
-      </div>
+      />
     );
   }
 

--- a/src/components/charts/TotalRepaymentChart.tsx
+++ b/src/components/charts/TotalRepaymentChart.tsx
@@ -1,12 +1,26 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useDeferredValue } from "react";
-import { ChartBase } from "./ChartBase";
 import type { ChartConfig } from "@/components/ui/chart";
 import { Skeleton } from "@/components/ui/skeleton";
 import { currencyFormatter, MIN_SALARY, MAX_SALARY } from "@/constants";
 import { useTotalRepaymentData } from "@/hooks/useChartData";
 import { useShowPresentValue } from "@/hooks/useStoreSelectors";
+
+const ChartBase = dynamic(
+  () => import("./ChartBase").then((m) => m.ChartBase),
+  {
+    ssr: false,
+    loading: () => (
+      <Skeleton
+        className="size-full"
+        role="status"
+        aria-label="Loading chart"
+      />
+    ),
+  },
+);
 
 const chartConfig = {
   value: {
@@ -27,13 +41,11 @@ export function TotalRepaymentChart() {
 
   if (data.length === 0) {
     return (
-      <div
-        className="flex h-full items-center justify-center"
+      <Skeleton
+        className="size-full"
         role="status"
         aria-label="Loading UK student loan calculator results showing total repayment by salary"
-      >
-        <Skeleton className="size-full" />
-      </div>
+      />
     );
   }
 

--- a/src/components/guides/how-interest-works/InterestRateChart.tsx
+++ b/src/components/guides/how-interest-works/InterestRateChart.tsx
@@ -1,12 +1,25 @@
 "use client";
 
+import dynamic from "next/dynamic";
+import type { ChartSeriesConfig } from "@/components/charts/ChartBase";
 import type { ChartConfig } from "@/components/ui/chart";
-import {
-  ChartBase,
-  type ChartSeriesConfig,
-} from "@/components/charts/ChartBase";
+import { Skeleton } from "@/components/ui/skeleton";
 import { getAnnualInterestRate } from "@/lib/loans/interest";
 import { CURRENT_RATES } from "@/lib/loans/plans";
+
+const ChartBase = dynamic(
+  () => import("@/components/charts/ChartBase").then((m) => m.ChartBase),
+  {
+    ssr: false,
+    loading: () => (
+      <Skeleton
+        className="size-full"
+        role="status"
+        aria-label="Loading chart"
+      />
+    ),
+  },
+);
 
 const SALARY_MIN = 20_000;
 const SALARY_MAX = 80_000;

--- a/src/components/guides/pay-upfront-or-take-loan/CostComparisonChart.tsx
+++ b/src/components/guides/pay-upfront-or-take-loan/CostComparisonChart.tsx
@@ -1,9 +1,24 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import type { ChartConfig } from "@/components/ui/chart";
-import { ChartBase } from "@/components/charts/ChartBase";
+import { Skeleton } from "@/components/ui/skeleton";
 import { simulate } from "@/lib/loans/engine";
 import { TUITION_FEE_CAP } from "@/lib/loans/plans";
+
+const ChartBase = dynamic(
+  () => import("@/components/charts/ChartBase").then((m) => m.ChartBase),
+  {
+    ssr: false,
+    loading: () => (
+      <Skeleton
+        className="size-full"
+        role="status"
+        aria-label="Loading chart"
+      />
+    ),
+  },
+);
 
 const TUITION_COST = TUITION_FEE_CAP * 3;
 

--- a/src/components/guides/plan-2-vs-plan-5/BalanceComparisonChart.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/BalanceComparisonChart.tsx
@@ -1,11 +1,26 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useState } from "react";
 import type { ChartAnnotationConfig } from "@/components/charts/ChartBase";
 import type { ChartConfig } from "@/components/ui/chart";
-import { ChartBase } from "@/components/charts/ChartBase";
+import { Skeleton } from "@/components/ui/skeleton";
 import { simulate } from "@/lib/loans/engine";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
+
+const ChartBase = dynamic(
+  () => import("@/components/charts/ChartBase").then((m) => m.ChartBase),
+  {
+    ssr: false,
+    loading: () => (
+      <Skeleton
+        className="size-full"
+        role="status"
+        aria-label="Loading chart"
+      />
+    ),
+  },
+);
 
 const SALARY_OPTIONS = [30000, 50000, 70000] as const;
 type SalaryOption = (typeof SALARY_OPTIONS)[number];

--- a/src/components/guides/plan-2-vs-plan-5/TotalRepaymentBySalaryChart.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/TotalRepaymentBySalaryChart.tsx
@@ -1,8 +1,23 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import type { ChartConfig } from "@/components/ui/chart";
-import { ChartBase } from "@/components/charts/ChartBase";
+import { Skeleton } from "@/components/ui/skeleton";
 import { simulate } from "@/lib/loans/engine";
+
+const ChartBase = dynamic(
+  () => import("@/components/charts/ChartBase").then((m) => m.ChartBase),
+  {
+    ssr: false,
+    loading: () => (
+      <Skeleton
+        className="size-full"
+        role="status"
+        aria-label="Loading chart"
+      />
+    ),
+  },
+);
 
 const EXAMPLE_BALANCE = 45_000;
 

--- a/src/components/guides/rpi-vs-cpi/InflationComparisonChart.tsx
+++ b/src/components/guides/rpi-vs-cpi/InflationComparisonChart.tsx
@@ -1,11 +1,26 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useState } from "react";
 import type { ChartConfig } from "@/components/ui/chart";
-import { ChartBase } from "@/components/charts/ChartBase";
+import { Skeleton } from "@/components/ui/skeleton";
 import { simulate } from "@/lib/loans/engine";
 import { CURRENT_RATES } from "@/lib/loans/plans";
 import { toPresent } from "@/utils/present-value";
+
+const ChartBase = dynamic(
+  () => import("@/components/charts/ChartBase").then((m) => m.ChartBase),
+  {
+    ssr: false,
+    loading: () => (
+      <Skeleton
+        className="size-full"
+        role="status"
+        aria-label="Loading chart"
+      />
+    ),
+  },
+);
 
 const SALARY_OPTIONS = [30000, 50000, 70000] as const;
 type SalaryOption = (typeof SALARY_OPTIONS)[number];

--- a/src/components/guides/student-loan-vs-mortgage/RepaymentImpactChart.tsx
+++ b/src/components/guides/student-loan-vs-mortgage/RepaymentImpactChart.tsx
@@ -1,8 +1,23 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import type { ChartConfig } from "@/components/ui/chart";
-import { ChartBase } from "@/components/charts/ChartBase";
+import { Skeleton } from "@/components/ui/skeleton";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
+
+const ChartBase = dynamic(
+  () => import("@/components/charts/ChartBase").then((m) => m.ChartBase),
+  {
+    ssr: false,
+    loading: () => (
+      <Skeleton
+        className="size-full"
+        role="status"
+        aria-label="Loading chart"
+      />
+    ),
+  },
+);
 
 const chartConfig = {
   plan2: {

--- a/src/components/overpay/OverpayComparisonChart.tsx
+++ b/src/components/overpay/OverpayComparisonChart.tsx
@@ -1,10 +1,25 @@
 "use client";
 
-import { ChartBase } from "../charts/ChartBase";
+import dynamic from "next/dynamic";
 import type { ChartConfig } from "@/components/ui/chart";
 import type { OverpayAnalysisResult } from "@/lib/loans/overpay-types";
+import { Skeleton } from "@/components/ui/skeleton";
 import { currencyFormatter } from "@/constants";
 import { useShowPresentValue } from "@/hooks/useStoreSelectors";
+
+const ChartBase = dynamic(
+  () => import("../charts/ChartBase").then((m) => m.ChartBase),
+  {
+    ssr: false,
+    loading: () => (
+      <Skeleton
+        className="size-full"
+        role="status"
+        aria-label="Loading chart"
+      />
+    ),
+  },
+);
 
 const chartConfig = {
   baselineBalance: {


### PR DESCRIPTION
## Summary

Lazy-load `ChartBase` (which wraps Recharts) using `next/dynamic` with `ssr: false` across all 9 chart components. This code-splits the heavy Recharts library out of the main bundle so it is only downloaded when a chart is actually rendered on the client, reducing initial page load JS.

## Context

Recharts is one of the largest client-side dependencies. Previously it was statically imported in every chart component, meaning it was included in the initial bundle even before charts were visible. By using `next/dynamic`, each chart now shows a skeleton placeholder while the Recharts code loads asynchronously. The two home-page charts also simplify their empty-data loading state to use `Skeleton` directly instead of wrapping it in a `div`.