### PR TITLE
seo: add datePublished to guide Article structured data

### DIFF
--- a/src/app/guides/how-interest-works/layout.tsx
+++ b/src/app/guides/how-interest-works/layout.tsx
@@ -99,6 +99,7 @@ const articleSchema = {
     name: "UK Student Loan Study",
     url: "https://studentloanstudy.uk",
   },
+  datePublished: "2026-02-14",
   dateModified: "2026-03-09",
 };
 

--- a/src/app/guides/moving-abroad/layout.tsx
+++ b/src/app/guides/moving-abroad/layout.tsx
@@ -113,6 +113,7 @@ const articleSchema = {
     name: "UK Student Loan Study",
     url: "https://studentloanstudy.uk",
   },
+  datePublished: "2026-02-14",
   dateModified: "2026-03-09",
 };
 

--- a/src/app/guides/pay-upfront-or-take-loan/layout.tsx
+++ b/src/app/guides/pay-upfront-or-take-loan/layout.tsx
@@ -104,6 +104,7 @@ const articleSchema = {
     name: "UK Student Loan Study",
     url: "https://studentloanstudy.uk",
   },
+  datePublished: "2026-02-14",
   dateModified: "2026-03-09",
 };
 

--- a/src/app/guides/plan-2-vs-plan-5/layout.tsx
+++ b/src/app/guides/plan-2-vs-plan-5/layout.tsx
@@ -121,6 +121,7 @@ const articleSchema = {
     name: "UK Student Loan Study",
     url: "https://studentloanstudy.uk",
   },
+  datePublished: "2026-02-14",
   dateModified: "2026-02-20",
 };
 

--- a/src/app/guides/rpi-vs-cpi/layout.tsx
+++ b/src/app/guides/rpi-vs-cpi/layout.tsx
@@ -96,6 +96,7 @@ const articleSchema = {
     name: "UK Student Loan Study",
     url: "https://studentloanstudy.uk",
   },
+  datePublished: "2026-02-18",
   dateModified: "2026-03-09",
 };
 

--- a/src/app/guides/self-employment/layout.tsx
+++ b/src/app/guides/self-employment/layout.tsx
@@ -98,6 +98,7 @@ const articleSchema = {
     name: "UK Student Loan Study",
     url: "https://studentloanstudy.uk",
   },
+  datePublished: "2026-02-14",
   dateModified: "2026-03-09",
 };
 

--- a/src/app/guides/student-loan-vs-mortgage/layout.tsx
+++ b/src/app/guides/student-loan-vs-mortgage/layout.tsx
@@ -124,6 +124,7 @@ const articleSchema = {
     name: "UK Student Loan Study",
     url: "https://studentloanstudy.uk",
   },
+  datePublished: "2026-02-14",
   dateModified: "2026-03-09",
 };
 


### PR DESCRIPTION
## Summary

Adds the `datePublished` property to the Article JSON-LD schema on all seven guide pages. Search engines recommend both `datePublished` and `dateModified` for Article structured data — previously only `dateModified` was present.

## Context

Each guide's publication date was determined from the commit history when the guide was first added. Most guides were published on 2026-02-14, with the RPI vs CPI guide published on 2026-02-18.