### PR TITLE
seo: add canonical URLs to calculator page layouts

### DIFF
--- a/src/app/balance/layout.tsx
+++ b/src/app/balance/layout.tsx
@@ -12,6 +12,9 @@ export const metadata: Metadata = {
     "student loan balance over time",
     "UK student loan payoff date",
   ],
+  alternates: {
+    canonical: "/balance",
+  },
   openGraph: {
     title: "How Long to Pay Off Your Student Loan — Payoff Timeline Calculator",
     description:

--- a/src/app/effective-rate/layout.tsx
+++ b/src/app/effective-rate/layout.tsx
@@ -10,6 +10,9 @@ export const metadata: Metadata = {
     "UK student loan interest rate comparison",
     "student loan vs base rate",
   ],
+  alternates: {
+    canonical: "/effective-rate",
+  },
   openGraph: {
     title: "Effective Rate — True Cost of Your Student Loan",
     description:

--- a/src/app/interest/layout.tsx
+++ b/src/app/interest/layout.tsx
@@ -10,6 +10,9 @@ export const metadata: Metadata = {
     "UK student loan interest cost",
     "student loan cost of borrowing",
   ],
+  alternates: {
+    canonical: "/interest",
+  },
   openGraph: {
     title: "Interest Paid — Student Loan Interest Breakdown",
     description:

--- a/src/app/overpay/layout.tsx
+++ b/src/app/overpay/layout.tsx
@@ -14,6 +14,9 @@ export const metadata: Metadata = {
     "Plan 5 overpayment",
     "student loan vs investing",
   ],
+  alternates: {
+    canonical: "/overpay",
+  },
   openGraph: {
     title:
       "Student Loan Overpayment Calculator — Should You Overpay or Invest?",

--- a/src/app/repaid/layout.tsx
+++ b/src/app/repaid/layout.tsx
@@ -12,6 +12,9 @@ export const metadata: Metadata = {
     "student loan repayments over time",
     "student loan cumulative repayments",
   ],
+  alternates: {
+    canonical: "/repaid",
+  },
   openGraph: {
     title: "Total Repayments — Student Loan Total Cost Calculator",
     description:


### PR DESCRIPTION
## Summary

Adds canonical URL metadata to the five calculator page layouts (balance, effective-rate, interest, overpay, repaid) to prevent duplicate content issues and consolidate SEO signals. This follows the same pattern used for guide page layouts in #261.

## Context

The guide pages already have canonical URLs (#261). This extends the same treatment to all calculator detail pages for consistent SEO coverage across the site.