### PR TITLE
style: remove redundant default exports from component files

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import App from "@/components/App";
+import { App } from "@/components/App";
 import { AppErrorBoundary } from "@/components/shared/ErrorBoundary";
 import { parseMetadataParams } from "@/lib/metadata";
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -13,7 +13,7 @@ import { ControlBar } from "./shared/ControlBar";
 import { InsightCards } from "./shared/InsightCards";
 import { PlanFromQuery } from "./shared/PlanFromQuery";
 
-function App() {
+export function App() {
   const { updateField } = useLoanActions();
   const config = useLoanConfigState();
   const { pendingQuizPlanTypes } = config;
@@ -50,5 +50,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/src/components/home/CurrencyInput.tsx
+++ b/src/components/home/CurrencyInput.tsx
@@ -49,5 +49,3 @@ function CustomInput({
 }: React.ComponentProps<"input"> & { ref?: React.Ref<HTMLInputElement> }) {
   return <Input ref={ref} {...props} />;
 }
-
-export default CurrencyInput;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { BrandLogo } from "@/components/brand/BrandLogo";
 import { GovUkBadge } from "./GovUkBadge";
 import { ShareButton } from "./ShareButton";
-import ThemeToggle from "./ThemeToggle";
+import { ThemeToggle } from "./ThemeToggle";
 
 interface HeaderProps {
   repaymentYear?: number;

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -172,5 +172,3 @@ export function ThemeToggle() {
     </DropdownMenu>
   );
 }
-
-export default ThemeToggle;

--- a/src/components/overpay/OverpayComparisonChart.tsx
+++ b/src/components/overpay/OverpayComparisonChart.tsx
@@ -66,5 +66,3 @@ export function OverpayComparisonChart({
     />
   );
 }
-
-export default OverpayComparisonChart;

--- a/src/components/overpay/OverpaySummaryCards.tsx
+++ b/src/components/overpay/OverpaySummaryCards.tsx
@@ -177,5 +177,3 @@ export function OverpaySummaryCards({ analysis }: OverpaySummaryCardsProps) {
     </div>
   );
 }
-
-export default OverpaySummaryCards;

--- a/src/components/overpay/OverpayVerdict.tsx
+++ b/src/components/overpay/OverpayVerdict.tsx
@@ -73,5 +73,3 @@ export function OverpayVerdict({
     </div>
   );
 }
-
-export default OverpayVerdict;


### PR DESCRIPTION
## Summary

Removes default exports from 6 component files to align with the project convention that only `page.tsx` and `layout.tsx` may use default exports. For `App.tsx` and `ThemeToggle.tsx`, the default export was replaced with a named export and their import sites (`page.tsx`, `Header.tsx`) were updated accordingly. For `CurrencyInput.tsx`, `OverpayComparisonChart.tsx`, `OverpaySummaryCards.tsx`, and `OverpayVerdict.tsx`, the redundant `export default` line was simply removed since consumers already use their named exports.