### PR TITLE
feat: add detail pages for balance, repaid, interest, and effective rate

### DIFF
--- a/scripts/check-govuk-figures/templates.ts
+++ b/scripts/check-govuk-figures/templates.ts
@@ -222,6 +222,10 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - [Repayment Calculator](https://studentloanstudy.uk): See total repayments across all UK student loan plan types (Plan 1, 2, 4, 5, Postgraduate)
 - [Which Plan Quiz](https://studentloanstudy.uk/which-plan): Find your loan plan in 3 questions
 - [Overpay Calculator](https://studentloanstudy.uk/overpay): Should you overpay or invest?
+- [Repaid Over Time](https://studentloanstudy.uk/repaid): Track cumulative student loan repayments over time
+- [Balance Over Time](https://studentloanstudy.uk/balance): See how your loan balance changes as interest accrues and repayments are made
+- [Interest Breakdown](https://studentloanstudy.uk/interest): Understand how much of your repayments go to interest vs principal
+- [Effective Rate](https://studentloanstudy.uk/effective-rate): Compare your loan's true effective annual rate to the Bank of England base rate
 - [Our Data](https://studentloanstudy.uk/our-data): How we keep figures current — daily automation checks GOV.UK and the Bank of England
 
 ## Guides

--- a/src/app/balance/layout.tsx
+++ b/src/app/balance/layout.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Balance Over Time — Student Loan Balance Trajectory",
+  description:
+    "See how your UK student loan balance changes over time. Track peak balance, interest growth, and when your loan will be paid off or written off.",
+  keywords: [
+    "student loan balance over time",
+    "student loan balance trajectory",
+    "UK student loan balance tracker",
+    "student loan peak balance",
+  ],
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://studentloanstudy.uk",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Balance Over Time",
+      item: "https://studentloanstudy.uk/balance",
+    },
+  ],
+};
+
+export default function BalanceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/balance/page.tsx
+++ b/src/app/balance/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import { BalanceDetailPage } from "@/components/detail/BalanceDetailPage";
+import { AppErrorBoundary } from "@/components/shared/ErrorBoundary";
+
+export function generateMetadata(): Metadata {
+  return {
+    alternates: {
+      canonical: "/balance",
+    },
+  };
+}
+
+export default function BalanceRoute() {
+  return (
+    <AppErrorBoundary>
+      <BalanceDetailPage />
+    </AppErrorBoundary>
+  );
+}

--- a/src/app/effective-rate/layout.tsx
+++ b/src/app/effective-rate/layout.tsx
@@ -1,0 +1,75 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Effective Rate — True Cost of Your Student Loan",
+  description:
+    "Discover the true effective annual rate of your UK student loan and compare it to the Bank of England base rate. See how your rate changes with different salaries.",
+  keywords: [
+    "student loan effective rate",
+    "student loan true cost",
+    "UK student loan interest rate comparison",
+    "student loan vs base rate",
+  ],
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://studentloanstudy.uk",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Effective Rate",
+      item: "https://studentloanstudy.uk/effective-rate",
+    },
+  ],
+};
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "What is the effective rate on a student loan?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "The effective rate is the true annualized cost of your student loan, calculated as an internal rate of return (IRR). Unlike the headline interest rate, it accounts for write-offs — if your loan is partially forgiven, your effective cost is lower than the stated interest rate.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Is my student loan interest rate higher than the Bank of England base rate?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "The headline interest rate often exceeds the base rate, but the effective rate may not. Lower and middle earners whose loans are written off before full repayment have an effective rate well below the base rate. Higher earners who repay in full may have an effective rate closer to or above the base rate.",
+      },
+    },
+  ],
+};
+
+export default function EffectiveRateLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/effective-rate/page.tsx
+++ b/src/app/effective-rate/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import { EffectiveRateDetailPage } from "@/components/detail/EffectiveRateDetailPage";
+import { AppErrorBoundary } from "@/components/shared/ErrorBoundary";
+
+export function generateMetadata(): Metadata {
+  return {
+    alternates: {
+      canonical: "/effective-rate",
+    },
+  };
+}
+
+export default function EffectiveRateRoute() {
+  return (
+    <AppErrorBoundary>
+      <EffectiveRateDetailPage />
+    </AppErrorBoundary>
+  );
+}

--- a/src/app/interest/layout.tsx
+++ b/src/app/interest/layout.tsx
@@ -1,0 +1,75 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Interest Paid — Student Loan Interest Breakdown",
+  description:
+    "Understand how much of your UK student loan repayments go towards interest vs reducing your balance. See the true cost of borrowing with a stacked breakdown chart.",
+  keywords: [
+    "student loan interest breakdown",
+    "student loan interest vs principal",
+    "UK student loan interest cost",
+    "student loan cost of borrowing",
+  ],
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://studentloanstudy.uk",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Interest Paid",
+      item: "https://studentloanstudy.uk/interest",
+    },
+  ],
+};
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "What percentage of my student loan repayments go towards interest?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "It depends on your salary, plan type, and interest rate. Lower earners may find that most of their repayments cover interest rather than reducing the balance. Use our interest breakdown tool to see your exact split between interest and principal payments.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Why do I pay more in interest than my original loan?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Student loan interest accrues from the day your loan is paid out, including while you study. For Plan 2 borrowers, interest can be RPI + up to 3%, meaning your balance can grow faster than your repayments reduce it — especially in the early years when your salary is lower.",
+      },
+    },
+  ],
+};
+
+export default function InterestLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/interest/page.tsx
+++ b/src/app/interest/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import { InterestDetailPage } from "@/components/detail/InterestDetailPage";
+import { AppErrorBoundary } from "@/components/shared/ErrorBoundary";
+
+export function generateMetadata(): Metadata {
+  return {
+    alternates: {
+      canonical: "/interest",
+    },
+  };
+}
+
+export default function InterestRoute() {
+  return (
+    <AppErrorBoundary>
+      <InterestDetailPage />
+    </AppErrorBoundary>
+  );
+}

--- a/src/app/repaid/layout.tsx
+++ b/src/app/repaid/layout.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Repaid Over Time — Cumulative Student Loan Repayments",
+  description:
+    "Track how your total UK student loan repayments grow over time. See cumulative payments, monthly repayment amounts, and whether your loan will be paid off or written off.",
+  keywords: [
+    "student loan repayments over time",
+    "cumulative student loan payments",
+    "UK student loan repayment tracker",
+    "student loan total cost",
+  ],
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://studentloanstudy.uk",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Repaid Over Time",
+      item: "https://studentloanstudy.uk/repaid",
+    },
+  ],
+};
+
+export default function RepaidLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/repaid/page.tsx
+++ b/src/app/repaid/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import { RepaidDetailPage } from "@/components/detail/RepaidDetailPage";
+import { AppErrorBoundary } from "@/components/shared/ErrorBoundary";
+
+export function generateMetadata(): Metadata {
+  return {
+    alternates: {
+      canonical: "/repaid",
+    },
+  };
+}
+
+export default function RepaidRoute() {
+  return (
+    <AppErrorBoundary>
+      <RepaidDetailPage />
+    </AppErrorBoundary>
+  );
+}

--- a/src/app/sitemap.xml
+++ b/src/app/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://studentloanstudy.uk</loc>
-    <lastmod>2026-02-22</lastmod>
+    <lastmod>2026-02-28</lastmod>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/which-plan</loc>
@@ -38,6 +38,22 @@
   </url>
   <url>
     <loc>https://studentloanstudy.uk/our-data</loc>
+  </url>
+  <url>
+    <loc>https://studentloanstudy.uk/repaid</loc>
+    <lastmod>2026-02-28</lastmod>
+  </url>
+  <url>
+    <loc>https://studentloanstudy.uk/balance</loc>
+    <lastmod>2026-02-28</lastmod>
+  </url>
+  <url>
+    <loc>https://studentloanstudy.uk/interest</loc>
+    <lastmod>2026-02-28</lastmod>
+  </url>
+  <url>
+    <loc>https://studentloanstudy.uk/effective-rate</loc>
+    <lastmod>2026-02-28</lastmod>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/brand</loc>

--- a/src/components/charts/BalanceOverTimeChart.tsx
+++ b/src/components/charts/BalanceOverTimeChart.tsx
@@ -1,25 +1,12 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import type { ChartConfig } from "@/components/ui/chart";
+import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
 import { Skeleton } from "@/components/ui/skeleton";
 import { currencyFormatter } from "@/constants";
 import { useBalanceOverTimeData } from "@/hooks/useChartData";
 import { useShowPresentValue } from "@/hooks/useStoreSelectors";
-
-const ChartBase = dynamic(
-  () => import("./ChartBase").then((m) => m.ChartBase),
-  {
-    ssr: false,
-    loading: () => (
-      <Skeleton
-        className="size-full"
-        role="status"
-        aria-label="Loading chart"
-      />
-    ),
-  },
-);
+import { formatYearFromMonth } from "@/lib/format";
 
 const chartConfig = {
   balance: {
@@ -27,11 +14,6 @@ const chartConfig = {
     color: "var(--chart-3)",
   },
 } satisfies ChartConfig;
-
-function formatYear(month: number): string {
-  const year = Math.round(month / 12).toString();
-  return `Year ${year}`;
-}
 
 export function BalanceOverTimeChart() {
   const { data } = useBalanceOverTimeData();
@@ -53,7 +35,7 @@ export function BalanceOverTimeChart() {
       data={data}
       xDataKey="month"
       xLabel="Time"
-      xFormatter={formatYear}
+      xFormatter={formatYearFromMonth}
       yLabel={showPresentValue ? "Balance (inflation-adjusted)" : "Balance"}
       yFormatter={(v) => currencyFormatter.format(v)}
       ariaLabel={

--- a/src/components/charts/ChartBase.tsx
+++ b/src/components/charts/ChartBase.tsx
@@ -18,6 +18,7 @@ import { ChartContainer, type ChartConfig } from "@/components/ui/chart";
 
 export interface ChartSeriesConfig {
   dataKey: string;
+  stackId?: string;
 }
 
 export interface ChartAnnotationConfig {
@@ -29,6 +30,13 @@ export interface ChartAnnotationConfig {
   color?: string;
   labelAnchor?: "start" | "end";
   labelOffsetY?: number;
+  strokeDasharray?: string;
+}
+
+export interface HorizontalAnnotationConfig {
+  y: number;
+  label: string;
+  color?: string;
   strokeDasharray?: string;
 }
 
@@ -49,6 +57,7 @@ export interface ChartBaseProps {
   chartConfig: ChartConfig;
   series: ChartSeriesConfig[];
   annotations?: ChartAnnotationConfig[];
+  horizontalAnnotations?: HorizontalAnnotationConfig[];
   showLegend?: boolean;
   interactionMode?: "crosshair" | "none";
   xDomain?: [number, number];
@@ -67,6 +76,7 @@ export function ChartBase({
   chartConfig,
   series,
   annotations = [],
+  horizontalAnnotations = [],
   showLegend = false,
   interactionMode = "crosshair",
   xDomain,
@@ -240,6 +250,7 @@ export function ChartBase({
                 activeDot={false}
                 isAnimationActive={false}
                 style={isCrosshair ? { touchAction: "none" } : undefined}
+                {...(s.stackId ? { stackId: s.stackId } : {})}
               />
             ))}
           {type === "line" &&
@@ -265,36 +276,59 @@ export function ChartBase({
               label={({ viewBox }: { viewBox: { x: number; y: number } }) => {
                 const isMulti = crosshairPoint.values.length > 1;
                 const xText = xFormatter(crosshairPoint.x);
+                const lines = crosshairPoint.values.map((v) => {
+                  const yText = yFormatter(v.y);
+                  const configLabel = chartConfig[v.dataKey].label;
+                  const seriesName =
+                    typeof configLabel === "string"
+                      ? configLabel.toLowerCase()
+                      : v.dataKey;
+                  return isMulti
+                    ? `${yText} at ${xText} ${seriesName}`
+                    : `${yText} at ${xText}`;
+                });
+                const charWidth = 6.6;
+                const px = 8;
+                const py = 4;
+                const lineHeight = 14;
+                const maxLen = Math.max(...lines.map((l) => l.length));
+                const rectW = maxLen * charWidth + px * 2;
+                const rectH = lines.length * lineHeight + py * 2;
+                const baseY = viewBox.y - 10 - (isMulti ? 14 : 0) - py;
                 return (
-                  <text
-                    x={viewBox.x}
-                    y={viewBox.y}
-                    textAnchor="middle"
-                    fontSize={11}
-                    fontWeight={500}
-                  >
-                    {crosshairPoint.values.map((v, i) => {
-                      const yText = yFormatter(v.y);
-                      const configLabel = chartConfig[v.dataKey].label;
-                      const seriesName =
-                        typeof configLabel === "string"
-                          ? configLabel.toLowerCase()
-                          : v.dataKey;
-                      const text = isMulti
-                        ? `${yText} at ${xText} ${seriesName}`
-                        : `${yText} at ${xText}`;
-                      return (
-                        <tspan
-                          key={v.dataKey}
-                          x={viewBox.x}
-                          dy={i === 0 ? -10 - (isMulti ? 14 : 0) : 14}
-                          fill={`var(--color-${v.dataKey})`}
-                        >
-                          {text}
-                        </tspan>
-                      );
-                    })}
-                  </text>
+                  <g>
+                    <rect
+                      x={viewBox.x - rectW / 2}
+                      y={baseY - lineHeight / 2}
+                      width={rectW}
+                      height={rectH}
+                      rx={4}
+                      fill="var(--background)"
+                      stroke="var(--border)"
+                      strokeWidth={1}
+                      opacity={0.95}
+                    />
+                    <text
+                      x={viewBox.x}
+                      y={viewBox.y}
+                      textAnchor="middle"
+                      fontSize={11}
+                      fontWeight={500}
+                    >
+                      {crosshairPoint.values.map((v, i) => {
+                        return (
+                          <tspan
+                            key={v.dataKey}
+                            x={viewBox.x}
+                            dy={i === 0 ? -10 - (isMulti ? 14 : 0) : 14}
+                            fill={`var(--color-${v.dataKey})`}
+                          >
+                            {lines[i]}
+                          </tspan>
+                        );
+                      })}
+                    </text>
+                  </g>
                 );
               }}
             />
@@ -409,6 +443,22 @@ export function ChartBase({
                   }}
                 />
               ))}
+          {horizontalAnnotations.map((ha) => (
+            <ReferenceLine
+              key={`hline-${String(ha.y)}-${ha.label}`}
+              y={ha.y}
+              stroke={ha.color ?? "var(--muted-foreground)"}
+              strokeWidth={1.5}
+              strokeDasharray={ha.strokeDasharray ?? "6 4"}
+              label={{
+                value: ha.label,
+                position: "right" as const,
+                fill: ha.color ?? "var(--muted-foreground)",
+                fontSize: 11,
+                fontWeight: 500,
+              }}
+            />
+          ))}
         </ChartComponent>
       </ChartContainer>
     </div>

--- a/src/components/charts/LazyChartBase.tsx
+++ b/src/components/charts/LazyChartBase.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export const LazyChartBase = dynamic(
+  () => import("@/components/charts/ChartBase").then((m) => m.ChartBase),
+  {
+    ssr: false,
+    loading: () => (
+      <Skeleton
+        className="size-full"
+        role="status"
+        aria-label="Loading chart"
+      />
+    ),
+  },
+);

--- a/src/components/charts/TotalRepaymentChart.tsx
+++ b/src/components/charts/TotalRepaymentChart.tsx
@@ -1,26 +1,12 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import { useDeferredValue } from "react";
 import type { ChartConfig } from "@/components/ui/chart";
+import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
 import { Skeleton } from "@/components/ui/skeleton";
 import { currencyFormatter, MIN_SALARY, MAX_SALARY } from "@/constants";
 import { useTotalRepaymentData } from "@/hooks/useChartData";
 import { useShowPresentValue } from "@/hooks/useStoreSelectors";
-
-const ChartBase = dynamic(
-  () => import("./ChartBase").then((m) => m.ChartBase),
-  {
-    ssr: false,
-    loading: () => (
-      <Skeleton
-        className="size-full"
-        role="status"
-        aria-label="Loading chart"
-      />
-    ),
-  },
-);
 
 const chartConfig = {
   value: {

--- a/src/components/detail/BalanceDetailChart.tsx
+++ b/src/components/detail/BalanceDetailChart.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import type { ChartConfig } from "@/components/ui/chart";
+import type { DetailSeriesResult } from "@/workers/simulation.worker";
+import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
+import { Skeleton } from "@/components/ui/skeleton";
+import { currencyFormatter } from "@/constants";
+import { formatYearFromMonth } from "@/lib/format";
+
+const chartConfig = {
+  balance: {
+    label: "Balance",
+    color: "var(--chart-2)",
+  },
+} satisfies ChartConfig;
+
+interface BalanceDetailChartProps {
+  data: DetailSeriesResult["balanceSeries"];
+  peakBalanceMonth: number;
+  peakBalance: number;
+  writeOffMonth: number | null;
+}
+
+export function BalanceDetailChart({
+  data,
+  peakBalanceMonth,
+  peakBalance,
+  writeOffMonth,
+}: BalanceDetailChartProps) {
+  if (data.length === 0) {
+    return (
+      <Skeleton
+        className="size-full"
+        role="status"
+        aria-label="Loading balance chart"
+      />
+    );
+  }
+
+  const annotations = [];
+
+  if (peakBalanceMonth > 0) {
+    annotations.push({
+      x: peakBalanceMonth,
+      y: peakBalance,
+      label: `Peak ${currencyFormatter.format(peakBalance)}`,
+      color: "var(--chart-2)",
+      labelAnchor: "end" as const,
+      labelOffsetY: -8,
+    });
+  }
+
+  if (writeOffMonth !== null) {
+    annotations.push({
+      x: writeOffMonth,
+      label: "Written off",
+      bottomLabel: "Write-off",
+      color: "var(--status-warning-foreground)",
+    });
+  }
+
+  return (
+    <ChartBase
+      type="area"
+      data={data}
+      xDataKey="month"
+      xLabel="Time"
+      xFormatter={formatYearFromMonth}
+      yLabel="Balance"
+      yFormatter={(v) => currencyFormatter.format(v)}
+      ariaLabel="Student loan balance trajectory over time"
+      chartConfig={chartConfig}
+      series={[{ dataKey: "balance" }]}
+      annotations={annotations}
+    />
+  );
+}

--- a/src/components/detail/BalanceDetailPage.tsx
+++ b/src/components/detail/BalanceDetailPage.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { BalanceDetailChart } from "./BalanceDetailChart";
+import { DetailPageShell } from "./DetailPageShell";
+import { StatCard, StatCardSkeleton } from "./StatCard";
+import { Skeleton } from "@/components/ui/skeleton";
+import { currencyFormatter } from "@/constants";
+import { useDetailSeriesData } from "@/hooks/useDetailData";
+
+export function BalanceDetailPage() {
+  const result = useDetailSeriesData();
+
+  const peakYear = result ? Math.round(result.stats.peakBalanceMonth / 12) : 0;
+  const payoffYears = result ? Math.round(result.stats.monthsToPayoff / 12) : 0;
+
+  function getInsightText() {
+    if (!result) return null;
+    const { peakBalanceMonth, writtenOff, peakBalance, initialBalance } =
+      result.stats;
+
+    const peakYears = Math.round(peakBalanceMonth / 12);
+    const peakPct = Math.round(
+      ((peakBalance - initialBalance) / initialBalance) * 100,
+    );
+
+    if (peakBalanceMonth === 0) {
+      return writtenOff
+        ? `Your repayments exceed interest from day one. You'll have remaining balance written off after ${String(payoffYears)} years.`
+        : `Your repayments exceed interest from day one. You'll pay it off in full in ${String(payoffYears)} years.`;
+    }
+
+    if (writtenOff) {
+      return `Interest outpaces repayments for the first ${String(peakYears)} years, pushing your balance ${String(peakPct)}% above what you borrowed. The remaining balance is written off after ${String(payoffYears)} years.`;
+    }
+
+    return `Interest outpaces repayments for the first ${String(peakYears)} years. After that, your growing salary tips the balance and you pay off the loan in ${String(payoffYears)} years.`;
+  }
+
+  function getPayoffSubtext() {
+    if (!result) return "";
+    if (result.stats.writtenOff) {
+      const forgiven =
+        result.balanceSeries[result.balanceSeries.length - 1].balance;
+      return `Written off — ${currencyFormatter.format(forgiven)} forgiven`;
+    }
+    return payoffYears <= 15
+      ? "Paid in full — ahead of schedule"
+      : "Paid in full";
+  }
+
+  return (
+    <DetailPageShell
+      pageTitle="Balance Over Time"
+      heading="Balance Trajectory"
+      description="See how your loan balance changes over time as interest accrues and repayments are made."
+    >
+      {result ? (
+        <>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+            <StatCard
+              label="Starting Balance"
+              value={currencyFormatter.format(result.stats.initialBalance)}
+              accentColor="var(--chart-2)"
+            />
+            <StatCard
+              label="Peak Balance"
+              value={currencyFormatter.format(result.stats.peakBalance)}
+              subtext={
+                result.stats.peakBalanceMonth > 0
+                  ? `at year ${String(peakYear)}`
+                  : "at start"
+              }
+              accentColor="var(--chart-3)"
+            />
+            <div className="col-span-2 sm:col-span-1">
+              <StatCard
+                label="Payoff"
+                value={`${String(payoffYears)} years`}
+                subtext={getPayoffSubtext()}
+                accentColor={
+                  result.stats.writtenOff ? "var(--chart-5)" : "var(--chart-1)"
+                }
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <div className="h-65 sm:h-75 md:h-85">
+              <BalanceDetailChart
+                data={result.balanceSeries}
+                peakBalanceMonth={result.stats.peakBalanceMonth}
+                peakBalance={result.stats.peakBalance}
+                writeOffMonth={result.stats.writeOffMonth}
+              />
+            </div>
+            <p className="text-center text-xs text-muted-foreground">
+              {getInsightText()}
+            </p>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+            <StatCardSkeleton />
+            <StatCardSkeleton />
+            <div className="col-span-2 sm:col-span-1">
+              <StatCardSkeleton />
+            </div>
+          </div>
+          <Skeleton className="h-65 sm:h-75 md:h-85" />
+        </>
+      )}
+    </DetailPageShell>
+  );
+}

--- a/src/components/detail/CumulativeRepaidChart.tsx
+++ b/src/components/detail/CumulativeRepaidChart.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import type { ChartConfig } from "@/components/ui/chart";
+import type { DetailSeriesResult } from "@/workers/simulation.worker";
+import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
+import { Skeleton } from "@/components/ui/skeleton";
+import { currencyFormatter } from "@/constants";
+import { formatYearFromMonth } from "@/lib/format";
+
+const chartConfig = {
+  cumulative: {
+    label: "Cumulative Repaid",
+    color: "var(--chart-1)",
+  },
+} satisfies ChartConfig;
+
+interface CumulativeRepaidChartProps {
+  data: DetailSeriesResult["cumulativeRepaid"];
+  writeOffMonth: number | null;
+}
+
+export function CumulativeRepaidChart({
+  data,
+  writeOffMonth,
+}: CumulativeRepaidChartProps) {
+  if (data.length === 0) {
+    return (
+      <Skeleton
+        className="size-full"
+        role="status"
+        aria-label="Loading cumulative repayment chart"
+      />
+    );
+  }
+
+  const annotations =
+    writeOffMonth !== null
+      ? [
+          {
+            x: writeOffMonth,
+            label: "Written off",
+            color: "var(--muted-foreground)",
+            strokeDasharray: "4 4",
+          },
+        ]
+      : [];
+
+  return (
+    <ChartBase
+      type="area"
+      data={data}
+      xDataKey="month"
+      xLabel="Time"
+      xFormatter={formatYearFromMonth}
+      yLabel="Cumulative repaid"
+      yFormatter={(v) => currencyFormatter.format(v)}
+      ariaLabel="Cumulative student loan repayments over time"
+      chartConfig={chartConfig}
+      series={[{ dataKey: "cumulative" }]}
+      annotations={annotations}
+    />
+  );
+}

--- a/src/components/detail/DetailPageNav.tsx
+++ b/src/components/detail/DetailPageNav.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { DETAIL_PAGES } from "@/lib/detail-pages";
+import { cn } from "@/lib/utils";
+
+export function DetailPageNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      aria-label="Loan breakdown pages"
+      className="relative -mx-3 overflow-hidden sm:mx-0 sm:overflow-visible"
+    >
+      <div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-linear-to-l from-background to-transparent sm:hidden" />
+      <div className="flex gap-1.5 overflow-x-auto px-3 pr-8 scrollbar-none sm:px-0 sm:pr-0">
+        {DETAIL_PAGES.map((page) => {
+          const isActive = pathname === page.href;
+          return (
+            <Link
+              key={page.href}
+              href={page.href}
+              className={cn(
+                "flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium whitespace-nowrap transition-colors",
+                isActive
+                  ? "bg-card shadow-sm ring-1 ring-foreground/10"
+                  : "text-muted-foreground hover:bg-accent hover:text-foreground",
+              )}
+              aria-current={isActive ? "page" : undefined}
+            >
+              <span
+                className={cn(
+                  "size-2 shrink-0 rounded-full",
+                  isActive && "ring-2 ring-offset-1 ring-offset-card",
+                )}
+                style={{ backgroundColor: page.color }}
+              />
+              <span className="hidden sm:inline">{page.label}</span>
+              <span className="sm:hidden">{page.shortLabel}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/detail/DetailPageShell.tsx
+++ b/src/components/detail/DetailPageShell.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+import { DetailPageNav } from "./DetailPageNav";
+import { RelatedContent } from "./RelatedContent";
+import { InputPanel } from "@/components/home/InputPanel";
+import { PageLayout } from "@/components/layout/PageLayout";
+import { AssumptionsCallout } from "@/components/shared/AssumptionsCallout";
+import { PlanFromQuery } from "@/components/shared/PlanFromQuery";
+import { Heading } from "@/components/typography/Heading";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { useInputPanelMode } from "@/hooks/useInputPanelMode";
+
+interface DetailPageShellProps {
+  pageTitle: string;
+  heading: string;
+  description: string;
+  children: React.ReactNode;
+}
+
+export function DetailPageShell({
+  pageTitle,
+  heading,
+  description,
+  children,
+}: DetailPageShellProps) {
+  const {
+    mode,
+    hasPersonalized,
+    handlePersonalise,
+    handlePresetApplied,
+    handleWizardComplete,
+    handleWizardClose,
+  } = useInputPanelMode();
+
+  return (
+    <>
+      <PlanFromQuery />
+      <PageLayout>
+        <div className="space-y-4">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>{pageTitle}</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+
+          <div className="space-y-2">
+            <Heading as="h1">{heading}</Heading>
+            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+              {description}
+            </p>
+          </div>
+        </div>
+
+        <DetailPageNav />
+
+        {children}
+
+        <InputPanel
+          hasPersonalized={hasPersonalized}
+          mode={mode}
+          onPersonalise={handlePersonalise}
+          onPresetApplied={handlePresetApplied}
+          onWizardComplete={handleWizardComplete}
+          onWizardClose={handleWizardClose}
+        />
+
+        <AssumptionsCallout />
+
+        <RelatedContent />
+      </PageLayout>
+    </>
+  );
+}

--- a/src/components/detail/EffectiveRateBySalaryChart.tsx
+++ b/src/components/detail/EffectiveRateBySalaryChart.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useDeferredValue } from "react";
+import type { ChartConfig } from "@/components/ui/chart";
+import type { EffectiveRateSalaryResult } from "@/workers/simulation.worker";
+import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  currencyFormatter,
+  percentageFormatter,
+  MIN_SALARY,
+  MAX_SALARY,
+} from "@/constants";
+
+const chartConfig = {
+  effectiveRate: {
+    label: "Effective Rate",
+    color: "var(--chart-4)",
+  },
+} satisfies ChartConfig;
+
+interface EffectiveRateBySalaryChartProps {
+  data: EffectiveRateSalaryResult["data"];
+  boeRate: number;
+  annotationSalary: number | undefined;
+}
+
+export function EffectiveRateBySalaryChart({
+  data,
+  boeRate,
+  annotationSalary,
+}: EffectiveRateBySalaryChartProps) {
+  const deferredSalary = useDeferredValue(annotationSalary);
+
+  if (data.length === 0) {
+    return (
+      <Skeleton
+        className="size-full"
+        role="status"
+        aria-label="Loading effective rate chart"
+      />
+    );
+  }
+
+  const closestPoint =
+    deferredSalary !== undefined
+      ? data.reduce((closest, point) =>
+          Math.abs(point.salary - deferredSalary) <
+          Math.abs(closest.salary - deferredSalary)
+            ? point
+            : closest,
+        )
+      : undefined;
+
+  const annotations =
+    deferredSalary !== undefined && closestPoint
+      ? [
+          {
+            x: deferredSalary,
+            y: closestPoint.effectiveRate,
+            label: percentageFormatter(closestPoint.effectiveRate),
+            bottomLabel: currencyFormatter.format(deferredSalary),
+            color: "var(--chart-4)",
+          },
+        ]
+      : [];
+
+  const horizontalAnnotations = [
+    {
+      y: boeRate,
+      label: `BoE base ${percentageFormatter(boeRate)}`,
+      color: "var(--muted-foreground)",
+      strokeDasharray: "6 4",
+    },
+  ];
+
+  return (
+    <ChartBase
+      type="line"
+      data={data}
+      xDataKey="salary"
+      xFormatter={(v) => currencyFormatter.format(v)}
+      yFormatter={percentageFormatter}
+      ariaLabel="Effective annual rate of student loan by salary"
+      chartConfig={chartConfig}
+      series={[{ dataKey: "effectiveRate" }]}
+      interactionMode="none"
+      annotations={annotations}
+      horizontalAnnotations={horizontalAnnotations}
+      xDomain={[MIN_SALARY, MAX_SALARY]}
+      margin={{ top: 25, right: 25, bottom: 8, left: 25 }}
+    />
+  );
+}

--- a/src/components/detail/EffectiveRateDetailPage.tsx
+++ b/src/components/detail/EffectiveRateDetailPage.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { DetailPageShell } from "./DetailPageShell";
+import { EffectiveRateBySalaryChart } from "./EffectiveRateBySalaryChart";
+import { StatCard, StatCardSkeleton } from "./StatCard";
+import { Skeleton } from "@/components/ui/skeleton";
+import { MIN_SALARY, MAX_SALARY, percentageFormatter } from "@/constants";
+import { useEffectiveRateBySalaryData } from "@/hooks/useDetailData";
+import { useCurrentSalary } from "@/hooks/useStoreSelectors";
+import { DETAIL_PAGE_COLOR } from "@/lib/detail-pages";
+
+const ACCENT = DETAIL_PAGE_COLOR["/effective-rate"];
+
+export function EffectiveRateDetailPage() {
+  const salaryResult = useEffectiveRateBySalaryData();
+  const salary = useCurrentSalary();
+
+  const boeRate = salaryResult?.boeRate ?? 0;
+
+  const closestPoint =
+    salaryResult?.data.reduce((closest, point) =>
+      Math.abs(point.salary - salary) < Math.abs(closest.salary - salary)
+        ? point
+        : closest,
+    ) ?? null;
+
+  const effectiveRate = closestPoint?.effectiveRate ?? 0;
+  const diff = effectiveRate - boeRate;
+  const isBelow = diff < 0;
+
+  const annotationSalary =
+    salary >= MIN_SALARY && salary <= MAX_SALARY ? salary : undefined;
+
+  return (
+    <DetailPageShell
+      pageTitle="Effective Rate"
+      heading="True Cost of Your Loan"
+      description="Compare your loan's effective annual rate to the Bank of England base rate across different salaries."
+    >
+      {salaryResult ? (
+        <>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+            <StatCard
+              label="Your Effective Rate"
+              value={percentageFormatter(effectiveRate)}
+              accentColor={ACCENT}
+            />
+            <StatCard
+              label="BoE Base Rate"
+              value={percentageFormatter(boeRate)}
+              accentColor={ACCENT}
+            />
+            <div className="col-span-2 sm:col-span-1">
+              <StatCard
+                label="Difference"
+                value={`${diff >= 0 ? "+" : ""}${percentageFormatter(diff)}`}
+                subtext={isBelow ? "Below base rate" : "Above base rate"}
+                accentColor={isBelow ? "var(--chart-5)" : "var(--chart-3)"}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <div className="h-65 sm:h-75 md:h-85">
+              <EffectiveRateBySalaryChart
+                data={salaryResult.data}
+                boeRate={salaryResult.boeRate}
+                annotationSalary={annotationSalary}
+              />
+            </div>
+            <p className="text-center text-xs text-muted-foreground">
+              The effective rate accounts for write-offs — lower earners pay
+              less because more of their debt is forgiven.
+            </p>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+            <StatCardSkeleton />
+            <StatCardSkeleton />
+            <div className="col-span-2 sm:col-span-1">
+              <StatCardSkeleton />
+            </div>
+          </div>
+          <Skeleton className="h-65 sm:h-75 md:h-85" />
+        </>
+      )}
+    </DetailPageShell>
+  );
+}

--- a/src/components/detail/InterestBreakdownChart.tsx
+++ b/src/components/detail/InterestBreakdownChart.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import type { ChartConfig } from "@/components/ui/chart";
+import type { DetailSeriesResult } from "@/workers/simulation.worker";
+import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
+import { Skeleton } from "@/components/ui/skeleton";
+import { currencyFormatter } from "@/constants";
+import { formatYearFromMonth } from "@/lib/format";
+
+const chartConfig = {
+  cumulativeInterest: {
+    label: "Interest",
+    color: "var(--chart-3)",
+  },
+  cumulativePrincipal: {
+    label: "Principal",
+    color: "var(--chart-5)",
+  },
+} satisfies ChartConfig;
+
+interface InterestBreakdownChartProps {
+  data: DetailSeriesResult["interestBreakdown"];
+}
+
+export function InterestBreakdownChart({ data }: InterestBreakdownChartProps) {
+  if (data.length === 0) {
+    return (
+      <Skeleton
+        className="size-full"
+        role="status"
+        aria-label="Loading interest breakdown chart"
+      />
+    );
+  }
+
+  return (
+    <ChartBase
+      type="area"
+      data={data}
+      xDataKey="month"
+      xLabel="Time"
+      xFormatter={formatYearFromMonth}
+      yLabel="Cumulative payments"
+      yFormatter={(v) => currencyFormatter.format(v)}
+      ariaLabel="Stacked area chart showing cumulative interest and principal portions of student loan repayments"
+      chartConfig={chartConfig}
+      series={[
+        { dataKey: "cumulativeInterest", stackId: "breakdown" },
+        { dataKey: "cumulativePrincipal", stackId: "breakdown" },
+      ]}
+      showLegend
+    />
+  );
+}

--- a/src/components/detail/InterestDetailPage.tsx
+++ b/src/components/detail/InterestDetailPage.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { DetailPageShell } from "./DetailPageShell";
+import { InterestBreakdownChart } from "./InterestBreakdownChart";
+import { StatCard, StatCardSkeleton } from "./StatCard";
+import { Skeleton } from "@/components/ui/skeleton";
+import { currencyFormatter } from "@/constants";
+import { useDetailSeriesData } from "@/hooks/useDetailData";
+import { DETAIL_PAGE_COLOR } from "@/lib/detail-pages";
+
+const ACCENT = DETAIL_PAGE_COLOR["/interest"];
+
+function ProportionBar({ interestRatio }: { interestRatio: number }) {
+  return (
+    <div className="rounded-lg bg-card p-4 ring-1 ring-foreground/10">
+      <div
+        className="flex h-4 overflow-hidden rounded-full"
+        role="img"
+        aria-label={`Interest is ${String(Math.round(interestRatio * 100))}% of total repayments`}
+      >
+        <div
+          className="rounded-l-full transition-all duration-500"
+          style={{
+            width: `${String(Math.max(interestRatio * 100, 2))}%`,
+            backgroundColor: ACCENT,
+          }}
+        />
+        <div className="flex-1 bg-muted" />
+      </div>
+      <div className="mt-2 flex justify-between text-sm text-muted-foreground">
+        <span>{String(Math.round(interestRatio * 100))}% interest</span>
+        <span>{String(Math.round((1 - interestRatio) * 100))}% principal</span>
+      </div>
+    </div>
+  );
+}
+
+export function InterestDetailPage() {
+  const result = useDetailSeriesData();
+
+  const costMultiplier = result
+    ? result.stats.totalPaid / result.stats.initialBalance
+    : 0;
+
+  return (
+    <DetailPageShell
+      pageTitle="Interest Paid"
+      heading="Interest Breakdown"
+      description="Understand how much of your repayments go towards interest vs reducing your loan balance."
+    >
+      {result ? (
+        <>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+            <StatCard
+              label="Total Interest"
+              value={currencyFormatter.format(result.stats.totalInterest)}
+              accentColor={ACCENT}
+            />
+            <StatCard
+              label="Interest Ratio"
+              value={`${String(Math.round(result.stats.interestRatio * 100))}%`}
+              subtext="of total repayments"
+              accentColor={ACCENT}
+            />
+            <div className="col-span-2 sm:col-span-1">
+              <StatCard
+                label="Total Cost"
+                value={currencyFormatter.format(result.stats.totalPaid)}
+                subtext={`${costMultiplier.toFixed(1)}x your original loan`}
+                accentColor={ACCENT}
+              />
+            </div>
+          </div>
+
+          <ProportionBar interestRatio={result.stats.interestRatio} />
+
+          <div className="space-y-2">
+            <div className="h-65 sm:h-75 md:h-85">
+              <InterestBreakdownChart data={result.interestBreakdown} />
+            </div>
+            <p className="text-center text-xs text-muted-foreground">
+              The stacked areas show how your payments split between interest
+              and principal reduction over time.
+            </p>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+            <StatCardSkeleton />
+            <StatCardSkeleton />
+            <div className="col-span-2 sm:col-span-1">
+              <StatCardSkeleton />
+            </div>
+          </div>
+          <Skeleton className="h-12" />
+          <Skeleton className="h-65 sm:h-75 md:h-85" />
+        </>
+      )}
+    </DetailPageShell>
+  );
+}

--- a/src/components/detail/RelatedContent.tsx
+++ b/src/components/detail/RelatedContent.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import {
+  AnalyticsUpIcon,
+  ArrowRight01Icon,
+  BookOpen01Icon,
+  Calculator01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { GuideEntry, GuideSlug } from "@/lib/guides";
+import { Heading } from "@/components/typography/Heading";
+import { GUIDES } from "@/lib/guides";
+
+interface ToolLink {
+  href: string;
+  icon: typeof Calculator01Icon;
+  title: string;
+  description: string;
+}
+
+interface PageRelatedConfig {
+  guides: GuideSlug[];
+  tools: ToolLink[];
+}
+
+const RELATED: Partial<Record<string, PageRelatedConfig>> = {
+  "/repaid": {
+    guides: ["how-interest-works", "plan-2-vs-plan-5"],
+    tools: [
+      {
+        href: "/overpay",
+        icon: AnalyticsUpIcon,
+        title: "Overpay Calculator",
+        description: "See if overpaying reduces your total cost",
+      },
+    ],
+  },
+  "/balance": {
+    guides: ["how-interest-works", "plan-2-vs-plan-5"],
+    tools: [
+      {
+        href: "/overpay",
+        icon: AnalyticsUpIcon,
+        title: "Overpay Calculator",
+        description: "See how overpaying affects your balance trajectory",
+      },
+    ],
+  },
+  "/interest": {
+    guides: ["how-interest-works", "rpi-vs-cpi"],
+    tools: [
+      {
+        href: "/overpay",
+        icon: AnalyticsUpIcon,
+        title: "Overpay Calculator",
+        description: "Could overpaying reduce your interest bill?",
+      },
+    ],
+  },
+  "/effective-rate": {
+    guides: ["rpi-vs-cpi", "student-loan-vs-mortgage"],
+    tools: [
+      {
+        href: "/",
+        icon: Calculator01Icon,
+        title: "Repayment Calculator",
+        description: "See your full repayment projection by salary",
+      },
+      {
+        href: "/overpay",
+        icon: AnalyticsUpIcon,
+        title: "Overpay Calculator",
+        description: "Should you pay off faster or invest?",
+      },
+    ],
+  },
+};
+
+export function RelatedContent() {
+  const pathname = usePathname();
+  const related = RELATED[pathname];
+  if (!related) return null;
+
+  const guidesBySlug = new Map(GUIDES.map((g) => [g.slug, g]));
+  const guides = related.guides
+    .map((slug) => guidesBySlug.get(slug))
+    .filter((g): g is GuideEntry => g !== undefined);
+
+  return (
+    <div className="space-y-6">
+      {guides.length > 0 && (
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Related Guides
+          </Heading>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {guides.map((guide) => (
+              <Link
+                key={guide.slug}
+                href={`/guides/${guide.slug}`}
+                className="group block"
+              >
+                <div className="flex h-full flex-col rounded-xl bg-card p-4 ring-1 ring-foreground/10 transition-all duration-200 hover:bg-accent hover:ring-primary/30">
+                  <div className="mb-2 flex items-center gap-2.5">
+                    <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
+                      <HugeiconsIcon icon={BookOpen01Icon} className="size-4" />
+                    </div>
+                    <h3 className="text-sm font-medium">{guide.title}</h3>
+                  </div>
+                  <p className="mb-3 flex-1 text-xs text-muted-foreground">
+                    {guide.description}
+                  </p>
+                  <div className="flex items-center gap-1 text-xs font-medium text-primary">
+                    Read Guide
+                    <HugeiconsIcon
+                      icon={ArrowRight01Icon}
+                      className="size-3.5 transition-transform group-hover:translate-x-0.5"
+                    />
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {related.tools.length > 0 && (
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            More Tools
+          </Heading>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {related.tools.map((tool) => (
+              <Link key={tool.href} href={tool.href} className="group block">
+                <div className="flex items-center gap-3 rounded-xl border p-4 transition-all duration-200 hover:bg-accent hover:ring-1 hover:ring-primary/30">
+                  <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
+                    <HugeiconsIcon icon={tool.icon} className="size-5" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <h3 className="text-sm font-medium">{tool.title}</h3>
+                    <p className="text-xs text-muted-foreground">
+                      {tool.description}
+                    </p>
+                  </div>
+                  <HugeiconsIcon
+                    icon={ArrowRight01Icon}
+                    className="size-4 shrink-0 text-primary transition-transform group-hover:translate-x-0.5"
+                  />
+                </div>
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/components/detail/RepaidDetailPage.tsx
+++ b/src/components/detail/RepaidDetailPage.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { CumulativeRepaidChart } from "./CumulativeRepaidChart";
+import { DetailPageShell } from "./DetailPageShell";
+import { StatCard, StatCardSkeleton } from "./StatCard";
+import { Skeleton } from "@/components/ui/skeleton";
+import { currencyFormatter } from "@/constants";
+import { useDetailSeriesData } from "@/hooks/useDetailData";
+import { DETAIL_PAGE_COLOR } from "@/lib/detail-pages";
+
+const ACCENT = DETAIL_PAGE_COLOR["/repaid"];
+
+export function RepaidDetailPage() {
+  const result = useDetailSeriesData();
+
+  const years = result ? Math.round(result.stats.monthsToPayoff / 12) : 0;
+
+  return (
+    <DetailPageShell
+      pageTitle="Repaid Over Time"
+      heading="Cumulative Repayments"
+      description="Track how your total repayments grow over the life of your loan."
+    >
+      {result ? (
+        <>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+            <StatCard
+              label="Total Repaid"
+              value={currencyFormatter.format(result.stats.totalPaid)}
+              subtext={`over ${String(years)} years`}
+              accentColor={ACCENT}
+            />
+            <StatCard
+              label="Monthly Repayment"
+              value={currencyFormatter.format(result.stats.monthlyRepayment)}
+              subtext="at current salary"
+              accentColor={ACCENT}
+            />
+            <div className="col-span-2 sm:col-span-1">
+              <StatCard
+                label="Outcome"
+                value={result.stats.writtenOff ? "Written off" : "Paid in full"}
+                subtext={
+                  result.stats.writtenOff
+                    ? `${currencyFormatter.format(result.balanceSeries[result.balanceSeries.length - 1]?.balance ?? 0)} forgiven`
+                    : undefined
+                }
+                accentColor={ACCENT}
+              />
+            </div>
+          </div>
+
+          <div className="h-65 sm:h-75 md:h-85">
+            <CumulativeRepaidChart
+              data={result.cumulativeRepaid}
+              writeOffMonth={result.stats.writeOffMonth}
+            />
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+            <StatCardSkeleton />
+            <StatCardSkeleton />
+            <div className="col-span-2 sm:col-span-1">
+              <StatCardSkeleton />
+            </div>
+          </div>
+          <Skeleton className="h-65 sm:h-75 md:h-85" />
+        </>
+      )}
+    </DetailPageShell>
+  );
+}

--- a/src/components/detail/StatCard.tsx
+++ b/src/components/detail/StatCard.tsx
@@ -1,0 +1,57 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface StatCardProps {
+  label: string;
+  value: string;
+  subtext?: string;
+  accentColor: string;
+}
+
+export function StatCard({
+  label,
+  value,
+  subtext,
+  accentColor,
+}: StatCardProps) {
+  return (
+    <div
+      className="relative overflow-hidden rounded-xl bg-card p-4 pl-3 ring-1 ring-foreground/10"
+      style={{
+        backgroundImage: `linear-gradient(135deg, ${accentColor}0D, transparent 60%)`,
+      }}
+    >
+      <div
+        className="absolute inset-y-2 left-0 w-1 rounded-r-full"
+        style={{ backgroundColor: accentColor }}
+      />
+      <div className="pl-3">
+        <span className="text-xs tracking-wide text-muted-foreground uppercase">
+          {label}
+        </span>
+        <p
+          className="mt-1 font-mono text-2xl font-semibold tabular-nums"
+          style={{ color: accentColor }}
+        >
+          {value}
+        </p>
+        {subtext && (
+          <span className="mt-0.5 block text-xs text-muted-foreground">
+            {subtext}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function StatCardSkeleton() {
+  return (
+    <div className="rounded-xl bg-card p-4 pl-3 ring-1 ring-foreground/10">
+      <div className="space-y-2 pl-3">
+        <Skeleton className="h-3 w-20" />
+        <Skeleton className="h-7 w-28" />
+        <Skeleton className="h-3 w-24" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/guides/how-interest-works/InterestRateChart.tsx
+++ b/src/components/guides/how-interest-works/InterestRateChart.tsx
@@ -1,25 +1,10 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import type { ChartSeriesConfig } from "@/components/charts/ChartBase";
 import type { ChartConfig } from "@/components/ui/chart";
-import { Skeleton } from "@/components/ui/skeleton";
+import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
 import { getAnnualInterestRate } from "@/lib/loans/interest";
 import { CURRENT_RATES } from "@/lib/loans/plans";
-
-const ChartBase = dynamic(
-  () => import("@/components/charts/ChartBase").then((m) => m.ChartBase),
-  {
-    ssr: false,
-    loading: () => (
-      <Skeleton
-        className="size-full"
-        role="status"
-        aria-label="Loading chart"
-      />
-    ),
-  },
-);
 
 const SALARY_MIN = 20_000;
 const SALARY_MAX = 80_000;

--- a/src/components/guides/pay-upfront-or-take-loan/CostComparisonChart.tsx
+++ b/src/components/guides/pay-upfront-or-take-loan/CostComparisonChart.tsx
@@ -1,24 +1,9 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import type { ChartConfig } from "@/components/ui/chart";
-import { Skeleton } from "@/components/ui/skeleton";
+import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
 import { simulate } from "@/lib/loans/engine";
 import { TUITION_FEE_CAP } from "@/lib/loans/plans";
-
-const ChartBase = dynamic(
-  () => import("@/components/charts/ChartBase").then((m) => m.ChartBase),
-  {
-    ssr: false,
-    loading: () => (
-      <Skeleton
-        className="size-full"
-        role="status"
-        aria-label="Loading chart"
-      />
-    ),
-  },
-);
 
 const TUITION_COST = TUITION_FEE_CAP * 3;
 

--- a/src/components/guides/plan-2-vs-plan-5/BalanceComparisonChart.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/BalanceComparisonChart.tsx
@@ -1,26 +1,11 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import { useState } from "react";
 import type { ChartAnnotationConfig } from "@/components/charts/ChartBase";
 import type { ChartConfig } from "@/components/ui/chart";
-import { Skeleton } from "@/components/ui/skeleton";
+import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
 import { simulate } from "@/lib/loans/engine";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
-
-const ChartBase = dynamic(
-  () => import("@/components/charts/ChartBase").then((m) => m.ChartBase),
-  {
-    ssr: false,
-    loading: () => (
-      <Skeleton
-        className="size-full"
-        role="status"
-        aria-label="Loading chart"
-      />
-    ),
-  },
-);
 
 const SALARY_OPTIONS = [30000, 50000, 70000] as const;
 type SalaryOption = (typeof SALARY_OPTIONS)[number];

--- a/src/components/guides/plan-2-vs-plan-5/TotalRepaymentBySalaryChart.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/TotalRepaymentBySalaryChart.tsx
@@ -1,23 +1,8 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import type { ChartConfig } from "@/components/ui/chart";
-import { Skeleton } from "@/components/ui/skeleton";
+import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
 import { simulate } from "@/lib/loans/engine";
-
-const ChartBase = dynamic(
-  () => import("@/components/charts/ChartBase").then((m) => m.ChartBase),
-  {
-    ssr: false,
-    loading: () => (
-      <Skeleton
-        className="size-full"
-        role="status"
-        aria-label="Loading chart"
-      />
-    ),
-  },
-);
 
 const EXAMPLE_BALANCE = 45_000;
 

--- a/src/components/guides/rpi-vs-cpi/InflationComparisonChart.tsx
+++ b/src/components/guides/rpi-vs-cpi/InflationComparisonChart.tsx
@@ -1,26 +1,11 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import { useState } from "react";
 import type { ChartConfig } from "@/components/ui/chart";
-import { Skeleton } from "@/components/ui/skeleton";
+import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
 import { simulate } from "@/lib/loans/engine";
 import { CURRENT_RATES } from "@/lib/loans/plans";
 import { toPresent } from "@/utils/present-value";
-
-const ChartBase = dynamic(
-  () => import("@/components/charts/ChartBase").then((m) => m.ChartBase),
-  {
-    ssr: false,
-    loading: () => (
-      <Skeleton
-        className="size-full"
-        role="status"
-        aria-label="Loading chart"
-      />
-    ),
-  },
-);
 
 const SALARY_OPTIONS = [30000, 50000, 70000] as const;
 type SalaryOption = (typeof SALARY_OPTIONS)[number];

--- a/src/components/guides/student-loan-vs-mortgage/RepaymentImpactChart.tsx
+++ b/src/components/guides/student-loan-vs-mortgage/RepaymentImpactChart.tsx
@@ -1,23 +1,8 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import type { ChartConfig } from "@/components/ui/chart";
-import { Skeleton } from "@/components/ui/skeleton";
+import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
-
-const ChartBase = dynamic(
-  () => import("@/components/charts/ChartBase").then((m) => m.ChartBase),
-  {
-    ssr: false,
-    loading: () => (
-      <Skeleton
-        className="size-full"
-        role="status"
-        aria-label="Loading chart"
-      />
-    ),
-  },
-);
 
 const chartConfig = {
   plan2: {

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -1,72 +1,38 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { InputPanel } from "./InputPanel";
 import { ResultSummary } from "./ResultSummary";
 import { SalaryExplorer } from "./SalaryExplorer";
 import type { InputMode } from "./InputPanel";
-import type { Preset } from "@/lib/presets";
 import { Heading } from "@/components/typography/Heading";
 import { useLoanActions, useLoanConfigState } from "@/context/LoanContext";
-import {
-  trackPresetApplied,
-  trackWizardCompleted,
-  trackWizardRestarted,
-  trackWizardStarted,
-} from "@/lib/analytics";
-import { isPresetConfig } from "@/lib/presets";
+import { useInputPanelMode } from "@/hooks/useInputPanelMode";
 
 export function HeroSection() {
-  const { applyPreset, updateField } = useLoanActions();
+  const { updateField } = useLoanActions();
   const config = useLoanConfigState();
   const { pendingQuizPlanTypes } = config;
 
-  const [mode, setMode] = useState<InputMode>(() => {
-    if (pendingQuizPlanTypes && pendingQuizPlanTypes.length > 0) {
-      return { view: "loan-config", initialPlanTypes: pendingQuizPlanTypes };
-    }
-    return { view: "summary" };
-  });
-  const hasPersonalized = !isPresetConfig(config.loans);
+  const initialMode: InputMode | undefined =
+    pendingQuizPlanTypes && pendingQuizPlanTypes.length > 0
+      ? { view: "loan-config", initialPlanTypes: pendingQuizPlanTypes }
+      : undefined;
+
+  const {
+    mode,
+    hasPersonalized,
+    handlePersonalise,
+    handlePresetApplied,
+    handleWizardComplete,
+    handleWizardClose,
+  } = useInputPanelMode({ initialMode });
 
   useEffect(() => {
     if (pendingQuizPlanTypes && pendingQuizPlanTypes.length > 0) {
       updateField("pendingQuizPlanTypes", null);
     }
   }, [pendingQuizPlanTypes, updateField]);
-
-  useEffect(() => {
-    if (mode.view !== "summary") {
-      document.body.style.overflow = "hidden";
-      return () => {
-        document.body.style.overflow = "";
-      };
-    }
-  }, [mode.view]);
-
-  function handlePersonalise() {
-    if (hasPersonalized) {
-      trackWizardRestarted("loan");
-    } else {
-      trackWizardStarted("loan");
-    }
-    setMode({ view: "loan-config" });
-  }
-
-  function handleWizardComplete() {
-    trackWizardCompleted("loan");
-    setMode({ view: "summary" });
-  }
-
-  function handlePresetApplied(preset: Preset) {
-    trackPresetApplied(preset.id);
-    applyPreset(preset);
-    setMode({ view: "summary" });
-  }
-
-  function handleWizardClose() {
-    setMode({ view: "summary" });
-  }
 
   return (
     <section className="space-y-6">

--- a/src/components/home/InsightCards.tsx
+++ b/src/components/home/InsightCards.tsx
@@ -6,6 +6,7 @@ import {
   SparklineCard,
 } from "./InsightCard";
 import { usePersonalizedResults } from "@/context/PersonalizedResultsContext";
+import { DETAIL_PAGES } from "@/lib/detail-pages";
 
 export function InsightCards() {
   const { cards: data } = usePersonalizedResults();
@@ -17,27 +18,27 @@ export function InsightCards() {
       </h2>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <SparklineCard
-          title="Repaid Over Time"
-          href="#"
-          color="var(--chart-1)"
+          title={DETAIL_PAGES[0].label}
+          href={DETAIL_PAGES[0].href}
+          color={DETAIL_PAGES[0].color}
           cardData={data?.cumulative ?? null}
         />
         <SparklineCard
-          title="Balance Over Time"
-          href="#"
-          color="var(--chart-2)"
+          title={DETAIL_PAGES[1].label}
+          href={DETAIL_PAGES[1].href}
+          color={DETAIL_PAGES[1].color}
           cardData={data?.balance ?? null}
         />
         <ProportionCard
-          title="Interest Paid"
-          href="#"
-          color="var(--chart-3)"
+          title={DETAIL_PAGES[2].label}
+          href={DETAIL_PAGES[2].href}
+          color={DETAIL_PAGES[2].color}
           cardData={data?.interest ?? null}
         />
         <RateComparisonCard
-          title="Effective Rate"
-          href="#"
-          color="var(--chart-4)"
+          title={DETAIL_PAGES[3].label}
+          href={DETAIL_PAGES[3].href}
+          color={DETAIL_PAGES[3].color}
           cardData={data?.effectiveRate ?? null}
         />
       </div>

--- a/src/components/overpay/OverpayComparisonChart.tsx
+++ b/src/components/overpay/OverpayComparisonChart.tsx
@@ -1,25 +1,10 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import type { ChartConfig } from "@/components/ui/chart";
 import type { OverpayAnalysisResult } from "@/lib/loans/overpay-types";
-import { Skeleton } from "@/components/ui/skeleton";
+import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
 import { currencyFormatter } from "@/constants";
 import { useShowPresentValue } from "@/hooks/useStoreSelectors";
-
-const ChartBase = dynamic(
-  () => import("../charts/ChartBase").then((m) => m.ChartBase),
-  {
-    ssr: false,
-    loading: () => (
-      <Skeleton
-        className="size-full"
-        role="status"
-        aria-label="Loading chart"
-      />
-    ),
-  },
-);
 
 const chartConfig = {
   baselineBalance: {

--- a/src/hooks/useDetailData.ts
+++ b/src/hooks/useDetailData.ts
@@ -1,0 +1,60 @@
+import { useSimulationWorker } from "./useSimulationWorker";
+import {
+  useLoanConfig,
+  useCurrentSalary,
+  useSalaryGrowthRate,
+  useThresholdGrowthRate,
+  useRpiRate,
+  useBoeBaseRate,
+  useActiveDiscountRate,
+} from "./useStoreSelectors";
+import type {
+  DetailSeriesPayload,
+  DetailSeriesResult,
+  EffectiveRateSalaryPayload,
+  EffectiveRateSalaryResult,
+} from "@/workers/simulation.worker";
+
+/** Hook for detail page time-series data (runs in Web Worker) */
+export function useDetailSeriesData(): DetailSeriesResult | null {
+  const config = useLoanConfig();
+  const salary = useCurrentSalary();
+  const salaryGrowthRate = useSalaryGrowthRate();
+  const thresholdGrowthRate = useThresholdGrowthRate();
+  const rpiRate = useRpiRate();
+  const boeBaseRate = useBoeBaseRate();
+  const activeDiscountRate = useActiveDiscountRate();
+
+  const payload: DetailSeriesPayload = {
+    type: "DETAIL_SERIES",
+    loans: config.loans,
+    annualSalary: salary,
+    salaryGrowthRate,
+    thresholdGrowthRate,
+    rpiRate,
+    boeBaseRate,
+    discountRate: activeDiscountRate,
+  };
+
+  return useSimulationWorker(payload);
+}
+
+/** Hook for effective rate by salary data (runs in Web Worker) */
+export function useEffectiveRateBySalaryData(): EffectiveRateSalaryResult | null {
+  const config = useLoanConfig();
+  const salaryGrowthRate = useSalaryGrowthRate();
+  const thresholdGrowthRate = useThresholdGrowthRate();
+  const rpiRate = useRpiRate();
+  const boeBaseRate = useBoeBaseRate();
+
+  const payload: EffectiveRateSalaryPayload = {
+    type: "EFFECTIVE_RATE_SALARY",
+    loans: config.loans,
+    salaryGrowthRate,
+    thresholdGrowthRate,
+    rpiRate,
+    boeBaseRate,
+  };
+
+  return useSimulationWorker(payload);
+}

--- a/src/hooks/useInputPanelMode.ts
+++ b/src/hooks/useInputPanelMode.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import type { InputMode } from "@/components/home/InputPanel";
+import type { Preset } from "@/lib/presets";
+import { useLoanActions, useLoanConfigState } from "@/context/LoanContext";
+import {
+  trackPresetApplied,
+  trackWizardCompleted,
+  trackWizardRestarted,
+  trackWizardStarted,
+} from "@/lib/analytics";
+import { isPresetConfig } from "@/lib/presets";
+
+interface UseInputPanelModeOptions {
+  initialMode?: InputMode;
+}
+
+export function useInputPanelMode(options?: UseInputPanelModeOptions) {
+  const [mode, setMode] = useState<InputMode>(
+    options?.initialMode ?? { view: "summary" },
+  );
+  const { applyPreset } = useLoanActions();
+  const config = useLoanConfigState();
+  const hasPersonalized = !isPresetConfig(config.loans);
+
+  useEffect(() => {
+    if (mode.view !== "summary") {
+      document.body.style.overflow = "hidden";
+      return () => {
+        document.body.style.overflow = "";
+      };
+    }
+  }, [mode.view]);
+
+  function handlePersonalise() {
+    if (hasPersonalized) {
+      trackWizardRestarted("loan");
+    } else {
+      trackWizardStarted("loan");
+    }
+    setMode({ view: "loan-config" });
+  }
+
+  function handleWizardComplete() {
+    trackWizardCompleted("loan");
+    setMode({ view: "summary" });
+  }
+
+  function handlePresetApplied(preset: Preset) {
+    trackPresetApplied(preset.id);
+    applyPreset(preset);
+    setMode({ view: "summary" });
+  }
+
+  function handleWizardClose() {
+    setMode({ view: "summary" });
+  }
+
+  return {
+    mode,
+    setMode,
+    hasPersonalized,
+    handlePersonalise,
+    handleWizardComplete,
+    handlePresetApplied,
+    handleWizardClose,
+  };
+}

--- a/src/lib/detail-pages.ts
+++ b/src/lib/detail-pages.ts
@@ -1,0 +1,37 @@
+export interface DetailPageConfig {
+  href: string;
+  label: string;
+  shortLabel: string;
+  color: string;
+}
+
+export const DETAIL_PAGES: DetailPageConfig[] = [
+  {
+    href: "/repaid",
+    label: "Repaid Over Time",
+    shortLabel: "Repaid",
+    color: "var(--chart-1)",
+  },
+  {
+    href: "/balance",
+    label: "Balance Over Time",
+    shortLabel: "Balance",
+    color: "var(--chart-2)",
+  },
+  {
+    href: "/interest",
+    label: "Interest Paid",
+    shortLabel: "Interest",
+    color: "var(--chart-3)",
+  },
+  {
+    href: "/effective-rate",
+    label: "Effective Rate",
+    shortLabel: "Eff. Rate",
+    color: "var(--chart-4)",
+  },
+];
+
+export const DETAIL_PAGE_COLOR: Record<string, string> = Object.fromEntries(
+  DETAIL_PAGES.map((p) => [p.href, p.color]),
+);

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -13,3 +13,11 @@ export function formatGBP(value: number): string {
 export function formatPercent(value: number): string {
   return `${String(value)}%`;
 }
+
+/**
+ * Format a month number as a year label for chart axes.
+ * @example formatYearFromMonth(24) → "Year 2"
+ */
+export function formatYearFromMonth(month: number): string {
+  return `Year ${String(Math.round(month / 12))}`;
+}

--- a/src/workers/simulation.worker.ts
+++ b/src/workers/simulation.worker.ts
@@ -2,11 +2,13 @@
  * Web Worker for loan simulation calculations.
  *
  * Moves expensive computations off the main thread to improve INP.
- * Handles four types of simulations:
+ * Handles six types of simulations:
  * - SALARY_SERIES: 126 simulations across salary range
  * - BALANCE_SERIES: 1 simulation for balance over time
  * - OVERPAY_ANALYSIS: 2 simulations for overpay comparison
  * - INSIGHT: 1 simulation for personalized insight text
+ * - DETAIL_SERIES: 1 simulation extracting all time-series for detail pages
+ * - EFFECTIVE_RATE_SALARY: 126 simulations computing effective rate by salary
  */
 
 import type {
@@ -16,6 +18,7 @@ import type {
 import type { Loan } from "@/lib/loans/types";
 import type { DataPoint, BalanceDataPoint } from "@/types/chart";
 import type { InsightCardsResult } from "@/types/insight-cards";
+import { MIN_SALARY, MAX_SALARY, SALARY_STEP } from "@/constants";
 import { simulate } from "@/lib/loans/engine";
 import { simulateOverpayScenarios } from "@/lib/loans/overpay-simulate";
 import { generateInsight, type Insight } from "@/utils/insights";
@@ -35,7 +38,9 @@ export type WorkerMessageType =
   | "SALARY_SERIES"
   | "BALANCE_SERIES"
   | "OVERPAY_ANALYSIS"
-  | "INSIGHT";
+  | "INSIGHT"
+  | "DETAIL_SERIES"
+  | "EFFECTIVE_RATE_SALARY";
 
 export interface SalarySeriesPayload {
   type: "SALARY_SERIES";
@@ -77,11 +82,33 @@ export interface InsightPayload {
   discountRate?: number;
 }
 
+export interface DetailSeriesPayload {
+  type: "DETAIL_SERIES";
+  loans: Loan[];
+  annualSalary: number;
+  salaryGrowthRate: number;
+  thresholdGrowthRate: number;
+  rpiRate: number;
+  boeBaseRate: number;
+  discountRate?: number;
+}
+
+export interface EffectiveRateSalaryPayload {
+  type: "EFFECTIVE_RATE_SALARY";
+  loans: Loan[];
+  salaryGrowthRate: number;
+  thresholdGrowthRate: number;
+  rpiRate: number;
+  boeBaseRate: number;
+}
+
 export type WorkerPayload =
   | SalarySeriesPayload
   | BalanceSeriesPayload
   | OverpayAnalysisPayload
-  | InsightPayload;
+  | InsightPayload
+  | DetailSeriesPayload
+  | EffectiveRateSalaryPayload;
 
 export type WorkerMessage =
   | { id: number; payload: WorkerPayload }
@@ -92,6 +119,37 @@ export interface InsightSummary {
   monthlyRepayment: number;
   monthsToPayoff: number;
   pvTotalPaid?: number;
+}
+
+export interface DetailSeriesResult {
+  type: "DETAIL_SERIES";
+  cumulativeRepaid: Array<{ month: number; cumulative: number }>;
+  balanceSeries: Array<{ month: number; balance: number }>;
+  interestBreakdown: Array<{
+    month: number;
+    cumulativeInterest: number;
+    cumulativePrincipal: number;
+  }>;
+  stats: {
+    totalPaid: number;
+    totalInterest: number;
+    initialBalance: number;
+    monthsToPayoff: number;
+    writtenOff: boolean;
+    writeOffMonth: number | null;
+    effectiveRate: number;
+    boeRate: number;
+    interestRatio: number;
+    monthlyRepayment: number;
+    peakBalance: number;
+    peakBalanceMonth: number;
+  };
+}
+
+export interface EffectiveRateSalaryResult {
+  type: "EFFECTIVE_RATE_SALARY";
+  data: Array<{ salary: number; effectiveRate: number }>;
+  boeRate: number;
 }
 
 export type WorkerResultType =
@@ -107,7 +165,9 @@ export type WorkerResultType =
       insight: Insight | null;
       summary: InsightSummary | null;
       cards: InsightCardsResult;
-    };
+    }
+  | DetailSeriesResult
+  | EffectiveRateSalaryResult;
 
 export interface WorkerResponse {
   id: number;
@@ -328,6 +388,167 @@ function formatCompactCurrency(value: number): string {
   return `£${String(Math.round(value))}`;
 }
 
+function handleDetailSeries(payload: DetailSeriesPayload): DetailSeriesResult {
+  const totalBalance = payload.loans.reduce((s, l) => s + l.balance, 0);
+
+  if (totalBalance <= 0) {
+    return {
+      type: "DETAIL_SERIES",
+      cumulativeRepaid: [],
+      balanceSeries: [],
+      interestBreakdown: [],
+      stats: {
+        totalPaid: 0,
+        totalInterest: 0,
+        initialBalance: 0,
+        monthsToPayoff: 0,
+        writtenOff: false,
+        writeOffMonth: null,
+        effectiveRate: 0,
+        boeRate: payload.boeBaseRate / 100,
+        interestRatio: 0,
+        monthlyRepayment: 0,
+        peakBalance: 0,
+        peakBalanceMonth: 0,
+      },
+    };
+  }
+
+  const result = simulate({
+    loans: payload.loans,
+    annualSalary: payload.annualSalary,
+    monthsElapsed: 0,
+    salaryGrowthRate: payload.salaryGrowthRate,
+    thresholdGrowthRate: payload.thresholdGrowthRate,
+    rpiRate: payload.rpiRate,
+    boeBaseRate: payload.boeBaseRate,
+  });
+
+  const { snapshots, summary } = result;
+  const hasPV = payload.discountRate !== undefined && payload.discountRate > 0;
+  const dr = payload.discountRate ?? 0;
+
+  const cumulativeRepaid: DetailSeriesResult["cumulativeRepaid"] = [];
+  const balanceSeries: DetailSeriesResult["balanceSeries"] = [];
+  const interestBreakdown: DetailSeriesResult["interestBreakdown"] = [];
+
+  let cumPaid = 0;
+  let pvCumPaid = 0;
+  let cumInterestPortion = 0;
+  let pvCumInterestPortion = 0;
+  let peakBalance = totalBalance;
+  let peakBalanceMonth = 0;
+
+  // Add initial point
+  const initBal = hasPV ? toPresent(totalBalance, dr, 0) : totalBalance;
+  balanceSeries.push({ month: 0, balance: initBal });
+  cumulativeRepaid.push({ month: 0, cumulative: 0 });
+  interestBreakdown.push({
+    month: 0,
+    cumulativeInterest: 0,
+    cumulativePrincipal: 0,
+  });
+
+  for (const snap of snapshots) {
+    const monthBalance = snap.loans.reduce((s, l) => s + l.closingBalance, 0);
+    const monthInterest = snap.loans.reduce((s, l) => s + l.interestApplied, 0);
+    const interestPortion = Math.min(snap.totalRepayment, monthInterest);
+
+    cumPaid += snap.totalRepayment;
+    cumInterestPortion += interestPortion;
+
+    if (hasPV) {
+      pvCumPaid += toPresent(snap.totalRepayment, dr, snap.month);
+      pvCumInterestPortion += toPresent(interestPortion, dr, snap.month);
+    }
+
+    if (monthBalance > peakBalance) {
+      peakBalance = monthBalance;
+      peakBalanceMonth = snap.month;
+    }
+
+    // Sample every 3 months + last snapshot
+    if (snap.month % 3 === 0 || snap.month === snapshots.length - 1) {
+      const bal = hasPV
+        ? toPresent(monthBalance, dr, snap.month)
+        : monthBalance;
+      const paid = hasPV ? pvCumPaid : cumPaid;
+      const interest = hasPV ? pvCumInterestPortion : cumInterestPortion;
+
+      balanceSeries.push({ month: snap.month, balance: bal });
+      cumulativeRepaid.push({ month: snap.month, cumulative: paid });
+      interestBreakdown.push({
+        month: snap.month,
+        cumulativeInterest: interest,
+        cumulativePrincipal: paid - interest,
+      });
+    }
+  }
+
+  const writtenOff = summary.perLoan.some((l) => l.writtenOff);
+  const totalPaid = hasPV
+    ? pvTotal(
+        snapshots.map((s) => ({ month: s.month, amount: s.totalRepayment })),
+        dr,
+      )
+    : summary.totalPaid;
+  const costOfBorrowing = Math.max(0, totalPaid - totalBalance);
+  const interestRatio = totalPaid > 0 ? costOfBorrowing / totalPaid : 0;
+  const effectiveRate = computeEffectiveAnnualRate(totalBalance, snapshots);
+  const peakBal = hasPV
+    ? toPresent(peakBalance, dr, peakBalanceMonth)
+    : peakBalance;
+
+  return {
+    type: "DETAIL_SERIES",
+    cumulativeRepaid,
+    balanceSeries,
+    interestBreakdown,
+    stats: {
+      totalPaid,
+      totalInterest: costOfBorrowing,
+      initialBalance: totalBalance,
+      monthsToPayoff: summary.monthsToPayoff,
+      writtenOff,
+      writeOffMonth: writtenOff ? summary.monthsToPayoff : null,
+      effectiveRate,
+      boeRate: payload.boeBaseRate / 100,
+      interestRatio,
+      monthlyRepayment: snapshots.length > 0 ? snapshots[0].totalRepayment : 0,
+      peakBalance: peakBal,
+      peakBalanceMonth,
+    },
+  };
+}
+
+function handleEffectiveRateSalary(
+  payload: EffectiveRateSalaryPayload,
+): EffectiveRateSalaryResult {
+  const data: EffectiveRateSalaryResult["data"] = [];
+  const totalBalance = payload.loans.reduce((s, l) => s + l.balance, 0);
+
+  for (let salary = MIN_SALARY; salary <= MAX_SALARY; salary += SALARY_STEP) {
+    const timeSeries = simulate({
+      loans: payload.loans,
+      annualSalary: salary,
+      monthsElapsed: 0,
+      rpiRate: payload.rpiRate,
+      salaryGrowthRate: payload.salaryGrowthRate,
+      thresholdGrowthRate: payload.thresholdGrowthRate,
+      boeBaseRate: payload.boeBaseRate,
+    });
+
+    const rate = computeEffectiveAnnualRate(totalBalance, timeSeries.snapshots);
+    data.push({ salary, effectiveRate: rate });
+  }
+
+  return {
+    type: "EFFECTIVE_RATE_SALARY",
+    data,
+    boeRate: payload.boeBaseRate / 100,
+  };
+}
+
 /**
  * Compute the effective annual interest rate (IRR) of the loan.
  * Finds the rate r where PV(all payments, r) = original balance.
@@ -412,6 +633,14 @@ self.onmessage = (event: MessageEvent<WorkerMessage>) => {
     case "INSIGHT": {
       const { insight, summary, cards } = handleInsight(payload);
       result = { type: "INSIGHT", insight, summary, cards };
+      break;
+    }
+    case "DETAIL_SERIES": {
+      result = handleDetailSeries(payload);
+      break;
+    }
+    case "EFFECTIVE_RATE_SALARY": {
+      result = handleEffectiveRateSalary(payload);
       break;
     }
   }


### PR DESCRIPTION
## Summary

Adds four new dedicated detail pages (`/balance`, `/repaid`, `/interest`, `/effective-rate`) that expand on the insight cards shown on the home page. Each page features a full-size chart, summary stat cards, navigation between detail pages, and contextual related content. The insight cards on the home page now link through to these pages.

## Context

The home page insight cards give a quick snapshot but lack the space for deeper exploration. These detail pages let users drill into each metric with larger interactive charts and additional context. Key architectural decisions:

- **Web Worker computation**: Two new worker message types (`DETAIL_SERIES`, `EFFECTIVE_RATE_SALARY`) keep heavy simulation off the main thread.
- **Extracted `useInputPanelMode` hook**: The input panel mode logic was duplicated between HeroSection and the new detail shell, so it's now a shared hook.
- **`LazyChartBase` wrapper**: Chart components across guides and detail pages now lazy-load via `next/dynamic` to reduce initial bundle size.
- **`ChartBase` compact mode**: A new `compact` prop supports both the home page's dense layout and the detail pages' full-size charts.
- SEO: sitemap, `llms.txt`, breadcrumb schemas, and page metadata all updated for the new routes.