### PR TITLE
refactor: extract findClosestBySalary utility from duplicated reduce logic

### DIFF
--- a/src/components/detail/EffectiveRateBySalaryChart.tsx
+++ b/src/components/detail/EffectiveRateBySalaryChart.tsx
@@ -11,6 +11,7 @@ import {
   MIN_SALARY,
   MAX_SALARY,
 } from "@/constants";
+import { findClosestBySalary } from "@/lib/utils";
 
 const chartConfig = {
   effectiveRate: {
@@ -44,12 +45,7 @@ export function EffectiveRateBySalaryChart({
 
   const closestPoint =
     deferredSalary !== undefined
-      ? data.reduce((closest, point) =>
-          Math.abs(point.salary - deferredSalary) <
-          Math.abs(closest.salary - deferredSalary)
-            ? point
-            : closest,
-        )
+      ? findClosestBySalary(data, deferredSalary)
       : undefined;
 
   const annotations =

--- a/src/components/detail/EffectiveRateDetailPage.tsx
+++ b/src/components/detail/EffectiveRateDetailPage.tsx
@@ -8,6 +8,7 @@ import { MIN_SALARY, MAX_SALARY, percentageFormatter } from "@/constants";
 import { useEffectiveRateBySalaryData } from "@/hooks/useDetailData";
 import { useCurrentSalary } from "@/hooks/useStoreSelectors";
 import { DETAIL_PAGE_COLOR } from "@/lib/detailPages";
+import { findClosestBySalary } from "@/lib/utils";
 
 const ACCENT = DETAIL_PAGE_COLOR["/effective-rate"];
 
@@ -18,11 +19,9 @@ export function EffectiveRateDetailPage() {
   const boeRate = salaryResult?.boeRate ?? 0;
 
   const closestPoint =
-    salaryResult?.data.reduce((closest, point) =>
-      Math.abs(point.salary - salary) < Math.abs(closest.salary - salary)
-        ? point
-        : closest,
-    ) ?? null;
+    salaryResult && salaryResult.data.length > 0
+      ? findClosestBySalary(salaryResult.data, salary)
+      : null;
 
   const effectiveRate = closestPoint?.effectiveRate ?? 0;
   const diff = effectiveRate - boeRate;

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -14,6 +14,7 @@ import type {
   BalanceSeriesPayload,
 } from "@/workers/simulation.worker";
 import { MIN_SALARY, MAX_SALARY } from "@/constants";
+import { findClosestBySalary } from "@/lib/utils";
 
 interface AnnotationData {
   annotationSalary: number | undefined;
@@ -33,13 +34,7 @@ function useAnnotationData(
     salary >= MIN_SALARY &&
     salary <= MAX_SALARY - maxSalaryOffset
   ) {
-    // Find the data point closest to the annotation salary
-    const closestPoint = data.reduce((closest, point) => {
-      if (Math.abs(point.salary - salary) < Math.abs(closest.salary - salary)) {
-        return point;
-      }
-      return closest;
-    }, data[0]);
+    const closestPoint = findClosestBySalary(data, salary);
 
     return {
       annotationSalary: salary,

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { findClosestBySalary } from "./utils";
+
+describe("findClosestBySalary", () => {
+  const data = [
+    { salary: 20_000, value: 100 },
+    { salary: 30_000, value: 200 },
+    { salary: 40_000, value: 300 },
+    { salary: 50_000, value: 400 },
+  ];
+
+  it("returns exact match when target equals a data point", () => {
+    expect(findClosestBySalary(data, 30_000)).toBe(data[1]);
+  });
+
+  it("returns closest point when target is between data points", () => {
+    expect(findClosestBySalary(data, 31_000)).toBe(data[1]);
+    expect(findClosestBySalary(data, 39_000)).toBe(data[2]);
+  });
+
+  it("returns first point when target is below all data points", () => {
+    expect(findClosestBySalary(data, 10_000)).toBe(data[0]);
+  });
+
+  it("returns last point when target is above all data points", () => {
+    expect(findClosestBySalary(data, 100_000)).toBe(data[3]);
+  });
+
+  it("returns the earlier point when target is equidistant", () => {
+    // At exactly 25_000, both 20k and 30k are 5k away — reduce keeps the earlier one
+    expect(findClosestBySalary(data, 25_000)).toBe(data[0]);
+  });
+
+  it("works with a single-element array", () => {
+    const single = [{ salary: 42_000, rate: 5.5 }];
+    expect(findClosestBySalary(single, 99_000)).toBe(single[0]);
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,18 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Find the item in an array whose `salary` is closest to the target value.
+ */
+export function findClosestBySalary<T extends { salary: number }>(
+  data: T[],
+  targetSalary: number,
+): T {
+  return data.reduce((closest, point) =>
+    Math.abs(point.salary - targetSalary) <
+    Math.abs(closest.salary - targetSalary)
+      ? point
+      : closest,
+  );
+}


### PR DESCRIPTION
## Summary

The same `Array.reduce` pattern for finding the data point with the closest salary appeared in three separate files. This extracts it into a single generic `findClosestBySalary` helper in `src/lib/utils.ts`, replacing all inline copies and adding unit tests.

## Context

The duplicated logic lived in `EffectiveRateBySalaryChart`, `EffectiveRateDetailPage`, and `useChartData`. Centralising it reduces the surface area for bugs (e.g. the empty-array edge case in `EffectiveRateDetailPage` is now guarded explicitly) and makes future changes to the lookup strategy a one-line fix.