### PR TITLE
chore: migrate to native Claude Code worktree config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,16 @@
 {
+  "permissions": {
+    "defaultMode": "bypassPermissions",
+    "deny": ["Read(./.env)", "Read(./.env.*)"]
+  },
+  "worktree": {
+    "symlinkDirectories": [
+      "node_modules",
+      ".claude/settings.local.json",
+      ".env.local"
+    ]
+  },
+  "showClearContextOnPlanAccept": true,
   "hooks": {
     "PreToolUse": [
       {
@@ -16,26 +28,6 @@
           {
             "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/.claude/hooks/worktree-guard.sh\""
-          }
-        ]
-      }
-    ],
-    "WorktreeCreate": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash -c 'NAME=$(jq -r .name) && REPO=$(git rev-parse --show-toplevel) && DIR=\"$REPO/.claude/worktrees/$NAME\" && git worktree add \"$DIR\" >&2 && cd \"$DIR\" && pnpm install >&2 && echo \"$DIR\"'"
-          }
-        ]
-      }
-    ],
-    "WorktreeRemove": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash -c 'WORKTREE_PATH=$(jq -r .worktree_path) && git worktree remove \"$WORKTREE_PATH\" --force >&2'"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Replace the custom `WorktreeCreate` and `WorktreeRemove` bash hook scripts with Claude Code's native `worktree.symlinkDirectories` configuration. This also adds the `permissions` block (bypass mode with `.env` file deny rules) and enables `showClearContextOnPlanAccept`.