### PR TITLE
fix: replace HTML entity with literal ampersand in BoeBaseRateStep subtitle

### DIFF
--- a/src/components/wizard/BoeBaseRateStep.tsx
+++ b/src/components/wizard/BoeBaseRateStep.tsx
@@ -41,7 +41,7 @@ export function BoeBaseRateStep({
   return (
     <QuestionStep
       title="What Bank of England base rate do you expect?"
-      subtitle="Plan 1 &amp; 4 interest is the lesser of RPI or base rate + 1%"
+      subtitle="Plan 1 & 4 interest is the lesser of RPI or base rate + 1%"
       direction={direction}
     >
       <div className="space-y-6">


### PR DESCRIPTION
## Summary

The `subtitle` prop in `BoeBaseRateStep` contained the HTML entity `&amp;` instead of a literal `&`. Since this is a JSX string prop (not raw HTML), React does not interpret HTML entities — it renders them verbatim. This caused the subtitle to display as "Plan 1 &amp; 4 interest is the lesser of RPI or base rate + 1%" instead of the intended "Plan 1 & 4 interest is the lesser of RPI or base rate + 1%".