### PR TITLE
feat: add breadcrumb JSON-LD to /brand page

### DIFF
--- a/src/app/brand/layout.tsx
+++ b/src/app/brand/layout.tsx
@@ -9,10 +9,37 @@ export const metadata: Metadata = {
   },
 };
 
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://studentloanstudy.uk",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Brand Guidelines",
+      item: "https://studentloanstudy.uk/brand",
+    },
+  ],
+};
+
 export default function BrandLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return children;
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      {children}
+    </>
+  );
 }


### PR DESCRIPTION
## Summary

Adds a BreadcrumbList JSON-LD structured data schema to the `/brand` page layout, following the same pattern used in the recent `/our-data` update (#302). This helps search engines understand the site's navigation hierarchy for the brand guidelines page, improving SEO discoverability.