### PR TITLE
fix: apply Plan 2 freeze toggle from shared URLs

### DIFF
--- a/src/components/shared/PlanFromQuery.tsx
+++ b/src/components/shared/PlanFromQuery.tsx
@@ -55,6 +55,9 @@ function PlanFromQueryInner({ onRepaymentYearChange }: PlanFromQueryProps) {
         updateField(field.stateKey, value as number);
       }
     }
+    if (decoded.applyPlan2Freeze !== undefined) {
+      updateField("applyPlan2Freeze", decoded.applyPlan2Freeze);
+    }
     if (decoded.showPresentValue) {
       updateField("showPresentValue", true);
     }


### PR DESCRIPTION
## Summary

When a user shares a URL with the Plan 2 threshold freeze toggle enabled, the `applyPlan2Freeze` field was not being decoded from query parameters in `PlanFromQuery`. This meant the recipient's calculator would not reflect the freeze setting, producing different results from what the sharer intended. This fix adds the missing decode step so `applyPlan2Freeze` is correctly restored from shared URLs.