### PR TITLE
chore: remove unused exports from constants, dateUtils, and store types

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -90,4 +90,3 @@ export const currencyFormatter = new Intl.NumberFormat("en-GB", {
 
 export const percentageFormatter = (value: number) =>
   `${(value * 100).toFixed(1)}%`;
-export const yearsFormatter = (value: number) => value.toFixed(1);

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -12,14 +12,3 @@ export function monthsElapsedSince(
     start.getMonth()
   );
 }
-
-/**
- * Formats a date as "Month Day, Year" (e.g., "January 15, 2024").
- */
-export function formatDateLong(date: Date): string {
-  return new Intl.DateTimeFormat("en-US", {
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-  }).format(date);
-}

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -33,16 +33,3 @@ export interface LoanState {
   /** Plan types discovered via the standalone /which-plan quiz, pending config panel open */
   pendingQuizPlanTypes: PlanType[] | null;
 }
-
-/**
- * Store actions for updating loan state.
- */
-export interface LoanActions {
-  /** Update a single field in the store */
-  updateField: <K extends keyof LoanState>(key: K, value: LoanState[K]) => void;
-}
-
-/**
- * Complete store interface with state values and actions.
- */
-export type LoanStore = LoanState & LoanActions;


### PR DESCRIPTION
## Summary

Remove three dead exports that are not imported anywhere in the codebase: `yearsFormatter` from `constants.ts`, `formatDateLong` from `dateUtils.ts`, and the `LoanActions`/`LoanStore` types from `store.ts`. This continues the cleanup effort from #300 to reduce unused code and keep the codebase lean.