### PR TITLE
seo: add Open Graph metadata to guide layouts

### DIFF
--- a/src/app/guides/how-interest-works/layout.tsx
+++ b/src/app/guides/how-interest-works/layout.tsx
@@ -14,6 +14,13 @@ export const metadata: Metadata = {
     "RPI student loan",
     "student loan balance growing",
   ],
+  openGraph: {
+    title: "Why Your Student Loan Balance Keeps Growing",
+    description:
+      "You're making repayments but your balance goes up? That's not a bug — it's how the interest works. See exactly how much interest you're being charged and why it matters less than you think.",
+    url: "https://studentloanstudy.uk/guides/how-interest-works",
+    type: "article",
+  },
 };
 
 const breadcrumbSchema = {

--- a/src/app/guides/moving-abroad/layout.tsx
+++ b/src/app/guides/moving-abroad/layout.tsx
@@ -12,6 +12,13 @@ export const metadata: Metadata = {
     "student loan living abroad",
     "SLC overseas income assessment",
   ],
+  openGraph: {
+    title: "What Happens to Your Student Loan If You Move Abroad?",
+    description:
+      "Moving overseas doesn't make your student loan disappear — the SLC will find you. Here's what they expect, what the penalties look like, and how repayment thresholds change by country.",
+    url: "https://studentloanstudy.uk/guides/moving-abroad",
+    type: "article",
+  },
 };
 
 const breadcrumbSchema = {

--- a/src/app/guides/pay-upfront-or-take-loan/layout.tsx
+++ b/src/app/guides/pay-upfront-or-take-loan/layout.tsx
@@ -15,6 +15,13 @@ export const metadata: Metadata = {
     "university fees UK",
     "salary growth student loan",
   ],
+  openGraph: {
+    title: "Pay Tuition Upfront or Take the Loan? It's Not Obvious",
+    description:
+      "The loan feels free until you realise middle earners can repay more than the original tuition. See where the break-even point is for your expected career path.",
+    url: "https://studentloanstudy.uk/guides/pay-upfront-or-take-loan",
+    type: "article",
+  },
 };
 
 const breadcrumbSchema = {

--- a/src/app/guides/rpi-vs-cpi/layout.tsx
+++ b/src/app/guides/rpi-vs-cpi/layout.tsx
@@ -11,6 +11,13 @@ export const metadata: Metadata = {
     "student loan inflation",
     "inflation adjusted student loan",
   ],
+  openGraph: {
+    title: "RPI vs CPI: Why Your Student Loan Interest Outpaces Inflation",
+    description:
+      "Your student loan interest uses RPI, but 'real' inflation is measured by CPI. That gap means your balance grows faster than the cost of living.",
+    url: "https://studentloanstudy.uk/guides/rpi-vs-cpi",
+    type: "article",
+  },
 };
 
 const breadcrumbSchema = {

--- a/src/app/guides/self-employment/layout.tsx
+++ b/src/app/guides/self-employment/layout.tsx
@@ -13,6 +13,13 @@ export const metadata: Metadata = {
     "student loan sole trader",
     "student loan tax return",
   ],
+  openGraph: {
+    title: "Self-Employed? Your Student Loan Repayments Work Differently",
+    description:
+      "No employer deducting it from your payslip means you handle repayments through Self Assessment. Get the timing, thresholds, and mixed-income rules straight before your next tax return.",
+    url: "https://studentloanstudy.uk/guides/self-employment",
+    type: "article",
+  },
 };
 
 const breadcrumbSchema = {

--- a/src/app/guides/student-loan-vs-mortgage/layout.tsx
+++ b/src/app/guides/student-loan-vs-mortgage/layout.tsx
@@ -14,6 +14,13 @@ export const metadata: Metadata = {
     "Plan 2 mortgage impact",
     "Plan 5 mortgage impact",
   ],
+  openGraph: {
+    title: "Does Your Student Loan Affect Your Mortgage?",
+    description:
+      "Yes — and it's not about the balance. Lenders care about your monthly repayment, which quietly shrinks how much you can borrow. See the exact impact at your salary.",
+    url: "https://studentloanstudy.uk/guides/student-loan-vs-mortgage",
+    type: "article",
+  },
 };
 
 const breadcrumbSchema = {


### PR DESCRIPTION
## Summary

Adds Open Graph metadata (`title`, `description`, `url`, `type: article`) to 6 guide layout files so that social sharing previews (Twitter/Facebook/LinkedIn/Slack etc.) display proper titles and descriptions instead of falling back to generic site metadata.

## Context

Guides covered: how-interest-works, moving-abroad, pay-upfront-or-take-loan, rpi-vs-cpi, self-employment, student-loan-vs-mortgage. Each guide gets a bespoke OG title and description tailored to its content.