### PR TITLE
style: simplify chart labels and stat card visuals

### DIFF
--- a/src/components/charts/ChartBase.tsx
+++ b/src/components/charts/ChartBase.tsx
@@ -287,48 +287,31 @@ export function ChartBase({
                     ? `${yText} at ${xText} ${seriesName}`
                     : `${yText} at ${xText}`;
                 });
-                const charWidth = 6.6;
-                const px = 8;
-                const py = 4;
-                const lineHeight = 14;
-                const maxLen = Math.max(...lines.map((l) => l.length));
-                const rectW = maxLen * charWidth + px * 2;
-                const rectH = lines.length * lineHeight + py * 2;
-                const baseY = viewBox.y - 10 - (isMulti ? 14 : 0) - py;
                 return (
-                  <g>
-                    <rect
-                      x={viewBox.x - rectW / 2}
-                      y={baseY - lineHeight / 2}
-                      width={rectW}
-                      height={rectH}
-                      rx={4}
-                      fill="var(--background)"
-                      stroke="var(--border)"
-                      strokeWidth={1}
-                      opacity={0.95}
-                    />
-                    <text
-                      x={viewBox.x}
-                      y={viewBox.y}
-                      textAnchor="middle"
-                      fontSize={11}
-                      fontWeight={500}
-                    >
-                      {crosshairPoint.values.map((v, i) => {
-                        return (
-                          <tspan
-                            key={v.dataKey}
-                            x={viewBox.x}
-                            dy={i === 0 ? -10 - (isMulti ? 14 : 0) : 14}
-                            fill={`var(--color-${v.dataKey})`}
-                          >
-                            {lines[i]}
-                          </tspan>
-                        );
-                      })}
-                    </text>
-                  </g>
+                  <text
+                    x={viewBox.x}
+                    y={viewBox.y}
+                    textAnchor="middle"
+                    fontSize={11}
+                    fontWeight={500}
+                    stroke="var(--background)"
+                    strokeWidth={4}
+                    strokeLinejoin="round"
+                    paintOrder="stroke"
+                  >
+                    {crosshairPoint.values.map((v, i) => {
+                      return (
+                        <tspan
+                          key={v.dataKey}
+                          x={viewBox.x}
+                          dy={i === 0 ? -10 - (isMulti ? 14 : 0) : 14}
+                          fill={`var(--color-${v.dataKey})`}
+                        >
+                          {lines[i]}
+                        </tspan>
+                      );
+                    })}
+                  </text>
                 );
               }}
             />
@@ -409,36 +392,22 @@ export function ChartBase({
                     const text = annotation.bottomLabel;
                     const tagX = viewBox.x;
                     const tagY = viewBox.y + viewBox.height - 10;
-                    const charWidth = 6.6;
-                    const px = 6;
-                    const py = 3;
-                    const rectW = text.length * charWidth + px * 2;
-                    const rectH = 16 + py * 2;
                     return (
-                      <g>
-                        <rect
-                          x={tagX - rectW / 2}
-                          y={tagY - rectH / 2}
-                          width={rectW}
-                          height={rectH}
-                          rx={4}
-                          fill="var(--background)"
-                          stroke={annotation.color ?? "var(--muted-foreground)"}
-                          strokeWidth={1}
-                          opacity={0.9}
-                        />
-                        <text
-                          x={tagX}
-                          y={tagY}
-                          textAnchor="middle"
-                          dominantBaseline="central"
-                          fill={annotation.color ?? "var(--muted-foreground)"}
-                          fontSize={11}
-                          fontWeight={500}
-                        >
-                          {text}
-                        </text>
-                      </g>
+                      <text
+                        x={tagX}
+                        y={tagY}
+                        textAnchor="middle"
+                        dominantBaseline="central"
+                        fill={annotation.color ?? "var(--muted-foreground)"}
+                        fontSize={11}
+                        fontWeight={500}
+                        stroke="var(--background)"
+                        strokeWidth={4}
+                        strokeLinejoin="round"
+                        paintOrder="stroke"
+                      >
+                        {text}
+                      </text>
                     );
                   }}
                 />

--- a/src/components/detail/StatCard.tsx
+++ b/src/components/detail/StatCard.tsx
@@ -14,40 +14,29 @@ export function StatCard({
   accentColor,
 }: StatCardProps) {
   return (
-    <div
-      className="relative overflow-hidden rounded-xl bg-card p-4 pl-3 ring-1 ring-foreground/10"
-      style={{
-        backgroundImage: `linear-gradient(135deg, ${accentColor}0D, transparent 60%)`,
-      }}
-    >
-      <div
-        className="absolute inset-y-2 left-0 w-1 rounded-r-full"
-        style={{ backgroundColor: accentColor }}
-      />
-      <div className="pl-3">
-        <span className="text-xs tracking-wide text-muted-foreground uppercase">
-          {label}
+    <div className="rounded-xl bg-card p-4 ring-1 ring-foreground/10">
+      <span className="text-xs tracking-wide text-muted-foreground uppercase">
+        {label}
+      </span>
+      <p
+        className="mt-1 font-mono text-2xl font-semibold tabular-nums"
+        style={{ color: accentColor }}
+      >
+        {value}
+      </p>
+      {subtext && (
+        <span className="mt-0.5 block text-xs text-muted-foreground">
+          {subtext}
         </span>
-        <p
-          className="mt-1 font-mono text-2xl font-semibold tabular-nums"
-          style={{ color: accentColor }}
-        >
-          {value}
-        </p>
-        {subtext && (
-          <span className="mt-0.5 block text-xs text-muted-foreground">
-            {subtext}
-          </span>
-        )}
-      </div>
+      )}
     </div>
   );
 }
 
 export function StatCardSkeleton() {
   return (
-    <div className="rounded-xl bg-card p-4 pl-3 ring-1 ring-foreground/10">
-      <div className="space-y-2 pl-3">
+    <div className="rounded-xl bg-card p-4 ring-1 ring-foreground/10">
+      <div className="space-y-2">
         <Skeleton className="h-3 w-20" />
         <Skeleton className="h-7 w-28" />
         <Skeleton className="h-3 w-24" />


### PR DESCRIPTION
## Summary

Replace explicit `<rect>` + `<text>` tooltip and annotation labels in charts with a single `<text>` element using SVG `paintOrder="stroke"` for a lightweight text-halo effect. Simplify StatCard by removing the colored left accent bar, gradient background overlay, and extra nesting — resulting in a cleaner flat card layout.

## Context

The previous chart labels drew a background rectangle behind each text element to ensure readability. The `paintOrder: stroke` technique achieves the same contrast with less SVG markup and no manual width/height calculations. The StatCard accent bar and gradient added visual weight without proportional benefit, so they have been stripped back to a minimal card style.