### PR TITLE
style: add comment explaining nav usage in InsightCards

### DIFF
--- a/src/components/shared/InsightCards.tsx
+++ b/src/components/shared/InsightCards.tsx
@@ -19,6 +19,7 @@ export function InsightCards({ excludeHref }: InsightCardsProps) {
   const { cards: data } = usePersonalizedResults();
 
   return (
+    // <nav> is correct here — each card is a link to a detail page
     <nav aria-label="Loan breakdown" className="space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-sm font-medium text-muted-foreground">


### PR DESCRIPTION
## Summary

Each insight card is a link to a detail page, so `<nav>` is semantically correct here. Added a comment to clarify this for future contributors who might be tempted to change it to `<section>`.