### PR TITLE
refactor: rename repaid page to payoff timeline for better SEO

### DIFF
--- a/e2e/preset-results.spec.ts
+++ b/e2e/preset-results.spec.ts
@@ -16,7 +16,7 @@ test.describe("Home page preset selection", () => {
     const section = page
       .locator("section")
       .filter({ hasText: "Your Loan Breakdown" });
-    await expect(section.getByText("Repaid Over Time")).toBeVisible();
+    await expect(section.getByText("Payoff Timeline")).toBeVisible();
     await expect(section.getByText("Balance Over Time")).toBeVisible();
     await expect(section.getByText("Interest Paid")).toBeVisible();
     await expect(section.getByText(/£[\d,]+/).first()).toBeVisible();

--- a/e2e/share-url.spec.ts
+++ b/e2e/share-url.spec.ts
@@ -10,7 +10,7 @@ test.describe("Share URL round-trip", () => {
       .locator("section")
       .filter({ hasText: "Your Loan Breakdown" });
     await expect(section.getByText(/£[\d,]+/).first()).toBeVisible();
-    await expect(section.getByText("Repaid Over Time")).toBeVisible();
+    await expect(section.getByText("Payoff Timeline")).toBeVisible();
     await expect(section.getByText("Balance Over Time")).toBeVisible();
     await expect(section.getByText("Interest Paid")).toBeVisible();
   });

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -11,7 +11,7 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - [Repayment Calculator](https://studentloanstudy.uk): See total repayments across all UK student loan plan types (Plan 1, 2, 4, 5, Postgraduate)
 - [Which Plan Quiz](https://studentloanstudy.uk/which-plan): Find your loan plan in 3 questions
 - [Overpay Calculator](https://studentloanstudy.uk/overpay): Should you overpay or invest?
-- [Repaid Over Time](https://studentloanstudy.uk/repaid): Track cumulative student loan repayments over time
+- [Payoff Timeline](https://studentloanstudy.uk/repaid): See how long to pay off your student loan and track total repayments over time
 - [Balance Over Time](https://studentloanstudy.uk/balance): See how your loan balance changes as interest accrues and repayments are made
 - [Interest Breakdown](https://studentloanstudy.uk/interest): Understand how much of your repayments go to interest vs principal
 - [Effective Rate](https://studentloanstudy.uk/effective-rate): Compare your loan's true effective annual rate to the Bank of England base rate

--- a/scripts/check-govuk-figures/templates.ts
+++ b/scripts/check-govuk-figures/templates.ts
@@ -222,7 +222,7 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - [Repayment Calculator](https://studentloanstudy.uk): See total repayments across all UK student loan plan types (Plan 1, 2, 4, 5, Postgraduate)
 - [Which Plan Quiz](https://studentloanstudy.uk/which-plan): Find your loan plan in 3 questions
 - [Overpay Calculator](https://studentloanstudy.uk/overpay): Should you overpay or invest?
-- [Repaid Over Time](https://studentloanstudy.uk/repaid): Track cumulative student loan repayments over time
+- [Payoff Timeline](https://studentloanstudy.uk/repaid): See how long to pay off your student loan and track total repayments over time
 - [Balance Over Time](https://studentloanstudy.uk/balance): See how your loan balance changes as interest accrues and repayments are made
 - [Interest Breakdown](https://studentloanstudy.uk/interest): Understand how much of your repayments go to interest vs principal
 - [Effective Rate](https://studentloanstudy.uk/effective-rate): Compare your loan's true effective annual rate to the Bank of England base rate

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -25,7 +25,7 @@ const faqSchema = {
       name: "How long does it take to pay off a UK student loan?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "It depends on your salary and plan type. High earners on Plan 2 might pay off in 10-15 years, while most graduates repay for the full 25-40 year term before write-off. Use our repayment calculator to see exactly how long your loan will take to pay off based on your salary and balance.",
+        text: "It depends on your salary and plan type. High earners on Plan 2 might pay off in 10-15 years, while most graduates repay for the full 25-40 year term before write-off. Use our payoff timeline calculator to see exactly how many years your loan will take to pay off based on your salary, balance, and plan type.",
       },
     },
     {

--- a/src/app/repaid/layout.tsx
+++ b/src/app/repaid/layout.tsx
@@ -1,14 +1,16 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Repaid Over Time — Cumulative Student Loan Repayments",
+  title: "How Long to Pay Off Your Student Loan — Payoff Timeline Calculator",
   description:
-    "Track how your total UK student loan repayments grow over time. See cumulative payments, monthly repayment amounts, and whether your loan will be paid off or written off.",
+    "Find out how long it takes to pay off your UK student loan. See your payoff timeline, total repayments over time, monthly costs, and whether your loan will be paid off or written off — based on your salary and plan type.",
   keywords: [
+    "how long to pay off student loan",
+    "student loan payoff calculator",
+    "student loan payoff timeline",
+    "how long to repay student loan UK",
     "student loan repayments over time",
-    "cumulative student loan payments",
-    "UK student loan repayment tracker",
-    "student loan total cost",
+    "UK student loan repayment calculator",
   ],
 };
 
@@ -25,8 +27,31 @@ const breadcrumbSchema = {
     {
       "@type": "ListItem",
       position: 2,
-      name: "Repaid Over Time",
+      name: "Payoff Timeline",
       item: "https://studentloanstudy.uk/repaid",
+    },
+  ],
+};
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "How long does it take to pay off a UK student loan?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "It depends on your salary, loan balance, and plan type. High earners on Plan 2 might pay off in 10-15 years, while most graduates repay for the full 25-40 year term before the loan is written off. Plan 1 loans write off after 25 years, Plan 2 after 30 years, Plan 4 after 30 years, Plan 5 after 40 years, and Postgraduate loans after 30 years.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Will my student loan be paid off or written off?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Most graduates will have their loan written off before paying it in full. Only high earners typically repay in full. Whether your loan is paid off or written off depends on your salary trajectory, starting balance, and plan type.",
+      },
     },
   ],
 };
@@ -41,6 +66,10 @@ export default function RepaidLayout({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
       />
       {children}
     </>

--- a/src/components/detail/RepaidDetailPage.tsx
+++ b/src/components/detail/RepaidDetailPage.tsx
@@ -17,8 +17,8 @@ export function RepaidDetailPage() {
 
   return (
     <DetailPageShell
-      heading="Cumulative Repayments"
-      description="Track how your total repayments grow over the life of your loan."
+      heading="Payoff Timeline"
+      description="See how long to pay off your student loan and track total repayments over time."
     >
       {result ? (
         <>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -55,7 +55,7 @@ export function Footer() {
               </li>
               <li>
                 <Link href="/repaid" className={NAV_LINK_CLASS}>
-                  Repaid Over Time
+                  Payoff Timeline
                 </Link>
               </li>
             </ul>

--- a/src/lib/detailPages.ts
+++ b/src/lib/detailPages.ts
@@ -8,8 +8,8 @@ export interface DetailPageConfig {
 export const DETAIL_PAGES: DetailPageConfig[] = [
   {
     href: "/repaid",
-    label: "Repaid Over Time",
-    shortLabel: "Repaid",
+    label: "Payoff Timeline",
+    shortLabel: "Payoff",
     color: "var(--chart-1)",
   },
   {


### PR DESCRIPTION
## Summary

Renames the /repaid page from "Repaid Over Time" to "Payoff Timeline" across all user-facing surfaces — navigation, headings, footer, SEO metadata, structured data, LLM descriptions, and e2e tests. The new framing targets the search intent "how long to pay off student loan" rather than the technical concept of cumulative repayments, which should improve organic discoverability.

## Context

The previous naming ("Repaid Over Time", "Cumulative Repayments") described what the chart shows, but not what users actually search for. "Payoff Timeline" better answers the user question and aligns with high-intent keywords like "how long to pay off student loan" and "student loan payoff calculator". A FAQPage JSON-LD schema was also added to the /repaid layout to target featured snippets for these queries.