### PR TITLE
seo: add ItemList structured data to guides layout

### DIFF
--- a/src/app/guides/layout.tsx
+++ b/src/app/guides/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { GUIDES } from "@/lib/guides";
 
 export const metadata: Metadata = {
   title: "Student Loan Guides — The Stuff They Don't Tell You",
@@ -14,6 +15,21 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "/guides",
   },
+};
+
+const itemListSchema = {
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  name: "UK Student Loan Guides",
+  description:
+    "In-depth guides to help you understand UK student loan repayment, interest, and how it fits into your wider finances.",
+  numberOfItems: GUIDES.length,
+  itemListElement: GUIDES.map((guide, index) => ({
+    "@type": "ListItem",
+    position: index + 1,
+    name: guide.title,
+    url: `https://studentloanstudy.uk/guides/${guide.slug}`,
+  })),
 };
 
 const breadcrumbSchema = {
@@ -42,6 +58,10 @@ export default function GuidesLayout({
 }) {
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListSchema) }}
+      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}


### PR DESCRIPTION
## Summary

Adds an `ItemList` JSON-LD schema to the guides index layout so search engines can understand the page as a curated list of guide entries, each with a position, title, and canonical URL. This continues the series of structured data improvements (Article schemas, canonical URLs, Open Graph metadata).

## Context

The `GUIDES` array from `src/lib/guides.ts` is used to dynamically generate the list items, keeping the schema in sync with the actual guide pages.