### PR TITLE
style: replace balance stat cards with compact payoff hero stats

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -239,6 +239,25 @@ body {
   }
 }
 
+@keyframes timeline-enter {
+  from {
+    transform: translateY(8px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@utility animate-timeline-enter {
+  animation: timeline-enter 300ms ease-out both;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
 @utility scrollbar-none {
   scrollbar-width: none;
 }

--- a/src/components/detail/BalanceDetailPage.tsx
+++ b/src/components/detail/BalanceDetailPage.tsx
@@ -2,7 +2,7 @@
 
 import { BalanceDetailChart } from "./BalanceDetailChart";
 import { DetailPageShell } from "./DetailPageShell";
-import { StatCard, StatCardSkeleton } from "./StatCard";
+import { PayoffHeroStats, PayoffHeroStatsSkeleton } from "./PayoffHeroStats";
 import { Skeleton } from "@/components/ui/skeleton";
 import { currencyFormatter } from "@/constants";
 import { useDetailSeriesData } from "@/hooks/useDetailData";
@@ -10,7 +10,6 @@ import { useDetailSeriesData } from "@/hooks/useDetailData";
 export function BalanceDetailPage() {
   const result = useDetailSeriesData();
 
-  const peakYear = result ? Math.round(result.stats.peakBalanceMonth / 12) : 0;
   const payoffYears = result ? Math.round(result.stats.monthsToPayoff / 12) : 0;
 
   function getInsightText() {
@@ -36,78 +35,40 @@ export function BalanceDetailPage() {
     return `Interest outpaces repayments for the first ${String(peakYears)} years. After that, your growing salary tips the balance and you pay off the loan in ${String(payoffYears)} years.`;
   }
 
-  function getPayoffSubtext() {
-    if (!result) return "";
-    if (result.stats.writtenOff) {
-      const forgiven =
-        result.balanceSeries[result.balanceSeries.length - 1].balance;
-      return `Written off — ${currencyFormatter.format(forgiven)} forgiven`;
-    }
-    return payoffYears <= 15
-      ? "Paid in full — ahead of schedule"
-      : "Paid in full";
-  }
-
   return (
     <DetailPageShell
       heading="Payoff Timeline"
       description="See when you'll pay off your student loan and how your balance changes over time."
     >
       {result ? (
-        <>
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-            <StatCard
-              label="Starting Balance"
-              value={currencyFormatter.format(result.stats.initialBalance)}
-              accentColor="var(--chart-2)"
+        <div className="space-y-2">
+          <PayoffHeroStats
+            payoffYears={payoffYears}
+            writtenOff={result.stats.writtenOff}
+            totalPaidAmount={
+              result.stats.writtenOff
+                ? currencyFormatter.format(result.stats.totalPaid)
+                : undefined
+            }
+            aheadOfSchedule={payoffYears <= 15 && !result.stats.writtenOff}
+          />
+          <div className="h-65 sm:h-75 md:h-85">
+            <BalanceDetailChart
+              data={result.balanceSeries}
+              peakBalanceMonth={result.stats.peakBalanceMonth}
+              peakBalance={result.stats.peakBalance}
+              writeOffMonth={result.stats.writeOffMonth}
             />
-            <StatCard
-              label="Peak Balance"
-              value={currencyFormatter.format(result.stats.peakBalance)}
-              subtext={
-                result.stats.peakBalanceMonth > 0
-                  ? `at year ${String(peakYear)}`
-                  : "at start"
-              }
-              accentColor="var(--chart-3)"
-            />
-            <div className="col-span-2 sm:col-span-1">
-              <StatCard
-                label="Payoff"
-                value={`${String(payoffYears)} years`}
-                subtext={getPayoffSubtext()}
-                accentColor={
-                  result.stats.writtenOff ? "var(--chart-5)" : "var(--chart-1)"
-                }
-              />
-            </div>
           </div>
-
-          <div className="space-y-2">
-            <div className="h-65 sm:h-75 md:h-85">
-              <BalanceDetailChart
-                data={result.balanceSeries}
-                peakBalanceMonth={result.stats.peakBalanceMonth}
-                peakBalance={result.stats.peakBalance}
-                writeOffMonth={result.stats.writeOffMonth}
-              />
-            </div>
-            <p className="text-center text-xs text-muted-foreground">
-              {getInsightText()}
-            </p>
-          </div>
-        </>
+          <p className="mx-auto max-w-2xl text-center text-sm text-muted-foreground">
+            {getInsightText()}
+          </p>
+        </div>
       ) : (
-        <>
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-            <StatCardSkeleton />
-            <StatCardSkeleton />
-            <div className="col-span-2 sm:col-span-1">
-              <StatCardSkeleton />
-            </div>
-          </div>
+        <div className="space-y-3">
+          <PayoffHeroStatsSkeleton />
           <Skeleton className="h-65 sm:h-75 md:h-85" />
-        </>
+        </div>
       )}
     </DetailPageShell>
   );

--- a/src/components/detail/PayoffHeroStats.tsx
+++ b/src/components/detail/PayoffHeroStats.tsx
@@ -1,0 +1,72 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface PayoffHeroStatsProps {
+  payoffYears: number;
+  writtenOff: boolean;
+  totalPaidAmount?: string;
+  aheadOfSchedule: boolean;
+}
+
+function OutcomeBadge({
+  writtenOff,
+  totalPaidAmount,
+  aheadOfSchedule,
+}: {
+  writtenOff: boolean;
+  totalPaidAmount?: string;
+  aheadOfSchedule: boolean;
+}) {
+  if (writtenOff) {
+    return (
+      <span className="inline-flex rounded-md border border-status-warning-border bg-status-warning px-2 py-0.5 text-xs font-medium text-status-warning-foreground">
+        Written off after paying a total of {totalPaidAmount}
+      </span>
+    );
+  }
+
+  if (aheadOfSchedule) {
+    return (
+      <span className="inline-flex rounded-md border border-status-success-border bg-status-success px-2 py-0.5 text-xs font-medium text-status-success-foreground">
+        Paid in full — ahead of schedule
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex rounded-md border border-status-success-border bg-status-success px-2 py-0.5 text-xs font-medium text-status-success-foreground">
+      Paid in full
+    </span>
+  );
+}
+
+export function PayoffHeroStats({
+  payoffYears,
+  writtenOff,
+  totalPaidAmount,
+  aheadOfSchedule,
+}: PayoffHeroStatsProps) {
+  return (
+    <div className="flex animate-timeline-enter flex-wrap items-baseline justify-end gap-x-3 gap-y-1">
+      <OutcomeBadge
+        writtenOff={writtenOff}
+        totalPaidAmount={totalPaidAmount}
+        aheadOfSchedule={aheadOfSchedule}
+      />
+      <p
+        className="font-mono text-2xl font-bold tabular-nums"
+        style={{ color: writtenOff ? "var(--chart-5)" : "var(--chart-1)" }}
+      >
+        {payoffYears} years
+      </p>
+    </div>
+  );
+}
+
+export function PayoffHeroStatsSkeleton() {
+  return (
+    <div className="flex items-baseline justify-end gap-3">
+      <Skeleton className="h-5 w-44" />
+      <Skeleton className="h-7 w-36" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the 3-column stat card grid (Starting Balance, Peak Balance, Payoff) on the balance detail page with a compact inline hero stat row. This puts the focus squarely on the payoff outcome — the number of years and an outcome badge (written off / paid in full / ahead of schedule) — instead of spreading attention across three separate cards.

## Context

The starting balance and peak balance stats duplicated information already visible on the chart itself. The new `PayoffHeroStats` component is a lightweight right-aligned row with a subtle entrance animation and `prefers-reduced-motion` support. The insight text below the chart was also bumped from `text-xs` to `text-sm` for readability.