### PR TITLE
seo: add Open Graph metadata to calculator page layouts

### DIFF
--- a/src/app/balance/layout.tsx
+++ b/src/app/balance/layout.tsx
@@ -12,6 +12,13 @@ export const metadata: Metadata = {
     "student loan balance over time",
     "UK student loan payoff date",
   ],
+  openGraph: {
+    title: "How Long to Pay Off Your Student Loan — Payoff Timeline Calculator",
+    description:
+      "Find out how long it takes to pay off your UK student loan. See your payoff timeline, balance trajectory, and whether your loan will be paid off or written off — based on your salary and plan type.",
+    url: "https://studentloanstudy.uk/balance",
+    type: "website",
+  },
 };
 
 const breadcrumbSchema = {

--- a/src/app/effective-rate/layout.tsx
+++ b/src/app/effective-rate/layout.tsx
@@ -10,6 +10,13 @@ export const metadata: Metadata = {
     "UK student loan interest rate comparison",
     "student loan vs base rate",
   ],
+  openGraph: {
+    title: "Effective Rate — True Cost of Your Student Loan",
+    description:
+      "Discover the true effective annual rate of your UK student loan and compare it to the Bank of England base rate. See how your rate changes with different salaries.",
+    url: "https://studentloanstudy.uk/effective-rate",
+    type: "website",
+  },
 };
 
 const breadcrumbSchema = {

--- a/src/app/interest/layout.tsx
+++ b/src/app/interest/layout.tsx
@@ -10,6 +10,13 @@ export const metadata: Metadata = {
     "UK student loan interest cost",
     "student loan cost of borrowing",
   ],
+  openGraph: {
+    title: "Interest Paid — Student Loan Interest Breakdown",
+    description:
+      "See a year-by-year breakdown of how your UK student loan repayments split between interest and principal. Understand whether you're reducing your balance — and how write-off affects the true cost.",
+    url: "https://studentloanstudy.uk/interest",
+    type: "website",
+  },
 };
 
 const breadcrumbSchema = {

--- a/src/app/overpay/layout.tsx
+++ b/src/app/overpay/layout.tsx
@@ -14,6 +14,14 @@ export const metadata: Metadata = {
     "Plan 5 overpayment",
     "student loan vs investing",
   ],
+  openGraph: {
+    title:
+      "Student Loan Overpayment Calculator — Should You Overpay or Invest?",
+    description:
+      "Free UK student loan overpayment calculator. Compare overpaying your loan vs investing in an index fund — see which strategy leaves you better off based on your salary, balance, and plan type.",
+    url: "https://studentloanstudy.uk/overpay",
+    type: "website",
+  },
 };
 
 const breadcrumbSchema = {

--- a/src/app/repaid/layout.tsx
+++ b/src/app/repaid/layout.tsx
@@ -12,6 +12,13 @@ export const metadata: Metadata = {
     "student loan repayments over time",
     "student loan cumulative repayments",
   ],
+  openGraph: {
+    title: "Total Repayments — Student Loan Total Cost Calculator",
+    description:
+      "Find out how much you'll repay on your UK student loan in total. See cumulative repayments over time, monthly costs, and whether you'll pay more or less than you borrowed — based on your salary and plan type.",
+    url: "https://studentloanstudy.uk/repaid",
+    type: "website",
+  },
 };
 
 const breadcrumbSchema = {

--- a/src/app/which-plan/layout.tsx
+++ b/src/app/which-plan/layout.tsx
@@ -7,6 +7,13 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "/which-plan",
   },
+  openGraph: {
+    title: "What Student Loan Plan Am I On?",
+    description:
+      "Not sure which plan you're on? Answer 3 quick questions and we'll tell you — plus what it means for your repayments, interest rate, and write-off date.",
+    url: "https://studentloanstudy.uk/which-plan",
+    type: "website",
+  },
 };
 
 const faqSchema = {


### PR DESCRIPTION
## Summary

Adds Open Graph metadata (`title`, `description`, `url`, `type`) to the six calculator/tool page layouts — balance, effective-rate, interest, overpay, repaid, and which-plan. This extends the OG coverage started in #259 (which covered guide pages) to the remaining public-facing pages, improving link previews when shared on social media and messaging platforms.

## Context

Each page gets a tailored OG title and description matching its existing SEO metadata style. All URLs use the canonical `studentloanstudy.uk` domain. The root-level `opengraph-image.png` will be inherited as the default image for these pages.