### PR TITLE
style: compact insight text on balance and repaid detail pages

### DIFF
--- a/src/components/detail/BalanceDetailPage.tsx
+++ b/src/components/detail/BalanceDetailPage.tsx
@@ -60,7 +60,7 @@ export function BalanceDetailPage() {
               writeOffMonth={result.stats.writeOffMonth}
             />
           </div>
-          <p className="mx-auto max-w-2xl text-center text-sm text-muted-foreground">
+          <p className="text-center text-xs text-muted-foreground">
             {getInsightText()}
           </p>
         </div>

--- a/src/components/detail/RepaidDetailPage.tsx
+++ b/src/components/detail/RepaidDetailPage.tsx
@@ -43,7 +43,7 @@ export function RepaidDetailPage() {
               writeOffMonth={result.stats.writeOffMonth}
             />
           </div>
-          <p className="mx-auto max-w-2xl text-center text-sm text-muted-foreground">
+          <p className="text-center text-xs text-muted-foreground">
             {getInsightText()}
           </p>
         </div>


### PR DESCRIPTION
## Summary

Reduces the visual weight of insight text beneath the hero stats on the Balance and Repaid detail pages. The font size is decreased from `text-sm` to `text-xs` and the `mx-auto max-w-2xl` width constraint is removed, letting the text sit naturally within the existing container.

## Context

Recent PRs (#242, #244) replaced the stat cards with compact hero stats on these pages. The insight text styling was still sized for the old layout — this brings it in line with the more compact design.