### PR TITLE
chore: add claude code hooks for pnpm enforcement and worktrees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,35 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'CMD=$(jq -r .tool_input.command) && if echo \"$CMD\" | grep -qE \"\\bnpm\\b|\\bnpx\\b\"; then echo \"Use pnpm/pnpx instead of npm/npx. This project uses pnpm.\" >&2; exit 2; fi'"
+          }
+        ]
+      }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'NAME=$(jq -r .name) && REPO=$(git rev-parse --show-toplevel) && DIR=\"$REPO/.claude/worktrees/$NAME\" && git worktree add \"$DIR\" >&2 && cd \"$DIR\" && pnpm install >&2 && echo \"$DIR\"'"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'WORKTREE_PATH=$(jq -r .worktree_path) && git worktree remove \"$WORKTREE_PATH\" --force >&2'"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Adds `.claude/settings.json` with project-level hooks that enforce pnpm usage and automate git worktree setup/teardown for Claude Code agents.

## Context
The project uses pnpm exclusively. The PreToolUse hook intercepts Bash commands and blocks any that invoke non-pnpm package managers, prompting agents to use pnpm/pnpx instead. The WorktreeCreate and WorktreeRemove hooks automate the full worktree lifecycle — creating the worktree directory under `.claude/worktrees/`, running `pnpm install`, and cleaning up with `git worktree remove --force`.