### PR TITLE
fix: move main landmark to page level on which-plan

### DIFF
--- a/src/app/which-plan/page.tsx
+++ b/src/app/which-plan/page.tsx
@@ -13,7 +13,7 @@ const ALL_PLANS = [
 
 export default function WhichPlanPage() {
   return (
-    <>
+    <main id="main-content">
       <QuizContainer />
       <section className="border-t bg-muted/30">
         <div className="mx-auto max-w-4xl px-3 py-12">
@@ -58,6 +58,6 @@ export default function WhichPlanPage() {
           </div>
         </div>
       </section>
-    </>
+    </main>
   );
 }

--- a/src/components/quiz/QuizContainer.tsx
+++ b/src/components/quiz/QuizContainer.tsx
@@ -241,7 +241,7 @@ export function QuizContainer({
         />
       )}
 
-      <main className="flex flex-1 flex-col items-center justify-center px-4 py-8">
+      <div className="flex flex-1 flex-col items-center justify-center px-4 py-8">
         <div className="w-full max-w-lg">
           {state.currentStep === "region" && (
             <RegionQuestion
@@ -286,7 +286,7 @@ export function QuizContainer({
             />
           )}
         </div>
-      </main>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The `<main>` landmark element was nested inside `QuizContainer`, a child component of the which-plan page. This caused the page-level content (the quiz and the informational section below it) to lack a proper top-level `<main>` landmark. This change lifts `<main id="main-content">` to the page level in `page.tsx` and downgrades the inner `<main>` in `QuizContainer` to a `<div>`, fixing HTML semantics and enabling skip-to-content navigation for keyboard and screen reader users.