### PR TITLE
seo: add canonical URLs to guide page layouts

### DIFF
--- a/src/app/guides/how-interest-works/layout.tsx
+++ b/src/app/guides/how-interest-works/layout.tsx
@@ -14,6 +14,9 @@ export const metadata: Metadata = {
     "RPI student loan",
     "student loan balance growing",
   ],
+  alternates: {
+    canonical: "/guides/how-interest-works",
+  },
   openGraph: {
     title: "Why Your Student Loan Balance Keeps Growing",
     description:

--- a/src/app/guides/moving-abroad/layout.tsx
+++ b/src/app/guides/moving-abroad/layout.tsx
@@ -12,6 +12,9 @@ export const metadata: Metadata = {
     "student loan living abroad",
     "SLC overseas income assessment",
   ],
+  alternates: {
+    canonical: "/guides/moving-abroad",
+  },
   openGraph: {
     title: "What Happens to Your Student Loan If You Move Abroad?",
     description:

--- a/src/app/guides/pay-upfront-or-take-loan/layout.tsx
+++ b/src/app/guides/pay-upfront-or-take-loan/layout.tsx
@@ -15,6 +15,9 @@ export const metadata: Metadata = {
     "university fees UK",
     "salary growth student loan",
   ],
+  alternates: {
+    canonical: "/guides/pay-upfront-or-take-loan",
+  },
   openGraph: {
     title: "Pay Tuition Upfront or Take the Loan? It's Not Obvious",
     description:

--- a/src/app/guides/plan-2-vs-plan-5/layout.tsx
+++ b/src/app/guides/plan-2-vs-plan-5/layout.tsx
@@ -17,6 +17,9 @@ export const metadata: Metadata = {
     "student loan write-off",
     "plan 2 vs plan 5 threshold",
   ],
+  alternates: {
+    canonical: "/guides/plan-2-vs-plan-5",
+  },
   openGraph: {
     title: "Plan 2 vs Plan 5: Which Student Loan Costs More?",
     description,

--- a/src/app/guides/rpi-vs-cpi/layout.tsx
+++ b/src/app/guides/rpi-vs-cpi/layout.tsx
@@ -11,6 +11,9 @@ export const metadata: Metadata = {
     "student loan inflation",
     "inflation adjusted student loan",
   ],
+  alternates: {
+    canonical: "/guides/rpi-vs-cpi",
+  },
   openGraph: {
     title: "RPI vs CPI: Why Your Student Loan Interest Outpaces Inflation",
     description:

--- a/src/app/guides/self-employment/layout.tsx
+++ b/src/app/guides/self-employment/layout.tsx
@@ -13,6 +13,9 @@ export const metadata: Metadata = {
     "student loan sole trader",
     "student loan tax return",
   ],
+  alternates: {
+    canonical: "/guides/self-employment",
+  },
   openGraph: {
     title: "Self-Employed? Your Student Loan Repayments Work Differently",
     description:

--- a/src/app/guides/student-loan-vs-mortgage/layout.tsx
+++ b/src/app/guides/student-loan-vs-mortgage/layout.tsx
@@ -14,6 +14,9 @@ export const metadata: Metadata = {
     "Plan 2 mortgage impact",
     "Plan 5 mortgage impact",
   ],
+  alternates: {
+    canonical: "/guides/student-loan-vs-mortgage",
+  },
   openGraph: {
     title: "Does Your Student Loan Affect Your Mortgage?",
     description:


### PR DESCRIPTION
## Summary

Adds `alternates.canonical` metadata to all seven guide layout files. This tells search engines the preferred URL for each guide, preventing duplicate content issues and consolidating ranking signals.

## Context

Follows the recent Open Graph and structured data additions (#258, #259). Canonical URLs are a standard SEO best practice — without them, search engines may treat query-parameterised or trailing-slash variants as separate pages.