### PR TITLE
test: add unit tests for dateUtils and format utility modules

### DIFF
--- a/src/lib/dateUtils.test.ts
+++ b/src/lib/dateUtils.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { monthsElapsedSince } from "./dateUtils";
+
+describe("monthsElapsedSince", () => {
+  it("returns 0 for the same month and year", () => {
+    const start = new Date(2024, 3, 15); // April 2024
+    const now = new Date(2024, 3, 20); // April 2024
+    expect(monthsElapsedSince(start, now)).toBe(0);
+  });
+
+  it("returns 1 for one month later", () => {
+    const start = new Date(2024, 0, 1); // Jan 2024
+    const now = new Date(2024, 1, 1); // Feb 2024
+    expect(monthsElapsedSince(start, now)).toBe(1);
+  });
+
+  it("returns 12 for one year later", () => {
+    const start = new Date(2024, 0, 1); // Jan 2024
+    const now = new Date(2025, 0, 1); // Jan 2025
+    expect(monthsElapsedSince(start, now)).toBe(12);
+  });
+
+  it("returns correct months across year boundary", () => {
+    const start = new Date(2024, 10, 1); // Nov 2024
+    const now = new Date(2025, 2, 1); // Mar 2025
+    expect(monthsElapsedSince(start, now)).toBe(4);
+  });
+
+  it("ignores the day component", () => {
+    const start = new Date(2024, 0, 31); // Jan 31
+    const now = new Date(2024, 1, 1); // Feb 1
+    expect(monthsElapsedSince(start, now)).toBe(1);
+  });
+
+  it("returns negative when start is in the future", () => {
+    const start = new Date(2025, 5, 1); // June 2025
+    const now = new Date(2025, 2, 1); // March 2025
+    expect(monthsElapsedSince(start, now)).toBe(-3);
+  });
+
+  it("handles multi-year spans", () => {
+    const start = new Date(2020, 3, 1); // April 2020
+    const now = new Date(2025, 3, 1); // April 2025
+    expect(monthsElapsedSince(start, now)).toBe(60);
+  });
+
+  it("handles the typical repayment start scenario", () => {
+    // Repayment starts April 2023, checking in March 2026
+    const start = new Date(2023, 3, 1); // April 2023
+    const now = new Date(2026, 2, 1); // March 2026
+    expect(monthsElapsedSince(start, now)).toBe(35);
+  });
+});

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { formatGBP, formatPercent, formatYearFromMonth } from "./format";
+
+describe("formatGBP", () => {
+  it("formats a typical balance with thousands separator", () => {
+    expect(formatGBP(28470)).toBe("£28,470");
+  });
+
+  it("formats zero", () => {
+    expect(formatGBP(0)).toBe("£0");
+  });
+
+  it("formats a small number without separator", () => {
+    expect(formatGBP(500)).toBe("£500");
+  });
+
+  it("formats a large number with thousands separators", () => {
+    expect(formatGBP(1234567)).toBe("£1,234,567");
+  });
+
+  it("formats a number at the thousands boundary", () => {
+    expect(formatGBP(1000)).toBe("£1,000");
+  });
+});
+
+describe("formatPercent", () => {
+  it("formats a decimal percentage", () => {
+    expect(formatPercent(3.2)).toBe("3.2%");
+  });
+
+  it("formats a whole number percentage", () => {
+    expect(formatPercent(5)).toBe("5%");
+  });
+
+  it("formats zero", () => {
+    expect(formatPercent(0)).toBe("0%");
+  });
+});
+
+describe("formatYearFromMonth", () => {
+  it("converts month 0 to Year 0", () => {
+    expect(formatYearFromMonth(0)).toBe("Year 0");
+  });
+
+  it("converts month 12 to Year 1", () => {
+    expect(formatYearFromMonth(12)).toBe("Year 1");
+  });
+
+  it("converts month 24 to Year 2", () => {
+    expect(formatYearFromMonth(24)).toBe("Year 2");
+  });
+
+  it("rounds partial years", () => {
+    expect(formatYearFromMonth(18)).toBe("Year 2");
+    expect(formatYearFromMonth(6)).toBe("Year 1");
+  });
+
+  it("converts a large month value", () => {
+    expect(formatYearFromMonth(360)).toBe("Year 30");
+  });
+
+  it("converts month 480 to Year 40", () => {
+    expect(formatYearFromMonth(480)).toBe("Year 40");
+  });
+});


### PR DESCRIPTION
## Summary

Add unit tests for `monthsElapsedSince` (dateUtils) and `formatGBP`, `formatPercent`, `formatYearFromMonth` (format) — foundational utility functions used across the loan simulation and chart rendering. These modules previously had no dedicated test coverage.