### PR TITLE
refactor: replace insight icon with salary annotation on calculator card

### DIFF
--- a/src/components/charts/Sparkline.tsx
+++ b/src/components/charts/Sparkline.tsx
@@ -7,12 +7,19 @@ interface SparklineProps {
   data: SparklinePoint[];
   color: string;
   ariaLabel: string;
+  /** Raw data x-value (e.g. salary) to draw a dashed vertical annotation line */
+  annotationX?: number;
 }
 
 const W = 100;
 const H = 48;
 
-export function Sparkline({ data, color, ariaLabel }: SparklineProps) {
+export function Sparkline({
+  data,
+  color,
+  ariaLabel,
+  annotationX,
+}: SparklineProps) {
   const gradientId = useId();
 
   if (data.length < 2) {
@@ -64,6 +71,18 @@ export function Sparkline({ data, color, ariaLabel }: SparklineProps) {
           strokeWidth={1.5}
           vectorEffect="non-scaling-stroke"
         />
+        {annotationX != null && annotationX >= xMin && annotationX <= xMax && (
+          <line
+            x1={((annotationX - xMin) / xRange) * W}
+            y1={0}
+            x2={((annotationX - xMin) / xRange) * W}
+            y2={H}
+            stroke={color}
+            strokeWidth={1.5}
+            strokeDasharray="6 4"
+            vectorEffect="non-scaling-stroke"
+          />
+        )}
       </svg>
     </div>
   );

--- a/src/components/shared/InsightCard.tsx
+++ b/src/components/shared/InsightCard.tsx
@@ -1,9 +1,4 @@
-import {
-  ArrowRight01Icon,
-  InformationCircleIcon,
-  Alert02Icon,
-  Tick02Icon,
-} from "@hugeicons/core-free-icons";
+import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import type {
@@ -11,7 +6,6 @@ import type {
   InsightCardData,
   InterestCardData,
 } from "@/types/insightCards";
-import type { InsightType } from "@/utils/insights";
 import { Sparkline } from "@/components/charts/Sparkline";
 
 // ---------------------------------------------------------------------------
@@ -252,62 +246,28 @@ export function RateComparisonCard({
 // Calculator card (insight text + sparkline)
 // ---------------------------------------------------------------------------
 
-const INSIGHT_ICON_CONFIG: Record<
-  InsightType,
-  { icon: typeof InformationCircleIcon; className: string }
-> = {
-  "low-earner": {
-    icon: InformationCircleIcon,
-    className: "text-status-info-foreground",
-  },
-  "middle-earner": {
-    icon: Alert02Icon,
-    className: "text-status-danger-foreground",
-  },
-  "high-earner": {
-    icon: Tick02Icon,
-    className: "text-status-success-foreground",
-  },
-};
-
 interface CalculatorCardProps {
   cardData: InsightCardData | null;
-  insightTitle: string | null;
-  insightType: InsightType | null;
+  currentSalary: number | undefined;
 }
 
 export function CalculatorCard({
   cardData,
-  insightTitle,
-  insightType,
+  currentSalary,
 }: CalculatorCardProps) {
-  const iconConfig = insightType ? INSIGHT_ICON_CONFIG[insightType] : null;
-
   return (
     <CardShell title="Repayment Calculator" href="/">
       {cardData ? (
         <div className="flex flex-1 flex-col">
-          <div className="px-5 pt-2">
-            {insightTitle && iconConfig ? (
-              <span className="flex items-center gap-1.5 text-sm font-medium">
-                <HugeiconsIcon
-                  icon={iconConfig.icon}
-                  className={`size-4 shrink-0 ${iconConfig.className}`}
-                  strokeWidth={2}
-                />
-                {insightTitle}
-              </span>
-            ) : (
-              <span className="font-mono text-xl font-semibold tabular-nums">
-                {cardData.stat}
-              </span>
-            )}
-          </div>
+          <span className="px-5 pt-2 font-mono text-xl font-semibold tabular-nums">
+            {cardData.stat}
+          </span>
           <div className="mt-auto">
             <Sparkline
               data={cardData.data}
               color="var(--primary)"
               ariaLabel={cardData.label}
+              annotationX={currentSalary}
             />
           </div>
         </div>

--- a/src/components/shared/InsightCards.tsx
+++ b/src/components/shared/InsightCards.tsx
@@ -7,6 +7,7 @@ import {
   SparklineCard,
 } from "./InsightCard";
 import { usePersonalizedResults } from "@/context/PersonalizedResultsContext";
+import { useCurrentSalary } from "@/hooks/useStoreSelectors";
 import { DETAIL_PAGES } from "@/lib/detailPages";
 import { cn } from "@/lib/utils";
 
@@ -15,7 +16,8 @@ interface InsightCardsProps {
 }
 
 export function InsightCards({ excludeHref }: InsightCardsProps) {
-  const { cards: data, insight } = usePersonalizedResults();
+  const { cards: data } = usePersonalizedResults();
+  const salary = useCurrentSalary();
 
   // Fixed 4-card positions: [Repaid, Balance, Interest, Eff. Rate]
   const detailCards = [
@@ -73,8 +75,7 @@ export function InsightCards({ excludeHref }: InsightCardsProps) {
     <CalculatorCard
       key="/"
       cardData={data?.totalRepayment ?? null}
-      insightTitle={insight?.title ?? null}
-      insightType={insight?.type ?? null}
+      currentSalary={salary}
     />
   );
 

--- a/src/workers/simulation.worker.ts
+++ b/src/workers/simulation.worker.ts
@@ -396,7 +396,7 @@ function handleInsight(payload: InsightPayload): {
     },
     totalRepayment: {
       data: salarySeriesData,
-      stat: formatCompactCurrency(totalPaid),
+      stat: `${formatCompactCurrency(totalPaid)} total`,
       label: "Total Repayment by Salary",
     },
   };


### PR DESCRIPTION
## Summary

The calculator insight card on detail pages previously showed an earner-type icon (info/warning/success) based on the user's salary bracket. This replaces that with a more useful visual cue: a dashed vertical annotation line on the sparkline that marks the user's current salary within the salary-vs-repayment curve. The stat display is also simplified to always show the total repayment figure with a "total" suffix.

## Context

The earner-type icon duplicated the insight already shown on the home page and didn't add much value in the detail-page card context. The salary annotation line gives immediate visual feedback about where the user sits on the repayment curve, which is more informative at a glance.