### PR TITLE
fix: add OpenGraph metadata to homepage shared-params branch

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -13,7 +13,7 @@ export async function generateMetadata({
   const params = await searchParams;
   const meta = parseMetadataParams(params);
 
-  // No share params - use defaults from layout
+  // No share params - use defaults from root layout, just add canonical
   if (!meta.hasShareParams) {
     return {
       alternates: {
@@ -31,6 +31,12 @@ export async function generateMetadata({
     description,
     alternates: {
       canonical: "/",
+    },
+    openGraph: {
+      title,
+      description,
+      url: "https://studentloanstudy.uk",
+      type: "website",
     },
   };
 }


### PR DESCRIPTION
## Summary

When the homepage's `generateMetadata` receives share parameters, it was returning a title and description but no explicit OpenGraph tags. This meant social media crawlers wouldn't render proper previews for shared homepage URLs with custom parameters. This adds the missing `openGraph` metadata (title, description, url, type) to the shared-params code path, matching the pattern used by other pages like `/our-data`.