### PR TITLE
chore: exclude .claude/worktrees from eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -81,6 +81,7 @@ export default tseslint.config(
     ignores: [
       "node_modules",
       ".next",
+      ".claude/worktrees",
       "out",
       "coverage",
       "dist",


### PR DESCRIPTION
## Summary

Adds `.claude/worktrees` to the ESLint ignore list so that duplicated source files inside worktree directories are not linted. This prevents false positives and keeps lint runs fast when Claude Code worktrees are active.