### PR TITLE
seo: add Article structured data to guide layouts

### DIFF
--- a/src/app/guides/how-interest-works/layout.tsx
+++ b/src/app/guides/how-interest-works/layout.tsx
@@ -72,6 +72,26 @@ const faqSchema = {
   ],
 };
 
+const articleSchema = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: "Why Your Student Loan Balance Keeps Growing",
+  description:
+    "You're making repayments but your balance goes up? That's not a bug — it's how the interest works. See exactly how much interest you're being charged and why it matters less than you think.",
+  url: "https://studentloanstudy.uk/guides/how-interest-works",
+  author: {
+    "@type": "Organization",
+    name: "UK Student Loan Study",
+    url: "https://studentloanstudy.uk",
+  },
+  publisher: {
+    "@type": "Organization",
+    name: "UK Student Loan Study",
+    url: "https://studentloanstudy.uk",
+  },
+  dateModified: "2026-03-09",
+};
+
 // Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
 // Google reads JSON-LD from anywhere in the document, so this is functionally equivalent.
 export default function HowInterestWorksLayout({
@@ -88,6 +108,10 @@ export default function HowInterestWorksLayout({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
       />
       {children}
     </>

--- a/src/app/guides/moving-abroad/layout.tsx
+++ b/src/app/guides/moving-abroad/layout.tsx
@@ -86,6 +86,26 @@ const faqSchema = {
   ],
 };
 
+const articleSchema = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: "What Happens to Your Student Loan If You Move Abroad?",
+  description:
+    "Moving overseas doesn't make your student loan disappear — the SLC will find you. Here's what they expect, what the penalties look like, and how repayment thresholds change by country.",
+  url: "https://studentloanstudy.uk/guides/moving-abroad",
+  author: {
+    "@type": "Organization",
+    name: "UK Student Loan Study",
+    url: "https://studentloanstudy.uk",
+  },
+  publisher: {
+    "@type": "Organization",
+    name: "UK Student Loan Study",
+    url: "https://studentloanstudy.uk",
+  },
+  dateModified: "2026-03-09",
+};
+
 // Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
 // Google reads JSON-LD from anywhere in the document, so this is functionally equivalent.
 export default function MovingAbroadLayout({
@@ -102,6 +122,10 @@ export default function MovingAbroadLayout({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
       />
       {children}
     </>

--- a/src/app/guides/pay-upfront-or-take-loan/layout.tsx
+++ b/src/app/guides/pay-upfront-or-take-loan/layout.tsx
@@ -77,6 +77,26 @@ const faqSchema = {
   ],
 };
 
+const articleSchema = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: "Pay Tuition Upfront or Take the Loan? It's Not Obvious",
+  description:
+    "The loan feels free until you realise middle earners can repay more than the original tuition. See where the break-even point is for your expected career path.",
+  url: "https://studentloanstudy.uk/guides/pay-upfront-or-take-loan",
+  author: {
+    "@type": "Organization",
+    name: "UK Student Loan Study",
+    url: "https://studentloanstudy.uk",
+  },
+  publisher: {
+    "@type": "Organization",
+    name: "UK Student Loan Study",
+    url: "https://studentloanstudy.uk",
+  },
+  dateModified: "2026-03-09",
+};
+
 // Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
 // Google reads JSON-LD from anywhere in the document, so this is functionally equivalent.
 export default function PayUpfrontOrTakeLoanLayout({
@@ -93,6 +113,10 @@ export default function PayUpfrontOrTakeLoanLayout({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
       />
       {children}
     </>

--- a/src/app/guides/rpi-vs-cpi/layout.tsx
+++ b/src/app/guides/rpi-vs-cpi/layout.tsx
@@ -69,6 +69,26 @@ const faqSchema = {
   ],
 };
 
+const articleSchema = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: "RPI vs CPI: Why Your Student Loan Interest Outpaces Inflation",
+  description:
+    "Your student loan interest uses RPI, but 'real' inflation is measured by CPI. That gap means your balance grows faster than the cost of living.",
+  url: "https://studentloanstudy.uk/guides/rpi-vs-cpi",
+  author: {
+    "@type": "Organization",
+    name: "UK Student Loan Study",
+    url: "https://studentloanstudy.uk",
+  },
+  publisher: {
+    "@type": "Organization",
+    name: "UK Student Loan Study",
+    url: "https://studentloanstudy.uk",
+  },
+  dateModified: "2026-03-09",
+};
+
 export default function RpiVsCpiLayout({
   children,
 }: {
@@ -83,6 +103,10 @@ export default function RpiVsCpiLayout({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
       />
       {children}
     </>

--- a/src/app/guides/self-employment/layout.tsx
+++ b/src/app/guides/self-employment/layout.tsx
@@ -71,6 +71,26 @@ const faqSchema = {
   ],
 };
 
+const articleSchema = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: "Self-Employed? Your Student Loan Repayments Work Differently",
+  description:
+    "No employer deducting it from your payslip means you handle repayments through Self Assessment. Get the timing, thresholds, and mixed-income rules straight before your next tax return.",
+  url: "https://studentloanstudy.uk/guides/self-employment",
+  author: {
+    "@type": "Organization",
+    name: "UK Student Loan Study",
+    url: "https://studentloanstudy.uk",
+  },
+  publisher: {
+    "@type": "Organization",
+    name: "UK Student Loan Study",
+    url: "https://studentloanstudy.uk",
+  },
+  dateModified: "2026-03-09",
+};
+
 // Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
 // Google reads JSON-LD from anywhere in the document, so this is functionally equivalent.
 export default function SelfEmploymentLayout({
@@ -87,6 +107,10 @@ export default function SelfEmploymentLayout({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
       />
       {children}
     </>

--- a/src/app/guides/student-loan-vs-mortgage/layout.tsx
+++ b/src/app/guides/student-loan-vs-mortgage/layout.tsx
@@ -97,6 +97,26 @@ const faqSchema = {
   ],
 };
 
+const articleSchema = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: "Does Your Student Loan Affect Your Mortgage?",
+  description:
+    "Yes — and it's not about the balance. Lenders care about your monthly repayment, which quietly shrinks how much you can borrow. See the exact impact at your salary.",
+  url: "https://studentloanstudy.uk/guides/student-loan-vs-mortgage",
+  author: {
+    "@type": "Organization",
+    name: "UK Student Loan Study",
+    url: "https://studentloanstudy.uk",
+  },
+  publisher: {
+    "@type": "Organization",
+    name: "UK Student Loan Study",
+    url: "https://studentloanstudy.uk",
+  },
+  dateModified: "2026-03-09",
+};
+
 // Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
 // Google reads JSON-LD from anywhere in the document, so this is functionally equivalent.
 export default function StudentLoanVsMortgageLayout({
@@ -113,6 +133,10 @@ export default function StudentLoanVsMortgageLayout({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
       />
       {children}
     </>

--- a/src/app/sitemap.xml
+++ b/src/app/sitemap.xml
@@ -20,21 +20,27 @@
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/how-interest-works</loc>
+    <lastmod>2026-03-09</lastmod>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/rpi-vs-cpi</loc>
+    <lastmod>2026-03-09</lastmod>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/student-loan-vs-mortgage</loc>
+    <lastmod>2026-03-09</lastmod>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/pay-upfront-or-take-loan</loc>
+    <lastmod>2026-03-09</lastmod>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/moving-abroad</loc>
+    <lastmod>2026-03-09</lastmod>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/self-employment</loc>
+    <lastmod>2026-03-09</lastmod>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/our-data</loc>


### PR DESCRIPTION
## Summary

Adds JSON-LD `Article` schema markup to all six guide layout files, giving search engines structured authorship, headline, and description signals for each guide page. Also adds `<lastmod>` dates to guide entries in `sitemap.xml` so crawlers know the content was recently reviewed.

## Context

The guides already had `FAQPage` schema but lacked `Article` markup, which is the primary schema type Google uses for article-style content in search results. Adding both schemas together improves eligibility for rich results and content freshness signals.