### PR TITLE
fix: hide decorative shadow span from screen readers in BrandLogo

### DIFF
--- a/src/components/brand/BrandLogo.tsx
+++ b/src/components/brand/BrandLogo.tsx
@@ -19,8 +19,9 @@ export function BrandLogo({ size = "default", className }: BrandLogoProps) {
     <div className={cn("flex items-center", className)} style={{ gap }}>
       <BrandIcon size={size} />
       <div className="relative">
-        {/* Shadow layer */}
+        {/* Shadow layer — decorative, hidden from screen readers */}
         <span
+          aria-hidden="true"
           className="absolute font-display font-bold whitespace-nowrap text-primary/15"
           style={{
             top: shadowOffset.y,


### PR DESCRIPTION
## Summary

The BrandLogo component renders a translucent offset shadow `<span>` as a purely visual effect behind the logo text. Without `aria-hidden="true"`, screen readers announce the logo name twice — once for the real text and once for the decorative shadow. This adds `aria-hidden="true"` to the shadow span so assistive technologies correctly skip it.