### PR TITLE
refactor: remove unused totalRepayment insight card

### DIFF
--- a/src/hooks/useInsightCardsData.test.tsx
+++ b/src/hooks/useInsightCardsData.test.tsx
@@ -40,7 +40,7 @@ describe("usePersonalizedResults (cards)", () => {
     expect(result.current.cards).toBeNull();
   });
 
-  it("returns all 5 card datasets with stat and label", async () => {
+  it("returns all 4 card datasets with stat and label", async () => {
     const { result } = renderHook(() => usePersonalizedResults(), {
       wrapper: createWrapper(),
     });
@@ -68,10 +68,6 @@ describe("usePersonalizedResults (cards)", () => {
     expect(cards.effectiveRate.stat).not.toBe("\u2014");
     expect(cards.effectiveRate.effectiveRate).toBeGreaterThan(0);
     expect(cards.effectiveRate.boeRate).toBeGreaterThan(0);
-
-    // Total repayment by salary sparkline
-    expect(cards.totalRepayment.data.length).toBeGreaterThan(0);
-    expect(cards.totalRepayment.stat).not.toBe("\u2014");
   });
 
   it("balance sparkline starts at initial balance and decreases", async () => {
@@ -156,7 +152,5 @@ describe("usePersonalizedResults (cards)", () => {
     expect(cards.interest.interestRatio).toBe(0);
     expect(cards.effectiveRate.stat).toBe("\u2014");
     expect(cards.effectiveRate.effectiveRate).toBe(0);
-    expect(cards.totalRepayment.data).toHaveLength(0);
-    expect(cards.totalRepayment.stat).toBe("\u2014");
   });
 });

--- a/src/types/insightCards.ts
+++ b/src/types/insightCards.ts
@@ -35,6 +35,4 @@ export interface InsightCardsResult {
   interest: InterestCardData;
   effectiveRate: EffectiveRateCardData;
   cumulative: InsightCardData;
-  /** Downsampled total-repayment-by-salary sparkline for the calculator card */
-  totalRepayment: InsightCardData;
 }

--- a/src/workers/simulation.worker.ts
+++ b/src/workers/simulation.worker.ts
@@ -273,7 +273,6 @@ function handleInsight(payload: InsightPayload): {
       boeRate: payload.boeBaseRate / 100,
     },
     cumulative: { data: [], stat: "\u2014", label: "Total Cost" },
-    totalRepayment: { data: [], stat: "\u2014", label: "Total Repayment" },
   };
 
   if (totalBalance <= 0) {
@@ -366,33 +365,6 @@ function handleInsight(payload: InsightPayload): {
 
   const cumulativeStat = `${formatCompactCurrency(totalPaid)} total`;
 
-  // --- Salary series sparkline (downsampled every 5k) ---
-  const SPARKLINE_STEP = 5_000;
-  const salarySeriesData: { month: number; value: number }[] = [];
-  for (let sal = MIN_SALARY; sal <= MAX_SALARY; sal += SPARKLINE_STEP) {
-    const salResult = simulate({
-      loans: payload.loans,
-      annualSalary: sal,
-      monthsElapsed: 0,
-      salaryGrowthRate: payload.salaryGrowthRate,
-      thresholdGrowthRate: payload.thresholdGrowthRate,
-      rpiRate: payload.rpiRate,
-      boeBaseRate: payload.boeBaseRate,
-    });
-    let salTotalPaid = salResult.summary.totalPaid;
-    if (hasPV) {
-      salTotalPaid = pvTotal(
-        salResult.snapshots.map((s) => ({
-          month: s.month,
-          amount: s.totalRepayment,
-        })),
-        dr,
-      );
-    }
-    // Use salary as the "month" axis for the sparkline
-    salarySeriesData.push({ month: sal, value: salTotalPaid });
-  }
-
   const cards: InsightCardsResult = {
     balance: { data: balanceData, stat: balanceStat, label: "Duration" },
     interest: {
@@ -419,11 +391,6 @@ function handleInsight(payload: InsightPayload): {
       data: cumulativeData,
       stat: cumulativeStat,
       label: "Total Cost",
-    },
-    totalRepayment: {
-      data: salarySeriesData,
-      stat: `${formatCompactCurrency(totalPaid)} total`,
-      label: "Total Repayment by Salary",
     },
   };
 


### PR DESCRIPTION
## Summary

Removes the `totalRepayment` sparkline card from the insight cards system. This card was no longer rendered in the UI, making its computation dead code. The removal also eliminates an expensive loop in the simulation worker that ran a full simulation for every 5k salary step to build the salary-series sparkline data.

## Context

The insight cards were reduced from 5 to 4 when the total-repayment-by-salary visualization was dropped from the home page. This cleans up the remaining dead code path in the worker, type definition, and tests.