### PR TITLE
fix: wrap which-plan page in AppErrorBoundary

### DIFF
--- a/src/app/which-plan/page.tsx
+++ b/src/app/which-plan/page.tsx
@@ -1,4 +1,5 @@
 import { QuizContainer } from "@/components/quiz/QuizContainer";
+import { AppErrorBoundary } from "@/components/shared/ErrorBoundary";
 import { Heading } from "@/components/typography/Heading";
 import { currencyFormatter } from "@/constants";
 import {
@@ -13,7 +14,7 @@ const ALL_PLANS = [
 
 export default function WhichPlanPage() {
   return (
-    <>
+    <AppErrorBoundary>
       <QuizContainer />
       <section className="border-t bg-muted/30">
         <div className="mx-auto max-w-4xl px-3 py-12">
@@ -58,6 +59,6 @@ export default function WhichPlanPage() {
           </div>
         </div>
       </section>
-    </>
+    </AppErrorBoundary>
   );
 }


### PR DESCRIPTION
## Summary

The `/which-plan` page content was wrapped in a bare React fragment (`<>...</>`), meaning any runtime error in child components (e.g. `QuizContainer`) would propagate uncaught and break the entire page. This wraps the page in `AppErrorBoundary` so users see a graceful fallback UI instead of a blank or broken page.