### PR TITLE
fix: use existing no-scrollbar utility for cross-browser scrollbar hiding

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -257,7 +257,3 @@ body {
     animation: none;
   }
 }
-
-@utility scrollbar-none {
-  scrollbar-width: none;
-}

--- a/src/components/shared/ControlBar.tsx
+++ b/src/components/shared/ControlBar.tsx
@@ -130,7 +130,7 @@ function ExpandedPresets({
         <div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-linear-to-l from-card to-transparent sm:hidden" />
 
         <div
-          className="flex gap-2 overflow-x-auto pr-8 pb-1 pl-3 scrollbar-none sm:grid sm:grid-cols-5 sm:overflow-visible sm:px-0 sm:pb-0 [&::-webkit-scrollbar]:hidden"
+          className="no-scrollbar flex gap-2 overflow-x-auto pr-8 pb-1 pl-3 sm:grid sm:grid-cols-5 sm:overflow-visible sm:px-0 sm:pb-0"
           role="group"
           aria-label="Preset profiles"
         >


### PR DESCRIPTION
## Summary

The ControlBar's preset scroller was using two separate mechanisms to hide scrollbars: a hand-rolled `@utility scrollbar-none` (Firefox) and an arbitrary `[&::-webkit-scrollbar]:hidden` variant (WebKit). The codebase already provides a `no-scrollbar` utility that covers both browsers in a single class. This replaces both approaches with `no-scrollbar` and removes the now-unused custom utility from `globals.css`.