### PR TITLE
fix: assign Plan 2 to Welsh students starting 2023+

### DIFF
--- a/src/components/quiz/AdditionalCourseQuestion.tsx
+++ b/src/components/quiz/AdditionalCourseQuestion.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import type { StartYearGroup } from "@/lib/quiz/determinePlan";
+import { PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
+import type { Region, StartYearGroup } from "@/lib/quiz/determinePlan";
+import { getAdditionalCoursePlan } from "@/lib/quiz/determinePlan";
 import { OptionCard } from "./OptionCard";
 import { QuestionStep } from "./QuestionStep";
 
@@ -9,6 +11,7 @@ interface AdditionalCourseQuestionProps {
   selectedValue: boolean | null;
   direction: "forward" | "backward";
   yearGroup: StartYearGroup;
+  region: Region;
 }
 
 export function AdditionalCourseQuestion({
@@ -16,10 +19,12 @@ export function AdditionalCourseQuestion({
   selectedValue,
   direction,
   yearGroup,
+  region,
 }: AdditionalCourseQuestionProps) {
   const dateLabel =
     yearGroup === "before-2012" ? "September 2012" : "August 2023";
-  const planLabel = yearGroup === "before-2012" ? "Plan 2" : "Plan 5";
+  const additionalPlanType = getAdditionalCoursePlan(yearGroup, region);
+  const planLabel = PLAN_DISPLAY_INFO[additionalPlanType].name;
 
   return (
     <QuestionStep

--- a/src/components/quiz/QuizContainer.tsx
+++ b/src/components/quiz/QuizContainer.tsx
@@ -260,12 +260,14 @@ export function QuizContainer({
           )}
 
           {state.currentStep === "additional-course" &&
-            state.startYearGroup && (
+            state.startYearGroup &&
+            state.region && (
               <AdditionalCourseQuestion
                 onSelect={handleAdditionalCourseSelect}
                 selectedValue={state.hasAdditionalCourse}
                 direction={state.direction}
                 yearGroup={state.startYearGroup}
+                region={state.region}
               />
             )}
 

--- a/src/lib/quiz/determinePlan.test.ts
+++ b/src/lib/quiz/determinePlan.test.ts
@@ -94,13 +94,13 @@ describe("determinePlan", () => {
       ).toBe("PLAN_2");
     });
 
-    it("returns PLAN_5 for 2023 or later", () => {
+    it("returns PLAN_2 for 2023 or later (Plan 5 is England-only)", () => {
       expect(
         determinePlan({
           region: "wales",
           startYearGroup: "2023-or-later",
         }),
-      ).toBe("PLAN_5");
+      ).toBe("PLAN_2");
     });
   });
 });
@@ -176,16 +176,17 @@ describe("shouldAskAboutAdditionalCourse", () => {
 });
 
 describe("getAdditionalCoursePlan", () => {
-  it("returns PLAN_2 for before-2012 students", () => {
-    expect(getAdditionalCoursePlan("before-2012")).toBe("PLAN_2");
+  it("returns PLAN_2 for pre-2012 starters regardless of region", () => {
+    expect(getAdditionalCoursePlan("before-2012", "england")).toBe("PLAN_2");
+    expect(getAdditionalCoursePlan("before-2012", "wales")).toBe("PLAN_2");
   });
 
-  it("returns PLAN_5 for 2012-2022 students", () => {
-    expect(getAdditionalCoursePlan("2012-2022")).toBe("PLAN_5");
+  it("returns PLAN_5 for 2012-2022 England starters", () => {
+    expect(getAdditionalCoursePlan("2012-2022", "england")).toBe("PLAN_5");
   });
 
-  it("returns PLAN_5 for 2023-or-later students", () => {
-    expect(getAdditionalCoursePlan("2023-or-later")).toBe("PLAN_5");
+  it("returns PLAN_2 for 2012-2022 Wales starters (Plan 5 is England-only)", () => {
+    expect(getAdditionalCoursePlan("2012-2022", "wales")).toBe("PLAN_2");
   });
 });
 

--- a/src/lib/quiz/determinePlan.ts
+++ b/src/lib/quiz/determinePlan.ts
@@ -27,7 +27,8 @@ export interface QuizAnswers {
  * - Northern Ireland → PLAN_1 (regardless of year)
  * - England/Wales before 2012 → PLAN_1
  * - England/Wales 2012-2022 → PLAN_2
- * - England/Wales 2023+ → PLAN_5
+ * - England 2023+ → PLAN_5
+ * - Wales 2023+ → PLAN_2 (Plan 5 is England-only)
  */
 export function determinePlan(answers: QuizAnswers): UndergraduatePlanType {
   const { region, startYearGroup } = answers;
@@ -49,7 +50,8 @@ export function determinePlan(answers: QuizAnswers): UndergraduatePlanType {
     case "2012-2022":
       return "PLAN_2";
     case "2023-or-later":
-      return "PLAN_5";
+      // Plan 5 is England-only; Welsh students starting 2023+ remain on Plan 2
+      return region === "england" ? "PLAN_5" : "PLAN_2";
     default:
       // Default to PLAN_2 if somehow called without startYearGroup for England/Wales
       return "PLAN_2";
@@ -78,12 +80,16 @@ export function shouldAskAboutAdditionalCourse(
 }
 
 /**
- * The plan type for the additional course, based on the original start year group.
+ * The plan type for the additional course, based on the original start year
+ * group and region. Plan 5 is England-only; Welsh students get Plan 2.
  */
 export function getAdditionalCoursePlan(
   yearGroup: StartYearGroup,
+  region: Region,
 ): UndergraduatePlanType {
-  return yearGroup === "before-2012" ? "PLAN_2" : "PLAN_5";
+  if (yearGroup === "before-2012") return "PLAN_2";
+  // 2012-2022 starters taking a new course after Aug 2023
+  return region === "england" ? "PLAN_5" : "PLAN_2";
 }
 
 /**
@@ -124,8 +130,8 @@ export function determineAllLoans(state: QuizState): PlanType[] {
   }
 
   // Additional undergraduate course
-  if (state.hasAdditionalCourse && state.startYearGroup) {
-    loans.push(getAdditionalCoursePlan(state.startYearGroup));
+  if (state.hasAdditionalCourse && state.startYearGroup && state.region) {
+    loans.push(getAdditionalCoursePlan(state.startYearGroup, state.region));
   }
 
   // Postgraduate loan


### PR DESCRIPTION
## Summary

Plan 5 is England-only, but the quiz was incorrectly assigning Plan 5 to Welsh students starting in 2023 or later. This fix corrects `determinePlan()` to return Plan 2 for Wales 2023+ students, and updates `getAdditionalCoursePlan()` to accept a `region` parameter so the additional course question also displays the correct plan label for Welsh users.

- `determinePlan`: Wales + 2023-or-later now returns `PLAN_2` instead of `PLAN_5`
- `getAdditionalCoursePlan`: accepts `region` and returns `PLAN_2` for Welsh students
- `AdditionalCourseQuestion` component updated to pass and use `region`
- Tests updated to reflect correct behaviour and cover the new `region` parameter