### PR TITLE
fix: add noindex robots directive to 404 page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -9,6 +9,10 @@ export const metadata: Metadata = {
   title: "Page Not Found",
   description:
     "The page you were looking for doesn't exist. Browse our UK student loan calculators, tools, and guides.",
+  robots: {
+    index: false,
+    follow: true,
+  },
 };
 
 const SUGGESTED_LINKS = [


### PR DESCRIPTION
## Summary

The custom 404 page was missing a robots directive, allowing search engines to index it. Since 404 pages contain no unique content and can dilute crawl budget, this adds `noindex, follow` — preventing indexing while still letting crawlers follow the suggested links on the page to discover valid routes.