### PR TITLE
fix: set html lang attribute to en-GB for UK-focused content

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -101,7 +101,7 @@ export default function RootLayout({
 }) {
   return (
     <html
-      lang="en"
+      lang="en-GB"
       className={cn(
         manrope.variable,
         spaceGrotesk.variable,


### PR DESCRIPTION
## Summary

The `<html>` element's `lang` attribute was set to `en` (generic English) despite the site being a UK-specific student loan calculator. This changes it to `en-GB` so that browsers, search engines, and assistive technologies correctly identify the content as British English, improving accessibility and SEO for the target UK audience.