### PR TITLE
feat: add OpenGraph metadata and breadcrumb JSON-LD to /our-data

### DIFF
--- a/src/app/our-data/layout.tsx
+++ b/src/app/our-data/layout.tsx
@@ -1,0 +1,52 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Our Data",
+  description:
+    "Every figure in our calculators comes from GOV.UK, the Bank of England, and the ONS, verified daily by automation. Cross-check them yourself.",
+  alternates: {
+    canonical: "/our-data",
+  },
+  openGraph: {
+    title: "Our Data",
+    description:
+      "Every figure in our calculators comes from GOV.UK, the Bank of England, and the ONS, verified daily by automation. Cross-check them yourself.",
+    url: "https://studentloanstudy.uk/our-data",
+    type: "website",
+  },
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://studentloanstudy.uk",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Our Data",
+      item: "https://studentloanstudy.uk/our-data",
+    },
+  ],
+};
+
+export default function OurDataLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/our-data/page.tsx
+++ b/src/app/our-data/page.tsx
@@ -1,13 +1,5 @@
-import type { Metadata } from "next";
 import { OurDataPage } from "@/components/our-data/OurDataPage";
 import { AppErrorBoundary } from "@/components/shared/ErrorBoundary";
-
-export const metadata: Metadata = {
-  title: "Our Data",
-  description:
-    "Every figure in our calculators comes from GOV.UK, the Bank of England, and the ONS, verified daily by automation. Cross-check them yourself.",
-  alternates: { canonical: "/our-data" },
-};
 
 export default function OurDataRoute() {
   return (


### PR DESCRIPTION
## Summary

The `/our-data` page was the only page missing OpenGraph metadata and BreadcrumbList JSON-LD structured data. This adds both by introducing a `layout.tsx` for the route — matching the pattern already used by every other page in the app (`/balance`, `/effective-rate`, `/interest`, etc.).

- Moved existing `Metadata` export from `page.tsx` into the new `layout.tsx`
- Added OpenGraph fields (title, description, url, type) for social sharing previews
- Added BreadcrumbList JSON-LD schema (Home → Our Data) for search engine rich results