### PR TITLE
fix: improve overpay CTA copy and add CTA for low-earner insight

### DIFF
--- a/src/utils/insights.ts
+++ b/src/utils/insights.ts
@@ -126,7 +126,7 @@ export function generateInsight(
       title: "You're in the peak repayment zone",
       description: `You'll repay ${formattedTotalPaid} in total on a ${formattedPrincipal} loan. At this salary, interest builds faster than your repayments reduce the balance.`,
       cta: {
-        text: "See if overpaying could help",
+        text: "Calculate your overpayment savings",
         href: "/overpay",
       },
     };
@@ -151,6 +151,10 @@ export function generateInsight(
         type: "low-earner",
         title: "Your loan will be written off",
         description,
+        cta: {
+          text: "See why overpaying could leave you worse off",
+          href: "/overpay",
+        },
       };
     }
   }
@@ -170,7 +174,7 @@ export function generateInsight(
     title: "You'll pay off quickly",
     description: `You'll clear your loan in about ${yearsToPayoff} years, ${interestDescription}.`,
     cta: {
-      text: "See if overpaying saves you money",
+      text: "See how overpaying saves you time",
       href: "/overpay",
     },
   };


### PR DESCRIPTION
## Summary

The overpay CTAs on insight cards were either missing or used vague, one-size-fits-all copy. This updates them to be scenario-specific: "Calculate your overpayment savings" for peak repayers, "See how overpaying saves you time" for quick payers, and adds a new cautionary CTA for the low-earner write-off scenario linking to the overpay page.

## Context

Previously, the "low earner" insight (loan will be written off) had no CTA at all, missing an opportunity to guide users to the overpay page where they can see why overpaying would leave them worse off. The other two CTAs used generic phrasing that didn't match the insight's message -- e.g. "saves you money" for someone who already pays off quickly (where time savings is the real benefit).