### PR TITLE
fix: prune stale cancelled IDs in simulation worker to prevent memory leak

### DIFF
--- a/src/workers/simulation.worker.ts
+++ b/src/workers/simulation.worker.ts
@@ -670,6 +670,16 @@ self.onmessage = (event: MessageEvent<WorkerMessage>) => {
     return;
   }
 
+  // Prune stale cancelled IDs: any ID below the current one was either
+  // already processed or will never arrive, so keeping it leaks memory.
+  if (cancelledIds.size > 0) {
+    for (const staleId of cancelledIds) {
+      if (staleId < id) {
+        cancelledIds.delete(staleId);
+      }
+    }
+  }
+
   let result: WorkerResultType;
 
   switch (payload.type) {


### PR DESCRIPTION
## Summary

The `cancelledIds` Set in the simulation web worker grows unboundedly over time. When a simulation request is cancelled (e.g. due to rapid user input changes), its ID is added to the set but never removed. Since IDs are monotonically increasing, any ID below the current incoming ID is guaranteed to never arrive, making its entry in the set dead weight.

This adds a pruning step at the start of each message handler invocation that removes all cancelled IDs strictly less than the current message ID, keeping the set bounded to at most the number of in-flight cancellations.