### PR TITLE
ci: add worktree guard hook to enforce worktree isolation

### DIFF
--- a/.claude/hooks/worktree-guard.sh
+++ b/.claude/hooks/worktree-guard.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Pre-tool-use hook: blocks tool calls that reach outside the current worktree
+# into the main repository. Only activates when running inside a worktree
+# created under .claude/worktrees/.
+#
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Determine current git root (worktree root when inside a worktree)
+WORKTREE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Only activate when inside a .claude/worktrees/ directory
+case "$WORKTREE_ROOT" in
+  */.claude/worktrees/*) ;;
+  *) exit 0 ;;
+esac
+
+# Derive the main repository root by stripping /.claude/worktrees/<name>
+MAIN_REPO="${WORKTREE_ROOT%%/.claude/worktrees/*}"
+
+TOOL=$(echo "$INPUT" | jq -r '.tool_name')
+
+# Check whether a path escapes the worktree into the main repo
+check_path() {
+  local p="$1"
+  [ -z "$p" ] && return 0
+
+  # Make absolute
+  [[ "$p" != /* ]] && p="$WORKTREE_ROOT/$p"
+
+  # Normalize (resolve . and ..)
+  p=$(python3 -c "import os.path, sys; print(os.path.normpath(sys.argv[1]))" "$p")
+
+  # Block if path is under the main repo but NOT under the worktree
+  if [[ "$p" == "$MAIN_REPO"* && "$p" != "$WORKTREE_ROOT"* ]]; then
+    echo "Blocked: path '$p' is outside worktree '$WORKTREE_ROOT'" >&2
+    exit 2
+  fi
+}
+
+case "$TOOL" in
+  Read|Write|Edit|MultiEdit|NotebookEdit)
+    check_path "$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty')"
+    ;;
+  Glob|Grep)
+    check_path "$(echo "$INPUT" | jq -r '.tool_input.path // empty')"
+    ;;
+  Bash)
+    CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+    # Remove worktree path references, then check if the main repo path remains
+    CLEANED=$(python3 -c "import sys; print(sys.argv[1].replace(sys.argv[2], ''))" "$CMD" "$WORKTREE_ROOT")
+    if echo "$CLEANED" | grep -qF "$MAIN_REPO"; then
+      echo "Blocked: command references main repo '$MAIN_REPO' from within worktree" >&2
+      exit 2
+    fi
+    ;;
+esac

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,15 @@
             "command": "bash -c 'CMD=$(jq -r .tool_input.command) && if echo \"$CMD\" | grep -qE \"\\bnpm\\b|\\bnpx\\b\"; then echo \"Use pnpm/pnpx instead of npm/npx. This project uses pnpm.\" >&2; exit 2; fi'"
           }
         ]
+      },
+      {
+        "matcher": "Bash|Read|Write|Edit|MultiEdit|Glob|Grep|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.claude/hooks/worktree-guard.sh\""
+          }
+        ]
       }
     ],
     "WorktreeCreate": [


### PR DESCRIPTION
## Summary

Adds a pre-tool-use hook that prevents Claude Code from accidentally reading or modifying files in the main repository when operating inside a `.claude/worktrees/` worktree. This enforces the existing CLAUDE.md rule that all operations inside a worktree must stay within the worktree.

## Context

When multiple agents run in parallel using worktrees, there is a risk that a tool call references the main repo path instead of the worktree path. The guard script intercepts file-based tools (Read, Write, Edit, Glob, Grep) by checking resolved paths, and intercepts Bash commands by scanning for main repo path references. It only activates when the working directory is under `.claude/worktrees/`, so normal (non-worktree) sessions are unaffected.