### PR TITLE
style: add aria-labels to wizard custom rate inputs

### DIFF
--- a/src/components/wizard/BoeBaseRateStep.tsx
+++ b/src/components/wizard/BoeBaseRateStep.tsx
@@ -86,6 +86,7 @@ export function BoeBaseRateStep({
                 decimalScale={2}
                 inputMode="decimal"
                 placeholder="e.g. 4"
+                aria-label="Custom Bank of England base rate percentage"
               />
               <span className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-xs text-muted-foreground">
                 %

--- a/src/components/wizard/RpiStep.tsx
+++ b/src/components/wizard/RpiStep.tsx
@@ -86,6 +86,7 @@ export function RpiStep({ direction, onNext, done }: RpiStepProps) {
                 decimalScale={1}
                 inputMode="decimal"
                 placeholder="e.g. 3"
+                aria-label="Custom RPI rate percentage"
               />
               <span className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-xs text-muted-foreground">
                 %

--- a/src/components/wizard/SalaryGrowthStep.tsx
+++ b/src/components/wizard/SalaryGrowthStep.tsx
@@ -81,6 +81,7 @@ export function SalaryGrowthStep({ direction, onNext }: SalaryGrowthStepProps) {
                 decimalScale={1}
                 inputMode="decimal"
                 placeholder="e.g. 5"
+                aria-label="Custom salary growth rate percentage"
               />
               <span className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-xs text-muted-foreground">
                 %/yr

--- a/src/components/wizard/ThresholdGrowthStep.tsx
+++ b/src/components/wizard/ThresholdGrowthStep.tsx
@@ -129,6 +129,7 @@ export function ThresholdGrowthStep({
                 decimalScale={1}
                 inputMode="decimal"
                 placeholder="e.g. 3"
+                aria-label="Custom threshold growth rate percentage"
               />
               <span className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-xs text-muted-foreground">
                 %/yr


### PR DESCRIPTION
## Summary

The custom numeric inputs in the assumptions wizard steps (BoE base rate, RPI, salary growth, threshold growth) had no programmatic labels, making them invisible to screen readers. This adds descriptive `aria-label` attributes to each input so assistive technology users can identify what each field controls.