### PR TITLE
refactor: highlight active insight card instead of swapping with calculator

### DIFF
--- a/src/components/shared/InsightCard.tsx
+++ b/src/components/shared/InsightCard.tsx
@@ -15,26 +15,51 @@ import { Sparkline } from "@/components/charts/Sparkline";
 function CardShell({
   title,
   href,
+  active,
+  color,
   children,
 }: {
   title: string;
   href: string;
+  active?: boolean;
+  color?: string;
   children: React.ReactNode;
 }) {
-  return (
-    <Link href={href} className="group block h-full">
-      <div className="flex h-full flex-col overflow-hidden rounded-xl bg-card ring-1 ring-foreground/10 transition-all duration-200 hover:bg-accent hover:ring-primary/30">
-        <div className="flex items-center justify-between px-5 pt-5">
-          <span className="text-sm font-medium text-muted-foreground">
-            {title}
-          </span>
+  const inner = (
+    <div
+      className={
+        active
+          ? "flex h-full flex-col overflow-hidden rounded-xl bg-card ring-2"
+          : "flex h-full flex-col overflow-hidden rounded-xl bg-card ring-1 ring-foreground/10 transition-all duration-200 hover:bg-accent hover:ring-primary/30"
+      }
+      style={
+        active && color
+          ? ({ "--tw-ring-color": color } as React.CSSProperties)
+          : undefined
+      }
+    >
+      <div className="flex items-center justify-between px-5 pt-5">
+        <span className="text-sm font-medium text-muted-foreground">
+          {title}
+        </span>
+        {!active && (
           <HugeiconsIcon
             icon={ArrowRight01Icon}
             className="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5"
           />
-        </div>
-        {children}
+        )}
       </div>
+      {children}
+    </div>
+  );
+
+  if (active) {
+    return <div className="block h-full">{inner}</div>;
+  }
+
+  return (
+    <Link href={href} className="group block h-full">
+      {inner}
     </Link>
   );
 }
@@ -58,6 +83,7 @@ interface SparklineCardProps {
   title: string;
   href: string;
   color: string;
+  active?: boolean;
   cardData: InsightCardData | null;
 }
 
@@ -65,10 +91,11 @@ export function SparklineCard({
   title,
   href,
   color,
+  active,
   cardData,
 }: SparklineCardProps) {
   return (
-    <CardShell title={title} href={href}>
+    <CardShell title={title} href={href} active={active} color={color}>
       {cardData ? (
         <div className="flex flex-1 flex-col">
           <span className="px-5 pt-2 font-mono text-xl font-semibold tabular-nums">
@@ -97,6 +124,7 @@ interface ProportionCardProps {
   title: string;
   href: string;
   color: string;
+  active?: boolean;
   cardData: InterestCardData | null;
 }
 
@@ -104,10 +132,11 @@ export function ProportionCard({
   title,
   href,
   color,
+  active,
   cardData,
 }: ProportionCardProps) {
   return (
-    <CardShell title={title} href={href}>
+    <CardShell title={title} href={href} active={active} color={color}>
       {cardData ? (
         <div className="flex flex-1 flex-col justify-between px-5 pt-2 pb-5">
           <span className="font-mono text-xl font-semibold tabular-nums">
@@ -161,6 +190,7 @@ interface RateComparisonCardProps {
   title: string;
   href: string;
   color: string;
+  active?: boolean;
   cardData: EffectiveRateCardData | null;
 }
 
@@ -168,6 +198,7 @@ export function RateComparisonCard({
   title,
   href,
   color,
+  active,
   cardData,
 }: RateComparisonCardProps) {
   const maxRate = Math.max(
@@ -185,7 +216,7 @@ export function RateComparisonCard({
       : 0;
 
   return (
-    <CardShell title={title} href={href}>
+    <CardShell title={title} href={href} active={active} color={color}>
       {cardData ? (
         <div className="flex flex-1 flex-col justify-between px-5 pt-2 pb-5">
           <span className="font-mono text-xl font-semibold tabular-nums">
@@ -237,42 +268,6 @@ export function RateComparisonCard({
             <div className="h-2 animate-pulse rounded-full bg-muted" />
           </div>
         </div>
-      )}
-    </CardShell>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Calculator card (insight text + sparkline)
-// ---------------------------------------------------------------------------
-
-interface CalculatorCardProps {
-  cardData: InsightCardData | null;
-  currentSalary: number | undefined;
-}
-
-export function CalculatorCard({
-  cardData,
-  currentSalary,
-}: CalculatorCardProps) {
-  return (
-    <CardShell title="Repayment Calculator" href="/">
-      {cardData ? (
-        <div className="flex flex-1 flex-col">
-          <span className="px-5 pt-2 font-mono text-xl font-semibold tabular-nums">
-            {cardData.stat}
-          </span>
-          <div className="mt-auto">
-            <Sparkline
-              data={cardData.data}
-              color="var(--primary)"
-              ariaLabel={cardData.label}
-              annotationX={currentSalary}
-            />
-          </div>
-        </div>
-      ) : (
-        <StatSkeleton />
       )}
     </CardShell>
   );

--- a/src/components/shared/InsightCards.tsx
+++ b/src/components/shared/InsightCards.tsx
@@ -1,15 +1,15 @@
 "use client";
 
+import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
 import {
-  CalculatorCard,
   ProportionCard,
   RateComparisonCard,
   SparklineCard,
 } from "./InsightCard";
 import { usePersonalizedResults } from "@/context/PersonalizedResultsContext";
-import { useCurrentSalary } from "@/hooks/useStoreSelectors";
 import { DETAIL_PAGES } from "@/lib/detailPages";
-import { cn } from "@/lib/utils";
 
 interface InsightCardsProps {
   excludeHref?: string;
@@ -17,98 +17,56 @@ interface InsightCardsProps {
 
 export function InsightCards({ excludeHref }: InsightCardsProps) {
   const { cards: data } = usePersonalizedResults();
-  const salary = useCurrentSalary();
 
-  // Fixed 4-card positions: [Repaid, Balance, Interest, Eff. Rate]
-  const detailCards = [
-    {
-      href: DETAIL_PAGES[0].href,
-      node: (
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-medium text-muted-foreground">
+          Your Loan Breakdown
+        </h2>
+        {excludeHref && (
+          <Link
+            href="/"
+            className="flex items-center gap-1 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+            Repayment Calculator
+          </Link>
+        )}
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <SparklineCard
           key={DETAIL_PAGES[0].href}
           title={DETAIL_PAGES[0].label}
           href={DETAIL_PAGES[0].href}
           color={DETAIL_PAGES[0].color}
+          active={excludeHref === DETAIL_PAGES[0].href}
           cardData={data?.cumulative ?? null}
         />
-      ),
-    },
-    {
-      href: DETAIL_PAGES[1].href,
-      node: (
         <SparklineCard
           key={DETAIL_PAGES[1].href}
           title={DETAIL_PAGES[1].label}
           href={DETAIL_PAGES[1].href}
           color={DETAIL_PAGES[1].color}
+          active={excludeHref === DETAIL_PAGES[1].href}
           cardData={data?.balance ?? null}
         />
-      ),
-    },
-    {
-      href: DETAIL_PAGES[2].href,
-      node: (
         <ProportionCard
           key={DETAIL_PAGES[2].href}
           title={DETAIL_PAGES[2].label}
           href={DETAIL_PAGES[2].href}
           color={DETAIL_PAGES[2].color}
+          active={excludeHref === DETAIL_PAGES[2].href}
           cardData={data?.interest ?? null}
         />
-      ),
-    },
-    {
-      href: DETAIL_PAGES[3].href,
-      node: (
         <RateComparisonCard
           key={DETAIL_PAGES[3].href}
           title={DETAIL_PAGES[3].label}
           href={DETAIL_PAGES[3].href}
           color={DETAIL_PAGES[3].color}
+          active={excludeHref === DETAIL_PAGES[3].href}
           cardData={data?.effectiveRate ?? null}
         />
-      ),
-    },
-  ];
-
-  const calculatorNode = (
-    <CalculatorCard
-      key="/"
-      cardData={data?.totalRepayment ?? null}
-      currentSalary={salary}
-    />
-  );
-
-  // Check if excludeHref matches one of the 4 detail cards
-  const swapIndex = detailCards.findIndex((c) => c.href === excludeHref);
-
-  let cards: React.ReactNode[];
-
-  if (!excludeHref) {
-    // Home page: show only the 4 detail cards
-    cards = detailCards.map((c) => c.node);
-  } else if (swapIndex !== -1) {
-    // Detail page: swap the current page's card with calculator card in-place
-    cards = detailCards.map((c, i) =>
-      i === swapIndex ? calculatorNode : c.node,
-    );
-  } else {
-    // Other pages (e.g. /overpay): prepend calculator card, show all 4 detail cards
-    cards = [calculatorNode, ...detailCards.map((c) => c.node)];
-  }
-
-  return (
-    <section className="space-y-4">
-      <h2 className="text-sm font-medium text-muted-foreground">
-        Your Loan Breakdown
-      </h2>
-      <div
-        className={cn(
-          "grid gap-4 sm:grid-cols-2",
-          cards.length >= 5 ? "lg:grid-cols-5" : "lg:grid-cols-4",
-        )}
-      >
-        {cards}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

Replace the card-swapping behaviour on detail pages with in-place visual highlighting. Previously, when viewing a detail page (e.g. /balance), the corresponding insight card was replaced by a "Repayment Calculator" card, which was confusing for navigation. Now all 4 breakdown cards are always visible, with the current page's card highlighted via a colored ring border and rendered as a non-clickable element. A back-link to the Repayment Calculator is added in the section header instead.

## Context

The `CalculatorCard` component and the swap/conditional logic in `InsightCards` added complexity without clear UX benefit. This change simplifies the component tree, removes unused imports (`useCurrentSalary`, `cn`), and deletes the `CalculatorCard` component entirely. The grid is now always a fixed 4-column layout, avoiding the dynamic 4/5-column switching.