### PR TITLE
refactor: rename repaid and balance detail pages for better SEO

### DIFF
--- a/e2e/preset-results.spec.ts
+++ b/e2e/preset-results.spec.ts
@@ -16,8 +16,8 @@ test.describe("Home page preset selection", () => {
     const section = page
       .locator("section")
       .filter({ hasText: "Your Loan Breakdown" });
+    await expect(section.getByText("Total Repayments")).toBeVisible();
     await expect(section.getByText("Payoff Timeline")).toBeVisible();
-    await expect(section.getByText("Balance Over Time")).toBeVisible();
     await expect(section.getByText("Interest Paid")).toBeVisible();
     await expect(section.getByText(/£[\d,]+/).first()).toBeVisible();
   });

--- a/e2e/share-url.spec.ts
+++ b/e2e/share-url.spec.ts
@@ -10,8 +10,8 @@ test.describe("Share URL round-trip", () => {
       .locator("section")
       .filter({ hasText: "Your Loan Breakdown" });
     await expect(section.getByText(/£[\d,]+/).first()).toBeVisible();
+    await expect(section.getByText("Total Repayments")).toBeVisible();
     await expect(section.getByText("Payoff Timeline")).toBeVisible();
-    await expect(section.getByText("Balance Over Time")).toBeVisible();
     await expect(section.getByText("Interest Paid")).toBeVisible();
   });
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -11,8 +11,8 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - [Repayment Calculator](https://studentloanstudy.uk): See total repayments across all UK student loan plan types (Plan 1, 2, 4, 5, Postgraduate)
 - [Which Plan Quiz](https://studentloanstudy.uk/which-plan): Find your loan plan in 3 questions
 - [Overpay Calculator](https://studentloanstudy.uk/overpay): Should you overpay or invest?
-- [Payoff Timeline](https://studentloanstudy.uk/repaid): See how long to pay off your student loan and track total repayments over time
-- [Balance Over Time](https://studentloanstudy.uk/balance): See how your loan balance changes as interest accrues and repayments are made
+- [Total Repayments](https://studentloanstudy.uk/repaid): Track how much you'll repay on your student loan over time
+- [Payoff Timeline](https://studentloanstudy.uk/balance): See when you'll pay off your student loan and how your balance changes over time
 - [Interest Breakdown](https://studentloanstudy.uk/interest): Understand how much of your repayments go to interest vs principal
 - [Effective Rate](https://studentloanstudy.uk/effective-rate): Compare your loan's true effective annual rate to the Bank of England base rate
 - [Our Data](https://studentloanstudy.uk/our-data): How we keep figures current — daily automation checks GOV.UK and the Bank of England

--- a/scripts/check-govuk-figures/templates.ts
+++ b/scripts/check-govuk-figures/templates.ts
@@ -222,8 +222,8 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - [Repayment Calculator](https://studentloanstudy.uk): See total repayments across all UK student loan plan types (Plan 1, 2, 4, 5, Postgraduate)
 - [Which Plan Quiz](https://studentloanstudy.uk/which-plan): Find your loan plan in 3 questions
 - [Overpay Calculator](https://studentloanstudy.uk/overpay): Should you overpay or invest?
-- [Payoff Timeline](https://studentloanstudy.uk/repaid): See how long to pay off your student loan and track total repayments over time
-- [Balance Over Time](https://studentloanstudy.uk/balance): See how your loan balance changes as interest accrues and repayments are made
+- [Total Repayments](https://studentloanstudy.uk/repaid): Track how much you'll repay on your student loan over time
+- [Payoff Timeline](https://studentloanstudy.uk/balance): See when you'll pay off your student loan and how your balance changes over time
 - [Interest Breakdown](https://studentloanstudy.uk/interest): Understand how much of your repayments go to interest vs principal
 - [Effective Rate](https://studentloanstudy.uk/effective-rate): Compare your loan's true effective annual rate to the Bank of England base rate
 - [Our Data](https://studentloanstudy.uk/our-data): How we keep figures current — daily automation checks GOV.UK and the Bank of England

--- a/src/app/balance/layout.tsx
+++ b/src/app/balance/layout.tsx
@@ -1,14 +1,16 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Balance Over Time — Student Loan Balance Trajectory",
+  title: "How Long to Pay Off Your Student Loan — Payoff Timeline Calculator",
   description:
-    "See how your UK student loan balance changes over time. Track peak balance, interest growth, and when your loan will be paid off or written off.",
+    "Find out how long it takes to pay off your UK student loan. See your payoff timeline, balance trajectory, and whether your loan will be paid off or written off — based on your salary and plan type.",
   keywords: [
+    "how long to pay off student loan",
+    "student loan payoff calculator",
+    "student loan payoff timeline",
+    "how long to repay student loan UK",
     "student loan balance over time",
-    "student loan balance trajectory",
-    "UK student loan balance tracker",
-    "student loan peak balance",
+    "UK student loan payoff date",
   ],
 };
 
@@ -25,7 +27,7 @@ const breadcrumbSchema = {
     {
       "@type": "ListItem",
       position: 2,
-      name: "Balance Over Time",
+      name: "Payoff Timeline",
       item: "https://studentloanstudy.uk/balance",
     },
   ],
@@ -37,18 +39,26 @@ const faqSchema = {
   mainEntity: [
     {
       "@type": "Question",
-      name: "Why is my student loan balance going up?",
+      name: "When will I finish paying off my student loan?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Your balance grows when interest added each month exceeds your repayments. This is common in the early years when your salary is lower and repayments are small. For Plan 2 borrowers, interest can be as high as RPI + 3%, meaning the balance may rise for several years before repayments start to outpace interest.",
+        text: "It depends on your salary, loan balance, and plan type. High earners on Plan 2 might pay off in 10–15 years, while most graduates repay for the full term before the loan is written off — 25 years for Plan 1, 30 years for Plans 2 and 4, 40 years for Plan 5, and 30 years for Postgraduate loans. Use our payoff timeline calculator to see a year-by-year projection for your situation.",
       },
     },
     {
       "@type": "Question",
-      name: "How do I track my student loan balance over time?",
+      name: "Will my student loan be paid off or written off?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Use our balance trajectory calculator to see a year-by-year projection of your loan balance. Enter your salary, balance, and plan type to visualise when your balance peaks, when repayments overtake interest, and whether your loan will be paid off or written off.",
+        text: "Most graduates will have their loan written off before paying it in full. Only high earners typically repay in full. Whether your loan is paid off or written off depends on your salary trajectory, starting balance, and plan type.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Why is my student loan balance going up?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Your balance grows when interest added each month exceeds your repayments. This is common in the early years when your salary is lower and repayments are small. For Plan 2 borrowers, interest can be as high as RPI + 3%, meaning the balance may rise for several years before repayments start to outpace interest.",
       },
     },
   ],

--- a/src/app/repaid/layout.tsx
+++ b/src/app/repaid/layout.tsx
@@ -1,16 +1,16 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "How Long to Pay Off Your Student Loan — Payoff Timeline Calculator",
+  title: "Total Repayments — Student Loan Total Cost Calculator",
   description:
-    "Find out how long it takes to pay off your UK student loan. See your payoff timeline, total repayments over time, monthly costs, and whether your loan will be paid off or written off — based on your salary and plan type.",
+    "Find out how much you'll repay on your UK student loan in total. See cumulative repayments over time, monthly costs, and whether you'll pay more or less than you borrowed — based on your salary and plan type.",
   keywords: [
-    "how long to pay off student loan",
-    "student loan payoff calculator",
-    "student loan payoff timeline",
-    "how long to repay student loan UK",
-    "student loan repayments over time",
+    "student loan total repayments",
+    "how much will I repay student loan",
+    "student loan total cost calculator",
     "UK student loan repayment calculator",
+    "student loan repayments over time",
+    "student loan cumulative repayments",
   ],
 };
 
@@ -27,7 +27,7 @@ const breadcrumbSchema = {
     {
       "@type": "ListItem",
       position: 2,
-      name: "Payoff Timeline",
+      name: "Total Repayments",
       item: "https://studentloanstudy.uk/repaid",
     },
   ],
@@ -39,26 +39,26 @@ const faqSchema = {
   mainEntity: [
     {
       "@type": "Question",
-      name: "When will I finish paying off my student loan?",
+      name: "How much will I repay on my student loan in total?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "It depends on your salary, loan balance, and plan type. High earners on Plan 2 might pay off in 10–15 years, while most graduates repay for the full term before the loan is written off — 25 years for Plan 1, 30 years for Plans 2 and 4, 40 years for Plan 5, and 30 years for Postgraduate loans. Use our payoff timeline calculator to see a year-by-year projection for your situation.",
+        text: "It depends on your salary, loan balance, and plan type. High earners on Plan 2 may repay significantly more than they borrowed due to interest, while lower earners may have the remaining balance written off after 25–40 years. Use our total repayments calculator to see a year-by-year breakdown of how much you'll pay.",
       },
     },
     {
       "@type": "Question",
-      name: "Will my student loan be paid off or written off?",
+      name: "Will I repay more than I borrowed?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Most graduates will have their loan written off before paying it in full. Only high earners typically repay in full. Whether your loan is paid off or written off depends on your salary trajectory, starting balance, and plan type.",
+        text: "Many graduates do repay more than they borrowed because interest accrues from day one. For Plan 2 borrowers, interest can be as high as RPI + 3%, meaning total repayments can exceed the original loan. However, if your salary stays low, you may repay less before the loan is written off.",
       },
     },
     {
       "@type": "Question",
-      name: "How is the student loan payoff date calculated?",
+      name: "How are total student loan repayments calculated?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "The calculator projects your loan balance forward month by month, applying your plan's interest rate and deducting 9% of income above the repayment threshold (6% for Postgraduate loans). It factors in salary growth and compares total repayments against the write-off date to show whether you'll repay in full or have the remaining balance cancelled.",
+        text: "The calculator projects your repayments month by month, deducting 9% of income above the repayment threshold (6% for Postgraduate loans). It accumulates these payments over the full loan term to show your total cost, factoring in salary growth and comparing against the write-off date.",
       },
     },
   ],

--- a/src/components/detail/BalanceDetailPage.tsx
+++ b/src/components/detail/BalanceDetailPage.tsx
@@ -50,8 +50,8 @@ export function BalanceDetailPage() {
 
   return (
     <DetailPageShell
-      heading="Balance Trajectory"
-      description="See how your loan balance changes over time as interest accrues and repayments are made."
+      heading="Payoff Timeline"
+      description="See when you'll pay off your student loan and how your balance changes over time."
     >
       {result ? (
         <>

--- a/src/components/detail/RepaidDetailPage.tsx
+++ b/src/components/detail/RepaidDetailPage.tsx
@@ -17,8 +17,8 @@ export function RepaidDetailPage() {
 
   return (
     <DetailPageShell
-      heading="Payoff Timeline"
-      description="See how long to pay off your student loan and track total repayments over time."
+      heading="Total Repayments"
+      description="Track how much you'll repay on your student loan over time."
     >
       {result ? (
         <>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -40,7 +40,7 @@ export function Footer() {
             <ul className="space-y-2">
               <li>
                 <Link href="/balance" className={NAV_LINK_CLASS}>
-                  Balance Over Time
+                  Payoff Timeline
                 </Link>
               </li>
               <li>
@@ -55,7 +55,7 @@ export function Footer() {
               </li>
               <li>
                 <Link href="/repaid" className={NAV_LINK_CLASS}>
-                  Payoff Timeline
+                  Total Repayments
                 </Link>
               </li>
             </ul>

--- a/src/lib/detailPages.ts
+++ b/src/lib/detailPages.ts
@@ -8,14 +8,14 @@ export interface DetailPageConfig {
 export const DETAIL_PAGES: DetailPageConfig[] = [
   {
     href: "/repaid",
-    label: "Payoff Timeline",
-    shortLabel: "Payoff",
+    label: "Total Repayments",
+    shortLabel: "Repayments",
     color: "var(--chart-1)",
   },
   {
     href: "/balance",
-    label: "Balance Over Time",
-    shortLabel: "Balance",
+    label: "Payoff Timeline",
+    shortLabel: "Payoff",
     color: "var(--chart-2)",
   },
   {


### PR DESCRIPTION
## Summary

Renames the two detail pages so their labels better reflect the content each page actually shows. The `/repaid` page (which displays cumulative repayment totals) becomes **Total Repayments**, and the `/balance` page (which shows the loan balance trajectory and payoff date) becomes **Payoff Timeline**. Updates all associated SEO metadata, FAQ schemas, breadcrumbs, footer links, LLM page descriptions, and e2e test assertions.

## Context

The previous naming had `/repaid` labeled "Payoff Timeline" and `/balance` labeled "Balance Over Time". This was misleading since the repaid page focuses on how much you repay in total, not when you pay off, and the balance page is the one that actually answers "when will I finish paying?". The rename aligns page names with their primary content, which should improve search relevance for queries like "how much will I repay" and "how long to pay off student loan".