### PR TITLE
chore: remove unused autoprefixer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@vitejs/plugin-react": "^5.1.4",
     "@vitest/coverage-v8": "^4.0.18",
     "@vitest/web-worker": "^4.0.18",
-    "autoprefixer": "^10.4.27",
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^10",
     "eslint-plugin-better-tailwindcss": "^4.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,9 +108,6 @@ importers:
       '@vitest/web-worker':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@types/node@25.5.0)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.7(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.2))
-      autoprefixer:
-        specifier: ^10.4.27
-        version: 10.4.27(postcss@8.5.8)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -8349,11 +8346,12 @@ snapshots:
   autoprefixer@10.4.27(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.1
-      caniuse-lite: 1.0.30001774
+      caniuse-lite: 1.0.30001781
       fraction.js: 5.3.4
       picocolors: 1.1.1
       postcss: 8.5.8
       postcss-value-parser: 4.2.0
+    optional: true
 
   axe-core@4.11.1: {}
 
@@ -9304,7 +9302,8 @@ snapshots:
       signal-exit: 4.1.0
     optional: true
 
-  fraction.js@5.3.4: {}
+  fraction.js@5.3.4:
+    optional: true
 
   fresh@2.0.0:
     optional: true
@@ -10685,7 +10684,8 @@ snapshots:
       postcss-selector-parser: 7.1.1
     optional: true
 
-  postcss-value-parser@4.2.0: {}
+  postcss-value-parser@4.2.0:
+    optional: true
 
   postcss@8.4.31:
     dependencies:


### PR DESCRIPTION
## Summary

Removes `autoprefixer` from `devDependencies` since it is no longer used. Next.js with Tailwind CSS v4 handles CSS processing via Lightning CSS, making autoprefixer redundant as a direct dependency. This reduces the project's dependency footprint.