### PR TITLE
feat: add OpenGraph metadata to /guides layout

### DIFF
--- a/src/app/guides/layout.tsx
+++ b/src/app/guides/layout.tsx
@@ -15,6 +15,13 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "/guides",
   },
+  openGraph: {
+    title: "Student Loan Guides — The Stuff They Don't Tell You",
+    description:
+      "The real questions graduates ask: Will my loan affect my mortgage? Should I overpay? What if I move abroad? Clear answers with interactive charts, not jargon.",
+    url: "https://studentloanstudy.uk/guides",
+    type: "website",
+  },
 };
 
 const itemListSchema = {


### PR DESCRIPTION
## Summary

Add OpenGraph metadata to the `/guides` section layout for better social sharing previews. This follows the same pattern established in #302 (which added OG metadata to `/our-data`), continuing the rollout of OpenGraph tags across all top-level pages.