### PR TITLE
fix: show forgiven amount instead of total paid on written-off badge

### DIFF
--- a/src/components/detail/BalanceDetailPage.tsx
+++ b/src/components/detail/BalanceDetailPage.tsx
@@ -45,9 +45,9 @@ export function BalanceDetailPage() {
           <PayoffHeroStats
             payoffYears={payoffYears}
             writtenOff={result.stats.writtenOff}
-            totalPaidAmount={
+            totalWrittenOffAmount={
               result.stats.writtenOff
-                ? currencyFormatter.format(result.stats.totalPaid)
+                ? currencyFormatter.format(result.stats.totalWrittenOff)
                 : undefined
             }
             aheadOfSchedule={payoffYears <= 15 && !result.stats.writtenOff}

--- a/src/components/detail/PayoffHeroStats.tsx
+++ b/src/components/detail/PayoffHeroStats.tsx
@@ -4,14 +4,14 @@ import { Skeleton } from "@/components/ui/skeleton";
 interface PayoffHeroStatsProps {
   payoffYears: number;
   writtenOff: boolean;
-  totalPaidAmount?: string;
+  totalWrittenOffAmount?: string;
   aheadOfSchedule: boolean;
 }
 
 export function PayoffHeroStats({
   payoffYears,
   writtenOff,
-  totalPaidAmount,
+  totalWrittenOffAmount,
   aheadOfSchedule,
 }: PayoffHeroStatsProps) {
   return (
@@ -20,7 +20,7 @@ export function PayoffHeroStats({
         conditions={[
           {
             when: writtenOff,
-            label: `Written off after paying a total of ${totalPaidAmount ?? ""}`,
+            label: `Written off — ${totalWrittenOffAmount ?? ""} forgiven`,
             variant: "warning",
           },
           {

--- a/src/workers/simulation.worker.ts
+++ b/src/workers/simulation.worker.ts
@@ -143,6 +143,7 @@ export interface DetailSeriesResult {
     monthlyRepayment: number;
     peakBalance: number;
     peakBalanceMonth: number;
+    totalWrittenOff: number;
   };
 }
 
@@ -443,6 +444,7 @@ function handleDetailSeries(payload: DetailSeriesPayload): DetailSeriesResult {
         monthlyRepayment: 0,
         peakBalance: 0,
         peakBalanceMonth: 0,
+        totalWrittenOff: 0,
       },
     };
   }
@@ -532,6 +534,10 @@ function handleDetailSeries(payload: DetailSeriesPayload): DetailSeriesResult {
     ? toPresent(peakBalance, dr, peakBalanceMonth)
     : peakBalance;
 
+  const totalWrittenOff = hasPV
+    ? toPresent(summary.totalWrittenOff, dr, summary.monthsToPayoff)
+    : summary.totalWrittenOff;
+
   return {
     type: "DETAIL_SERIES",
     cumulativeRepaid,
@@ -550,6 +556,7 @@ function handleDetailSeries(payload: DetailSeriesPayload): DetailSeriesResult {
       monthlyRepayment: snapshots.length > 0 ? snapshots[0].totalRepayment : 0,
       peakBalance: peakBal,
       peakBalanceMonth,
+      totalWrittenOff,
     },
   };
 }


### PR DESCRIPTION
## Summary

When a loan is written off, the payoff hero badge now displays the forgiven amount (e.g. "Written off — £12,345 forgiven") instead of the total paid. The previous wording — "Written off after paying a total of £X" — was misleading because the total-paid figure doesn't convey how much debt was actually forgiven, which is the more useful piece of information for users.

## Context

Added a new `totalWrittenOff` stat to the simulation worker's detail series output (with present-value adjustment when enabled), renamed the prop from `totalPaidAmount` to `totalWrittenOffAmount` in `PayoffHeroStats`, and wired it up in `BalanceDetailPage`.