### PR TITLE
feat: add OpenGraph metadata to /brand and /guides layouts

### DIFF
--- a/src/app/brand/layout.tsx
+++ b/src/app/brand/layout.tsx
@@ -7,6 +7,13 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "/brand",
   },
+  openGraph: {
+    title: "Brand Guidelines",
+    description:
+      "Brand guidelines for studentloanstudy.uk including logo usage, color palette, and typography specifications.",
+    url: "https://studentloanstudy.uk/brand",
+    type: "website",
+  },
 };
 
 export default function BrandLayout({

--- a/src/app/guides/layout.tsx
+++ b/src/app/guides/layout.tsx
@@ -15,6 +15,13 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "/guides",
   },
+  openGraph: {
+    title: "Student Loan Guides — The Stuff They Don't Tell You",
+    description:
+      "The real questions graduates ask: Will my loan affect my mortgage? Should I overpay? What if I move abroad? Clear answers with interactive charts, not jargon.",
+    url: "https://studentloanstudy.uk/guides",
+    type: "website",
+  },
 };
 
 const itemListSchema = {


### PR DESCRIPTION
## Summary

Add OpenGraph metadata to the `/brand` and `/guides` route layouts so social media platforms display rich previews when these pages are shared. This continues the pattern established in #302, which added OpenGraph metadata to `/our-data`, ensuring consistent social sharing support across the site.