### PR TITLE
fix: align manifest theme_color with brand green

### DIFF
--- a/src/app/manifest.json
+++ b/src/app/manifest.json
@@ -5,7 +5,7 @@
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#10B981",
+  "theme_color": "#2B7F55",
   "icons": [
     {
       "src": "/icon.png",


### PR DESCRIPTION
## Summary

The PWA manifest (`manifest.json`) was using `#10B981` (Tailwind emerald-500) as the `theme_color`, which doesn't match the project's established brand green (`#2B7F55`). This updates it to the correct brand color, ensuring consistency with the rest of the app (CSS custom properties, icons, social images).