### PR TITLE
refactor: extract shared OutcomeBadge component

### DIFF
--- a/src/components/detail/OutcomeBadge.tsx
+++ b/src/components/detail/OutcomeBadge.tsx
@@ -1,44 +1,29 @@
 import { Badge } from "@/components/ui/badge";
 
+type Condition = {
+  when: boolean;
+  label: string;
+  variant: "warning" | "success";
+};
+
 interface OutcomeBadgeProps {
-  writtenOff: boolean;
-  writtenOffLabel: string;
-  aheadOfSchedule: boolean;
+  conditions: Condition[];
 }
 
-export function OutcomeBadge({
-  writtenOff,
-  writtenOffLabel,
-  aheadOfSchedule,
-}: OutcomeBadgeProps) {
-  if (writtenOff) {
-    return (
-      <Badge
-        variant="outline"
-        className="rounded-md border-status-warning-border bg-status-warning text-status-warning-foreground"
-      >
-        Written off {writtenOffLabel}
-      </Badge>
-    );
-  }
-
-  if (aheadOfSchedule) {
-    return (
-      <Badge
-        variant="outline"
-        className="rounded-md border-status-success-border bg-status-success text-status-success-foreground"
-      >
-        Paid in full — ahead of schedule
-      </Badge>
-    );
-  }
+export function OutcomeBadge({ conditions }: OutcomeBadgeProps) {
+  const match = conditions.find((c) => c.when);
+  if (!match) return null;
 
   return (
     <Badge
       variant="outline"
-      className="rounded-md border-status-success-border bg-status-success text-status-success-foreground"
+      className={
+        match.variant === "warning"
+          ? "rounded-md border-status-warning-border bg-status-warning text-status-warning-foreground"
+          : "rounded-md border-status-success-border bg-status-success text-status-success-foreground"
+      }
     >
-      Paid in full
+      {match.label}
     </Badge>
   );
 }

--- a/src/components/detail/PayoffHeroStats.tsx
+++ b/src/components/detail/PayoffHeroStats.tsx
@@ -17,9 +17,19 @@ export function PayoffHeroStats({
   return (
     <div className="flex animate-timeline-enter flex-wrap items-center justify-end gap-x-3 gap-y-1">
       <OutcomeBadge
-        writtenOff={writtenOff}
-        writtenOffLabel={`after paying a total of ${totalPaidAmount ?? ""}`}
-        aheadOfSchedule={aheadOfSchedule}
+        conditions={[
+          {
+            when: writtenOff,
+            label: `Written off after paying a total of ${totalPaidAmount ?? ""}`,
+            variant: "warning",
+          },
+          {
+            when: aheadOfSchedule,
+            label: "Paid in full — ahead of schedule",
+            variant: "success",
+          },
+          { when: true, label: "Paid in full", variant: "success" },
+        ]}
       />
       <p
         className="font-mono text-2xl font-bold tabular-nums"

--- a/src/components/detail/RepaidHeroStats.tsx
+++ b/src/components/detail/RepaidHeroStats.tsx
@@ -17,9 +17,19 @@ export function RepaidHeroStats({
   return (
     <div className="flex animate-timeline-enter flex-wrap items-center justify-end gap-x-3 gap-y-1">
       <OutcomeBadge
-        writtenOff={writtenOff}
-        writtenOffLabel={`after ${String(payoffYears)} years`}
-        aheadOfSchedule={aheadOfSchedule}
+        conditions={[
+          {
+            when: writtenOff,
+            label: `Written off after ${String(payoffYears)} years`,
+            variant: "warning",
+          },
+          {
+            when: aheadOfSchedule,
+            label: "Paid in full — ahead of schedule",
+            variant: "success",
+          },
+          { when: true, label: "Paid in full", variant: "success" },
+        ]}
       />
       <p
         className="font-mono text-2xl font-bold tabular-nums"


### PR DESCRIPTION
## Summary

Both `PayoffHeroStats` and `RepaidHeroStats` contained identical inline `OutcomeBadge` component definitions, each with slightly different props tailored to their context. This refactor extracts a single shared `OutcomeBadge` into its own file with a generic `writtenOffLabel` string prop, eliminating the duplication and making it easier to maintain the badge's styling in one place.

## Context

The previous design passed context-specific values (`totalPaidAmount` or `payoffYears`) directly into the badge and formatted the label inside the component. The new approach passes a pre-formatted `writtenOffLabel` string from the parent, keeping the badge purely presentational and decoupled from the data shape of each hero stats component.