### PR TITLE
refactor: replace pixel-based BrandIcon sizing with CVA variants

### DIFF
--- a/src/components/brand/BrandGuidelinesPage.tsx
+++ b/src/components/brand/BrandGuidelinesPage.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Card } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
-import { BrandIcon, BRAND_HEX } from "./BrandIcon";
+import { BrandIcon, BRAND_HEX, type BrandIconSize } from "./BrandIcon";
 import { BrandLogo } from "./BrandLogo";
 
 const BRAND_SWATCHES = [
@@ -19,7 +19,7 @@ const BRAND_SWATCHES = [
   { name: "Primary Emerald", hex: BRAND_HEX.emerald },
 ];
 
-const ICON_SIZES = [64, 48, 32, 16];
+const ICON_SIZES: BrandIconSize[] = ["2xl", "lg", "md", "xs"];
 
 const CORE_TOKENS = [
   { name: "Primary", var: "--primary" },
@@ -139,7 +139,7 @@ export function BrandGuidelinesPage() {
           {ICON_SIZES.map((size) => (
             <div key={size} className="flex flex-col items-center gap-2">
               <BrandIcon size={size} />
-              <span className="text-xs text-muted-foreground">{size}px</span>
+              <span className="text-xs text-muted-foreground">{size}</span>
             </div>
           ))}
         </div>
@@ -260,7 +260,7 @@ export function BrandGuidelinesPage() {
       {/* Section: Logo Anatomy */}
       <Section title="LOGO ANATOMY">
         <Card className="flex items-center gap-3.5 p-8">
-          <BrandLogo size="large" />
+          <BrandLogo size="xl" />
         </Card>
         <ul className="mt-6 space-y-3">
           {LOGO_ANATOMY.map((point) => (

--- a/src/components/brand/BrandIcon.tsx
+++ b/src/components/brand/BrandIcon.tsx
@@ -1,3 +1,4 @@
+import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 /** Brand hex constants — the two fixed colors used in the icon and logo. */
@@ -6,33 +7,44 @@ export const BRAND_HEX = {
   emerald: "#34D399",
 } as const;
 
+const brandIconVariants = cva("relative overflow-hidden", {
+  variants: {
+    size: {
+      xs: "size-4 rounded-sm",
+      sm: "size-6 rounded-md",
+      md: "size-8 rounded-lg",
+      default: "size-11 rounded-xl",
+      lg: "size-12 rounded-xl",
+      xl: "size-14 rounded-2xl",
+      "2xl": "size-16 rounded-2xl",
+    },
+  },
+  defaultVariants: {
+    size: "default",
+  },
+});
+
+export type BrandIconSize = NonNullable<
+  VariantProps<typeof brandIconVariants>["size"]
+>;
+
 interface BrandIconProps {
-  size?: number;
+  size?: BrandIconSize;
   className?: string;
 }
 
-export function BrandIcon({ size = 44, className }: BrandIconProps) {
-  // Calculate corner radius proportional to size (roughly 10/44 ratio)
-  const cornerRadius = Math.round((size / 44) * 10);
-
+export function BrandIcon({ size = "default", className }: BrandIconProps) {
   return (
     <div
-      className={cn("relative overflow-hidden", className)}
-      style={{
-        width: size,
-        height: size,
-        borderRadius: cornerRadius,
-        backgroundColor: BRAND_HEX.emerald,
-      }}
+      className={cn(brandIconVariants({ size, className }))}
+      style={{ backgroundColor: BRAND_HEX.emerald }}
     >
       <svg
-        width={size}
-        height={size}
         viewBox="0 0 44 44"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
         aria-hidden="true"
-        className="absolute top-0 left-0"
+        className="absolute inset-0 size-full"
       >
         <path
           d="M44 44l0-20q-11-16-22-12-11 5-22 16l0 16z"

--- a/src/components/brand/BrandLogo.tsx
+++ b/src/components/brand/BrandLogo.tsx
@@ -1,24 +1,23 @@
 import { cn } from "@/lib/utils";
-import { BrandIcon } from "./BrandIcon";
+import { BrandIcon, type BrandIconSize } from "./BrandIcon";
 
 interface BrandLogoProps {
-  size?: "small" | "default" | "large";
+  size?: Extract<BrandIconSize, "sm" | "default" | "xl">;
   className?: string;
 }
 
 const SIZE_CONFIG = {
-  small: { icon: 24, fontSize: 16, shadow: { x: 1, y: 3 }, gap: 8 },
-  default: { icon: 44, fontSize: 19, shadow: { x: 2, y: 4 }, gap: 12 },
-  large: { icon: 56, fontSize: 24, shadow: { x: 2, y: 5 }, gap: 14 },
+  sm: { fontSize: 16, shadow: { x: 1, y: 3 }, gap: 8 },
+  default: { fontSize: 19, shadow: { x: 2, y: 4 }, gap: 12 },
+  xl: { fontSize: 24, shadow: { x: 2, y: 5 }, gap: 14 },
 } as const;
 
 export function BrandLogo({ size = "default", className }: BrandLogoProps) {
-  const config = SIZE_CONFIG[size];
-  const { icon: iconSize, fontSize, shadow: shadowOffset, gap } = config;
+  const { fontSize, shadow: shadowOffset, gap } = SIZE_CONFIG[size];
 
   return (
     <div className={cn("flex items-center", className)} style={{ gap }}>
-      <BrandIcon size={iconSize} />
+      <BrandIcon size={size} />
       <div className="relative">
         {/* Shadow layer */}
         <span

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -21,7 +21,7 @@ export function Header({ repaymentYear }: HeaderProps) {
         <header className="relative rounded-xl border bg-muted/50 px-3 pt-2 pb-4 shadow-lg backdrop-blur-sm sm:pb-2">
           <div className="flex items-center justify-between gap-3">
             <Link href="/" aria-label="Go to home page">
-              <BrandLogo size="small" />
+              <BrandLogo size="sm" />
             </Link>
             <div className="flex shrink-0 items-center gap-2">
               <div className="hidden sm:block">


### PR DESCRIPTION
## Summary

Replace inline pixel-based sizing in `BrandIcon` with class-variance-authority (CVA) variants using standard Tailwind size tokens. This eliminates runtime style calculations (proportional corner radius, explicit width/height) in favour of declarative variant classes, aligning with the project's no-arbitrary-values rule.

`BrandLogo` size props are updated from string literals (`"small"`, `"large"`) to match the new icon size tokens (`"sm"`, `"xl"`), and `BrandGuidelinesPage` switches from numeric pixel sizes to named variants.

## Context

`BrandIcon` previously used a numeric `size` prop with inline styles for width, height, border-radius, and SVG dimensions. This meant every size was an arbitrary pixel value, and the corner radius was computed at render time. CVA variants replace all of this with Tailwind's `size-*` and `rounded-*` utilities, keeping the component consistent with the rest of the design system.