### PR TITLE
feat: add Escape key dismissal and auto-focus to modal dialogs

### DIFF
--- a/src/components/shared/ControlBar.tsx
+++ b/src/components/shared/ControlBar.tsx
@@ -2,7 +2,7 @@
 
 import { PreferenceHorizontalIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { startTransition, useOptimistic } from "react";
+import { startTransition, useEffect, useOptimistic, useRef } from "react";
 import { LoanConfigPanel } from "@/components/home/LoanConfigPanel";
 import { PresentValueToggle } from "@/components/home/PresentValueToggle";
 import { Slider } from "@/components/ui/slider";
@@ -239,14 +239,34 @@ function ConfigOverlay({
   onComplete: () => void;
   onClose: () => void;
 }) {
-  if (mode.view !== "loan-config") return null;
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  const isOpen = mode.view === "loan-config";
+
+  // Auto-focus the dialog container when it opens so keyboard events work
+  // and the next Tab lands inside the dialog rather than on page content.
+  useEffect(() => {
+    if (isOpen) {
+      dialogRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
 
   return (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-label="Configure your loans"
       className="fixed inset-0 z-50 flex min-h-dvh flex-col overflow-y-auto bg-background"
+      tabIndex={-1}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.stopPropagation();
+          onClose();
+        }
+      }}
     >
       <LoanConfigPanel
         isEditing={hasPersonalized}

--- a/src/context/AssumptionsWizardContext.test.tsx
+++ b/src/context/AssumptionsWizardContext.test.tsx
@@ -193,6 +193,22 @@ describe("AssumptionsWizardContext", () => {
     expect(trackWizardCompleted).toHaveBeenCalledTimes(1);
   });
 
+  it("closes the dialog when Escape is pressed", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <AssumptionsWizardProvider>
+        <TestConsumer />
+      </AssumptionsWizardProvider>,
+    );
+
+    await user.click(screen.getByText("Open"));
+    expect(screen.queryByRole("dialog")).not.toBeNull();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
   it("does not call analytics when closing without completing", async () => {
     const user = userEvent.setup();
 

--- a/src/context/AssumptionsWizardContext.tsx
+++ b/src/context/AssumptionsWizardContext.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { createContext, use, useEffect, useState, type ReactNode } from "react";
+import {
+  createContext,
+  use,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { AssumptionsWizard } from "@/components/wizard/AssumptionsWizard";
 import type { AssumptionsWizardStep } from "@/components/wizard/wizardReducer";
 import { trackWizardCompleted, trackWizardStarted } from "@/lib/analytics";
@@ -54,6 +61,16 @@ export function AssumptionsWizardProvider({
     setWizardState({ open: false });
   }
 
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Auto-focus the dialog container when it opens so keyboard events work
+  // and the next Tab lands inside the dialog rather than on page content.
+  useEffect(() => {
+    if (wizardState.open) {
+      dialogRef.current?.focus();
+    }
+  }, [wizardState.open]);
+
   const value: AssumptionsWizardValue = { openAssumptions };
 
   return (
@@ -61,10 +78,18 @@ export function AssumptionsWizardProvider({
       {children}
       {wizardState.open && (
         <div
+          ref={dialogRef}
           role="dialog"
           aria-modal="true"
           aria-label="Adjust assumptions"
           className="fixed inset-0 z-50 overflow-y-auto"
+          tabIndex={-1}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.stopPropagation();
+              handleClose();
+            }
+          }}
         >
           <AssumptionsWizard
             onComplete={handleComplete}


### PR DESCRIPTION
## Summary

Adds standard keyboard accessibility to the two full-screen modal dialogs (the loan config overlay in ControlBar and the assumptions wizard). Both dialogs now dismiss when the user presses Escape and auto-focus their container element on open, so keyboard navigation lands inside the dialog rather than on hidden page content behind it. A new test verifies the Escape-to-close behaviour on the assumptions wizard.