### PR TITLE
style: remove duplicate canonical metadata from detail pages

### DIFF
--- a/src/app/balance/page.tsx
+++ b/src/app/balance/page.tsx
@@ -1,14 +1,5 @@
-import type { Metadata } from "next";
 import { BalanceDetailPage } from "@/components/detail/BalanceDetailPage";
 import { AppErrorBoundary } from "@/components/shared/ErrorBoundary";
-
-export function generateMetadata(): Metadata {
-  return {
-    alternates: {
-      canonical: "/balance",
-    },
-  };
-}
 
 export default function BalanceRoute() {
   return (

--- a/src/app/effective-rate/page.tsx
+++ b/src/app/effective-rate/page.tsx
@@ -1,14 +1,5 @@
-import type { Metadata } from "next";
 import { EffectiveRateDetailPage } from "@/components/detail/EffectiveRateDetailPage";
 import { AppErrorBoundary } from "@/components/shared/ErrorBoundary";
-
-export function generateMetadata(): Metadata {
-  return {
-    alternates: {
-      canonical: "/effective-rate",
-    },
-  };
-}
 
 export default function EffectiveRateRoute() {
   return (

--- a/src/app/interest/page.tsx
+++ b/src/app/interest/page.tsx
@@ -1,14 +1,5 @@
-import type { Metadata } from "next";
 import { InterestDetailPage } from "@/components/detail/InterestDetailPage";
 import { AppErrorBoundary } from "@/components/shared/ErrorBoundary";
-
-export function generateMetadata(): Metadata {
-  return {
-    alternates: {
-      canonical: "/interest",
-    },
-  };
-}
 
 export default function InterestRoute() {
   return (

--- a/src/app/repaid/page.tsx
+++ b/src/app/repaid/page.tsx
@@ -1,14 +1,5 @@
-import type { Metadata } from "next";
 import { RepaidDetailPage } from "@/components/detail/RepaidDetailPage";
 import { AppErrorBoundary } from "@/components/shared/ErrorBoundary";
-
-export function generateMetadata(): Metadata {
-  return {
-    alternates: {
-      canonical: "/repaid",
-    },
-  };
-}
 
 export default function RepaidRoute() {
   return (


### PR DESCRIPTION
## Summary

The four detail page files (`balance`, `effective-rate`, `interest`, `repaid`) each had a `generateMetadata()` function that only set `alternates.canonical`. These canonical URLs were already defined in the corresponding `layout.tsx` files for each route, making the page-level metadata redundant. Removing them keeps canonical URL configuration in a single location per route and simplifies the page components.