### PR TITLE
feat: expand FAQ structured data across page layouts

### DIFF
--- a/src/app/balance/layout.tsx
+++ b/src/app/balance/layout.tsx
@@ -31,6 +31,29 @@ const breadcrumbSchema = {
   ],
 };
 
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "Why is my student loan balance going up?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Your balance grows when interest added each month exceeds your repayments. This is common in the early years when your salary is lower and repayments are small. For Plan 2 borrowers, interest can be as high as RPI + 3%, meaning the balance may rise for several years before repayments start to outpace interest.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How do I track my student loan balance over time?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Use our balance trajectory calculator to see a year-by-year projection of your loan balance. Enter your salary, balance, and plan type to visualise when your balance peaks, when repayments overtake interest, and whether your loan will be paid off or written off.",
+      },
+    },
+  ],
+};
+
 export default function BalanceLayout({
   children,
 }: {
@@ -41,6 +64,10 @@ export default function BalanceLayout({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
       />
       {children}
     </>

--- a/src/app/guides/moving-abroad/layout.tsx
+++ b/src/app/guides/moving-abroad/layout.tsx
@@ -67,6 +67,22 @@ const faqSchema = {
         text: "SLC sets country-specific repayment thresholds based on the cost of living in your country of residence. You still repay 9% of income above the threshold (6% for Postgraduate loans), but the threshold itself varies by country rather than using the standard UK figure.",
       },
     },
+    {
+      "@type": "Question",
+      name: "What happens to my student loan if I emigrate from the UK?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Your loan remains active regardless of where you live. When you emigrate, you must contact the Student Loans Company within three months, complete an overseas income assessment, and switch to country-specific repayment thresholds. The write-off date stays the same — emigrating does not reset or extend it.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Can I avoid paying my student loan by moving abroad?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "No. The Student Loans Company actively tracks overseas borrowers and has legal powers to pursue repayment internationally. If you do not respond to income assessments, SLC will impose fixed repayment amounts that are often much higher than income-based repayments. They may also refer your account to debt collection agencies or take court action.",
+      },
+    },
   ],
 };
 

--- a/src/app/guides/student-loan-vs-mortgage/layout.tsx
+++ b/src/app/guides/student-loan-vs-mortgage/layout.tsx
@@ -78,6 +78,22 @@ const faqSchema = {
         text: "No, UK student loans do not appear on your credit report and have no direct impact on your credit score. The Student Loans Company does not report to credit reference agencies.",
       },
     },
+    {
+      "@type": "Question",
+      name: "Can I get a mortgage with a student loan in the UK?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes, having a student loan does not prevent you from getting a mortgage. Lenders do not treat it as conventional debt. However, your monthly student loan repayment reduces the income figure lenders use for affordability checks, which may lower the maximum amount you can borrow.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Do mortgage lenders take student loans into account?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes, but not as a debt. Mortgage lenders deduct your monthly student loan repayment from your gross income before applying their affordability multiplier. This means the higher your salary (and therefore your repayment), the bigger the reduction in borrowing power — even though the loan itself doesn't appear on your credit file.",
+      },
+    },
   ],
 };
 

--- a/src/app/interest/layout.tsx
+++ b/src/app/interest/layout.tsx
@@ -51,6 +51,14 @@ const faqSchema = {
         text: "Student loan interest accrues from the day your loan is paid out, including while you study. For Plan 2 borrowers, interest can be RPI + up to 3%, meaning your balance can grow faster than your repayments reduce it — especially in the early years when your salary is lower.",
       },
     },
+    {
+      "@type": "Question",
+      name: "How much interest am I paying on my student loan?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "The amount of interest you pay depends on your plan type, loan balance, and how long you hold the loan. Use our interest breakdown calculator to see a year-by-year split of how much of each repayment goes towards interest versus reducing your balance.",
+      },
+    },
   ],
 };
 

--- a/src/app/overpay/layout.tsx
+++ b/src/app/overpay/layout.tsx
@@ -55,6 +55,14 @@ const faqSchema = {
         text: "If your loan will be written off before full repayment, investing is typically better since you're effectively getting free money. If you'll repay in full, compare your loan's interest rate to expected investment returns. Our calculator helps you compare both strategies.",
       },
     },
+    {
+      "@type": "Question",
+      name: "How do I make an early repayment on my student loan?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "You can make voluntary overpayments at any time by logging into your Student Loans Company account and paying by debit card or bank transfer. There is no penalty for early repayment. Before overpaying, check whether your loan will be written off — if it will, overpaying means you pay more than you need to.",
+      },
+    },
   ],
 };
 

--- a/src/app/repaid/layout.tsx
+++ b/src/app/repaid/layout.tsx
@@ -39,10 +39,10 @@ const faqSchema = {
   mainEntity: [
     {
       "@type": "Question",
-      name: "How long does it take to pay off a UK student loan?",
+      name: "When will I finish paying off my student loan?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "It depends on your salary, loan balance, and plan type. High earners on Plan 2 might pay off in 10-15 years, while most graduates repay for the full 25-40 year term before the loan is written off. Plan 1 loans write off after 25 years, Plan 2 after 30 years, Plan 4 after 30 years, Plan 5 after 40 years, and Postgraduate loans after 30 years.",
+        text: "It depends on your salary, loan balance, and plan type. High earners on Plan 2 might pay off in 10–15 years, while most graduates repay for the full term before the loan is written off — 25 years for Plan 1, 30 years for Plans 2 and 4, 40 years for Plan 5, and 30 years for Postgraduate loans. Use our payoff timeline calculator to see a year-by-year projection for your situation.",
       },
     },
     {
@@ -51,6 +51,14 @@ const faqSchema = {
       acceptedAnswer: {
         "@type": "Answer",
         text: "Most graduates will have their loan written off before paying it in full. Only high earners typically repay in full. Whether your loan is paid off or written off depends on your salary trajectory, starting balance, and plan type.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How is the student loan payoff date calculated?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "The calculator projects your loan balance forward month by month, applying your plan's interest rate and deducting 9% of income above the repayment threshold (6% for Postgraduate loans). It factors in salary growth and compares total repayments against the write-off date to show whether you'll repay in full or have the remaining balance cancelled.",
       },
     },
   ],


### PR DESCRIPTION
## Summary

Adds 9 new FAQ entries and refines 1 existing answer across six page layouts to improve search visibility. The balance page gains its first FAQPage schema, while the overpay, interest, repaid, moving-abroad, and mortgage guide pages each get additional questions targeting high-volume search queries.

## Context

Several calculator and guide pages had minimal or no FAQ structured data. Expanding the FAQ schemas increases the chance of Google surfacing rich results for common questions like "Why is my student loan balance going up?", "Can I get a mortgage with a student loan?", and "What happens to my student loan if I move abroad?". The existing repaid FAQ answer was also tightened to reference the payoff timeline calculator.