### PR TITLE
fix: position crosshair dots at stacked y for stacked charts

### DIFF
--- a/src/components/charts/ChartBase.tsx
+++ b/src/components/charts/ChartBase.tsx
@@ -42,7 +42,7 @@ export interface HorizontalAnnotationConfig {
 
 interface CrosshairPoint {
   x: number;
-  values: Array<{ dataKey: string; y: number }>;
+  values: Array<{ dataKey: string; y: number; stackedY: number }>;
 }
 
 export interface ChartBaseProps {
@@ -104,9 +104,17 @@ export function ChartBase({
     }
     const payload = state.activePayload;
     const xValue = Number(payload[0].payload[xDataKey]);
+    const stackAccumulator: Record<string, number> = {};
     const values = series.map((s) => {
       const match = payload.find((p) => p.dataKey === s.dataKey);
-      return { dataKey: s.dataKey, y: match ? match.value : 0 };
+      const y = match ? match.value : 0;
+      if (s.stackId) {
+        const acc = stackAccumulator[s.stackId] ?? 0;
+        const stackedY = acc + y;
+        stackAccumulator[s.stackId] = stackedY;
+        return { dataKey: s.dataKey, y, stackedY };
+      }
+      return { dataKey: s.dataKey, y, stackedY: y };
     });
     setCrosshairPoint({ x: xValue, values });
   }
@@ -338,7 +346,7 @@ export function ChartBase({
               <ReferenceDot
                 key={`crosshair-dot-${v.dataKey}`}
                 x={crosshairPoint.x}
-                y={v.y}
+                y={v.stackedY}
                 r={4}
                 fill={`var(--color-${v.dataKey})`}
                 stroke="var(--background)"


### PR DESCRIPTION
## Summary

Crosshair indicator dots on stacked charts (e.g. stacked area or bar charts) were rendered at each series' individual y value instead of the cumulative stacked position. This caused the dots to appear misaligned from the actual chart areas they represent.

This fix computes a running `stackedY` accumulator grouped by `stackId` during crosshair mouse-move handling, so each dot is positioned at its true visual location in the stack.

## Context

Recharts renders stacked series by accumulating values on top of each other, but the `activePayload` from mouse events still reports raw (unstacked) values per series. The fix mirrors the stacking logic by summing values in series order per stack group, and uses the cumulative value for `ReferenceDot` placement. Non-stacked series continue to use their raw y value.