### PR TITLE
refactor: simplify logic and reuse existing utils/variables

### DIFF
--- a/src/components/charts/ChartBase.tsx
+++ b/src/components/charts/ChartBase.tsx
@@ -171,10 +171,8 @@ export function ChartBase({
             {series.map((s) => {
               // Top segment in a stack gets rounded top corners
               const isTopInStack =
-                s.stackId !== undefined
-                  ? series.filter((x) => x.stackId === s.stackId).at(-1)
-                      ?.dataKey === s.dataKey
-                  : true;
+                s.stackId === undefined ||
+                series.findLast((x) => x.stackId === s.stackId) === s;
               return (
                 <Bar
                   key={s.dataKey}

--- a/src/components/shared/InsightCard.tsx
+++ b/src/components/shared/InsightCard.tsx
@@ -7,6 +7,7 @@ import type {
   InterestCardData,
 } from "@/types/insightCards";
 import { Sparkline } from "@/components/charts/Sparkline";
+import { percentageFormatter } from "@/constants";
 
 // ---------------------------------------------------------------------------
 // Shared card shell
@@ -139,11 +140,9 @@ export function ProportionCard({
   active,
   cardData,
 }: ProportionCardProps) {
-  const interestPct = cardData ? Math.round(cardData.interestRatio * 100) : 0;
-  const principalPct = cardData ? Math.round(cardData.principalRatio * 100) : 0;
-  const writtenOffPct = cardData
-    ? Math.round(cardData.writtenOffRatio * 100)
-    : 0;
+  const interestPct = Math.round((cardData?.interestRatio ?? 0) * 100);
+  const principalPct = Math.round((cardData?.principalRatio ?? 0) * 100);
+  const writtenOffPct = Math.round((cardData?.writtenOffRatio ?? 0) * 100);
 
   return (
     <CardShell title={title} href={href} active={active} color={color}>
@@ -246,7 +245,7 @@ export function RateComparisonCard({
           <div
             className="space-y-1.5"
             role="img"
-            aria-label={`Effective rate ${(cardData.effectiveRate * 100).toFixed(1)}% vs base rate ${(cardData.boeRate * 100).toFixed(1)}%`}
+            aria-label={`Effective rate ${percentageFormatter(cardData.effectiveRate)} vs base rate ${percentageFormatter(cardData.boeRate)}`}
           >
             <div className="flex items-center gap-2">
               <span className="w-14 shrink-0 text-xs text-muted-foreground">
@@ -262,7 +261,7 @@ export function RateComparisonCard({
                 />
               </div>
               <span className="w-10 shrink-0 text-right font-mono text-xs tabular-nums">
-                {(cardData.effectiveRate * 100).toFixed(1)}%
+                {percentageFormatter(cardData.effectiveRate)}
               </span>
             </div>
             <div className="flex items-center gap-2">
@@ -276,7 +275,7 @@ export function RateComparisonCard({
                 />
               </div>
               <span className="w-10 shrink-0 text-right font-mono text-xs text-muted-foreground tabular-nums">
-                {(cardData.boeRate * 100).toFixed(1)}%
+                {percentageFormatter(cardData.boeRate)}
               </span>
             </div>
           </div>

--- a/src/workers/simulation.worker.ts
+++ b/src/workers/simulation.worker.ts
@@ -353,16 +353,10 @@ function handleInsight(payload: InsightPayload): {
   const years = Math.round(months / 12);
   const balanceStat = months < 12 ? "<1 year" : `${String(years)} years`;
 
-  const totalPaid = hasPV
-    ? pvTotal(
-        snapshots.map((s) => ({ month: s.month, amount: s.totalRepayment })),
-        dr,
-      )
-    : simSummary.totalPaid;
+  const totalPaid = hasPV ? pvCumulativePaid : simSummary.totalPaid;
 
   const insightWrittenOff = simSummary.perLoan.some((l) => l.writtenOff);
-  const insightTotalInterest = insightCumInterest;
-  const insightTotalPrincipal = totalPaid - insightTotalInterest;
+  const insightTotalPrincipal = totalPaid - insightCumInterest;
   const insightWrittenOffBalance = insightWrittenOff ? insightLastBalance : 0;
   const insightTotalSettled = totalPaid + insightWrittenOffBalance;
 
@@ -405,9 +399,7 @@ function handleInsight(payload: InsightPayload): {
       stat: formatCompactCurrency(Math.max(0, totalPaid - totalBalance)),
       label: insightWrittenOff ? "Interest Paid (adj.)" : "Interest Paid",
       interestRatio:
-        insightTotalSettled > 0
-          ? insightTotalInterest / insightTotalSettled
-          : 0,
+        insightTotalSettled > 0 ? insightCumInterest / insightTotalSettled : 0,
       principalRatio:
         insightTotalSettled > 0
           ? insightTotalPrincipal / insightTotalSettled
@@ -577,12 +569,7 @@ function handleDetailSeries(payload: DetailSeriesPayload): DetailSeriesResult {
   }
 
   const writtenOff = summary.perLoan.some((l) => l.writtenOff);
-  const totalPaid = hasPV
-    ? pvTotal(
-        snapshots.map((s) => ({ month: s.month, amount: s.totalRepayment })),
-        dr,
-      )
-    : summary.totalPaid;
+  const totalPaid = hasPV ? pvCumPaid : summary.totalPaid;
   const writtenOffBalance = writtenOff ? lastMonthBalance : 0;
   // Adjusted interest: assume every repayment covered principal first.
   // The write-off clears whatever principal remained, so interest = excess


### PR DESCRIPTION
## Summary

Reduces code duplication and simplifies conditional logic across three files. The simulation worker was redundantly recomputing present-value totals that were already available as local variables, InsightCard was using inline percentage formatting instead of the shared `percentageFormatter`, and ChartBase had an unnecessarily verbose stack-top check.

## Context

These are pure refactoring changes with no behavioral impact. The `findLast` approach in ChartBase uses reference equality instead of filtering + dataKey comparison, the worker drops two redundant `pvTotal()` calls in favor of already-computed values, and the InsightCard rate display now uses the same formatter used elsewhere in the app.