### PR TITLE
feat: expand student loan vs mortgage guide

### DIFF
--- a/src/app/guides/student-loan-vs-mortgage/layout.tsx
+++ b/src/app/guides/student-loan-vs-mortgage/layout.tsx
@@ -7,10 +7,14 @@ export const metadata: Metadata = {
   description:
     "Yes — and it's not about the balance. Lenders care about your monthly repayment, which quietly shrinks how much you can borrow. See the exact impact at your salary.",
   keywords: [
+    "student loan mortgage uk",
+    "does student loan affect mortgage uk",
     "student loan mortgage",
     "mortgage affordability student loan",
     "student loan affect mortgage",
     "student loan borrowing power",
+    "student loan credit score mortgage",
+    "pay off student loan before mortgage",
     "Plan 2 mortgage impact",
     "Plan 5 mortgage impact",
   ],
@@ -104,6 +108,14 @@ const faqSchema = {
         text: "Yes, but not as a debt. Mortgage lenders deduct your monthly student loan repayment from your gross income before applying their affordability multiplier. This means the higher your salary (and therefore your repayment), the bigger the reduction in borrowing power — even though the loan itself doesn't appear on your credit file.",
       },
     },
+    {
+      "@type": "Question",
+      name: "Should I pay off my student loan before buying a house?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Almost certainly not. The money is usually better spent on a larger deposit, which unlocks lower mortgage interest rates and saves more over the mortgage term. Paying down your student loan only reduces your monthly repayment if it brings the balance to zero — otherwise the repayment stays the same because it's based on salary, not balance. Any remaining balance is eventually written off.",
+      },
+    },
   ],
 };
 
@@ -125,7 +137,7 @@ const articleSchema = {
     url: "https://studentloanstudy.uk",
   },
   datePublished: "2026-02-14",
-  dateModified: "2026-03-09",
+  dateModified: "2026-03-14",
 };
 
 // Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).

--- a/src/components/guides/student-loan-vs-mortgage/BorrowingReductionChart.tsx
+++ b/src/components/guides/student-loan-vs-mortgage/BorrowingReductionChart.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
+import type { ChartConfig } from "@/components/ui/chart";
+import { PLAN_CONFIGS } from "@/lib/loans/plans";
+
+const MULTIPLIER = 4.5;
+
+const chartConfig = {
+  plan2: {
+    label: "Plan 2",
+    color: "var(--chart-1)",
+  },
+  plan5: {
+    label: "Plan 5",
+    color: "oklch(0.7 0.15 50)",
+  },
+} satisfies ChartConfig;
+
+function buildChartData() {
+  const data: Array<{ salary: number; plan2: number; plan5: number }> = [];
+
+  for (let salary = 25000; salary <= 80000; salary += 1000) {
+    const monthlyIncome = salary / 12;
+
+    const plan2Monthly = Math.max(
+      0,
+      (monthlyIncome - PLAN_CONFIGS.PLAN_2.monthlyThreshold) *
+        PLAN_CONFIGS.PLAN_2.repaymentRate,
+    );
+    const plan5Monthly = Math.max(
+      0,
+      (monthlyIncome - PLAN_CONFIGS.PLAN_5.monthlyThreshold) *
+        PLAN_CONFIGS.PLAN_5.repaymentRate,
+    );
+
+    data.push({
+      salary,
+      plan2: Math.round(plan2Monthly * 12 * MULTIPLIER),
+      plan5: Math.round(plan5Monthly * 12 * MULTIPLIER),
+    });
+  }
+
+  return data;
+}
+
+const data = buildChartData();
+
+const xFormatter = (value: number) => `£${String(value / 1000)}k`;
+const yFormatter = (value: number) => `£${String(Math.round(value / 1000))}k`;
+
+export function BorrowingReductionChart() {
+  return (
+    <ChartBase
+      type="line"
+      data={data}
+      xDataKey="salary"
+      xLabel="Annual salary"
+      xFormatter={xFormatter}
+      yLabel="Mortgage reduction"
+      yFormatter={yFormatter}
+      ariaLabel="Line chart showing estimated mortgage borrowing reduction caused by student loan repayments for Plan 2 and Plan 5"
+      chartConfig={chartConfig}
+      series={[{ dataKey: "plan2" }, { dataKey: "plan5" }]}
+      showLegend
+    />
+  );
+}

--- a/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
+++ b/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/breadcrumb";
 import { formatGBP } from "@/lib/format";
 import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
+import { BorrowingReductionChart } from "./BorrowingReductionChart";
 import { RepaymentImpactChart } from "./RepaymentImpactChart";
 
 const plan2Threshold = PLAN_DISPLAY_INFO.PLAN_2.yearlyThreshold;
@@ -144,15 +145,156 @@ export function MortgageGuide() {
               repayment is roughly {formatGBP(example60kMonthly)}, trimming
               potential borrowing by about{" "}
               {formatGBP(example60kMortgageReduction)} on the same multiplier.
-              Use the{" "}
+              The chart below shows the full picture across the salary range.
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Estimated Mortgage Reduction by Salary
+          </Heading>
+          <div className="h-75 sm:h-90">
+            <BorrowingReductionChart />
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Estimated reduction based on a 4.5&times; income multiplier applied
+            to the annualised student loan repayment. Actual lending criteria
+            vary by provider.
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Does a Student Loan Count as Debt for a Mortgage?
+          </Heading>
+          <div className="space-y-3 text-muted-foreground">
+            <p>
+              No. A UK student loan is <strong>not</strong> treated as
+              conventional debt by mortgage lenders. Unlike a personal loan or
+              credit card balance, your student loan does not appear on your
+              credit report and is not included in debt-to-income ratios.
+            </p>
+            <p>
+              What lenders do care about is the monthly repayment. Because
+              repayments are deducted from your salary before you receive it
+              (like tax), lenders treat it as a committed outgoing that reduces
+              your disposable income. The loan balance itself &mdash; whether
+              it&rsquo;s &pound;20,000 or &pound;60,000 &mdash; is irrelevant to
+              the mortgage application.
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Does a Student Loan Affect Your Credit Score?
+          </Heading>
+          <div className="space-y-3 text-muted-foreground">
+            <p>
+              No. The Student Loans Company (SLC) does not report to credit
+              reference agencies like Experian, Equifax, or TransUnion. Your
+              student loan balance and repayment history are completely
+              invisible on your credit file.
+            </p>
+            <p>
+              This means a student loan cannot lower your credit score, trigger
+              a hard search, or show up as an outstanding liability. Lenders
+              learn about your repayment only through payslips and bank
+              statements during the affordability assessment, not from your
+              credit report.
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Should You Pay Off Your Student Loan Before Buying a House?
+          </Heading>
+          <div className="space-y-3 text-muted-foreground">
+            <p>
+              Almost certainly not. The money you would use to clear (or reduce)
+              your student loan balance would likely be better spent on a larger
+              deposit. Here&rsquo;s why:
+            </p>
+            <ul className="list-inside list-disc space-y-2">
+              <li>
+                A larger deposit unlocks lower mortgage interest rates (lower
+                LTV bands), saving you far more over the mortgage term than the
+                student loan repayment costs.
+              </li>
+              <li>
+                Paying off &pound;10,000 of student loan debt would only reduce
+                your monthly repayment if it brings the balance to zero. If you
+                still owe money afterwards, your monthly repayment stays exactly
+                the same because it&rsquo;s based on salary, not balance.
+              </li>
+              <li>
+                Any remaining student loan balance is written off after{" "}
+                {PLAN_CONFIGS.PLAN_2.writeOffYears} years (Plan 2) or{" "}
+                {PLAN_CONFIGS.PLAN_5.writeOffYears} years (Plan 5). Many
+                graduates never repay the full amount, so overpaying can mean
+                giving away money you would never have had to pay.
+              </li>
+            </ul>
+            <p>
+              The only scenario where clearing the loan first might help is if
+              you are very close to paying it off anyway and eliminating the
+              monthly repayment would meaningfully boost your affordability. Use
+              the{" "}
               <Link
                 href="/"
                 className="text-primary underline underline-offset-4 hover:text-primary/80"
               >
                 student loan repayment calculator
               </Link>{" "}
-              to see your exact monthly repayment at your salary.
+              to check how close you are.
             </p>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Tips for Mortgage Applicants with Student Loans
+          </Heading>
+          <div className="space-y-3 text-muted-foreground">
+            <ol className="list-inside list-decimal space-y-2">
+              <li>
+                <strong>Know your monthly repayment.</strong> Lenders will ask
+                for it. Check a recent payslip or use the{" "}
+                <Link
+                  href="/"
+                  className="text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  calculator
+                </Link>{" "}
+                to confirm the exact amount.
+              </li>
+              <li>
+                <strong>Prioritise your deposit over loan repayment.</strong>{" "}
+                Every extra pound in your deposit does more for your mortgage
+                rate than paying down a student loan that may eventually be
+                written off.
+              </li>
+              <li>
+                <strong>Factor in salary growth.</strong> If you expect a pay
+                rise, your student loan repayment will increase too. Some
+                lenders stress-test affordability at a higher salary, so be
+                prepared for questions about future income.
+              </li>
+              <li>
+                <strong>Compare lenders.</strong> Different lenders treat
+                student loan repayments differently in their affordability
+                models. A mortgage broker can help identify lenders whose
+                criteria are more favourable for borrowers with student loans.
+              </li>
+              <li>
+                <strong>Keep other debts low.</strong> Since your student loan
+                repayment already reduces disposable income, minimising credit
+                card balances, car finance, and other committed spending will
+                maximise the amount you can borrow.
+              </li>
+            </ol>
           </div>
         </section>
 
@@ -163,15 +305,16 @@ export function MortgageGuide() {
           <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
             <li>
               A student loan is <strong>not</strong> conventional debt &mdash;
-              it won&rsquo;t appear on your credit report.
+              it won&rsquo;t appear on your credit report or affect your credit
+              score.
             </li>
             <li>
               Lenders deduct your monthly repayment when calculating how much
               you can borrow, reducing your affordability.
             </li>
             <li>
-              Your credit score is <strong>not</strong> affected by having a
-              student loan.
+              The loan balance is irrelevant &mdash; only the monthly repayment
+              matters to lenders.
             </li>
             <li>
               Any remaining balance is written off after{" "}
@@ -180,15 +323,18 @@ export function MortgageGuide() {
               never chased for unpaid amounts.
             </li>
             <li>
+              Prioritise a bigger deposit over paying off your student loan
+              &mdash; it unlocks better mortgage rates and saves more long-term.
+            </li>
+            <li>
               <Link
                 href="/overpay"
                 className="text-primary underline underline-offset-4 hover:text-primary/80"
               >
                 Overpaying your student loan
               </Link>{" "}
-              to boost mortgage affordability rarely makes sense &mdash; the
-              reduction in borrowing power is modest compared to deposit
-              savings.
+              to boost mortgage affordability rarely makes sense unless
+              you&rsquo;re very close to clearing the balance entirely.
             </li>
           </ul>
         </section>


### PR DESCRIPTION
## Summary

Expands the student loan vs mortgage guide to target high-impression search queries identified in Google Search Console (453 impressions, 0 clicks). Adds four new content sections answering common questions (debt classification, credit score impact, pay-off-before-buying advice, and applicant tips), a borrowing reduction chart showing mortgage impact across the salary range, a new FAQ entry with structured data, and additional SEO keywords.

## Context

Issue #277 identified significant search demand for mortgage-related student loan queries where the site had zero content ranking. The new sections are structured around People Also Ask questions to maximise featured snippet eligibility. The borrowing reduction chart complements the existing repayment impact chart by visualising the mortgage affordability reduction at different salary levels.

Closes #277