### PR TITLE
test: fix flaky wizard e2e assertion with auto-retrying helper

### DIFF
--- a/e2e/config-wizard.spec.ts
+++ b/e2e/config-wizard.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from "@playwright/test";
-import { waitForResults, getResultValues } from "./helpers";
+import {
+  waitForResults,
+  getResultValues,
+  waitForResultChange,
+} from "./helpers";
 
 test.describe("Config wizard dialog", () => {
   test.beforeEach(async ({ page }) => {
@@ -53,10 +57,8 @@ test.describe("Config wizard dialog", () => {
     // Dialog should close
     await expect(dialog).toBeHidden();
 
-    // Results should change
-    await waitForResults(page);
-    const after = await getResultValues(page);
-    expect(after.totalText).not.toBe(before.totalText);
+    // Wait for results to actually change (auto-retries until value differs)
+    await waitForResultChange(page, before.totalText);
   });
 
   test("clicking Close closes dialog without changing results", async ({


### PR DESCRIPTION
## Summary

Replace a one-shot `not.toBe` assertion in the config wizard e2e test with `waitForResultChange`, which uses Playwright's auto-retrying `expect` to poll until the result value actually differs from the pre-wizard snapshot. This eliminates a race condition where the assertion could fire before the loan recalculation completed.

## Context

The existing pattern (`waitForResults` + `getResultValues` + manual comparison) only waited for *any* currency value to appear, not for the value to *change*. Under load or slow recalculations, the old value could still be visible when the assertion ran, causing intermittent failures. The `waitForResultChange` helper was already available in `e2e/helpers.ts` but not used here.