### PR TITLE
fix: replace <main> with <div> in modal components to avoid duplicate landmarks

### DIFF
--- a/src/components/home/LoanConfigPanel.tsx
+++ b/src/components/home/LoanConfigPanel.tsx
@@ -323,7 +323,7 @@ export function LoanConfigPanel({
         </div>
       </header>
 
-      <main className="flex flex-1 flex-col px-4 py-6">
+      <div className="flex flex-1 flex-col px-4 py-6">
         <div className="mx-auto w-full max-w-3xl space-y-6">
           <div className="space-y-3 md:flex md:gap-3 md:space-y-0">
             <div className="space-y-3 md:flex-1">
@@ -362,7 +362,7 @@ export function LoanConfigPanel({
             </Button>
           </div>
         </div>
-      </main>
+      </div>
 
       <footer className="sticky bottom-0 border-t border-border/50 bg-background/80 p-4 backdrop-blur-sm">
         <div className="mx-auto max-w-3xl">

--- a/src/components/wizard/AssumptionsWizard.tsx
+++ b/src/components/wizard/AssumptionsWizard.tsx
@@ -118,9 +118,9 @@ export function AssumptionsWizard({
         closeLabel="Done"
       />
 
-      <main className="flex flex-1 flex-col items-center justify-center px-4 py-8">
+      <div className="flex flex-1 flex-col items-center justify-center px-4 py-8">
         <div className="w-full max-w-lg">{renderStep()}</div>
-      </main>
+      </div>
 
       <LivePreview />
     </div>


### PR DESCRIPTION
## Summary

LoanConfigPanel and AssumptionsWizard are modal overlays rendered on top of the page, not the page's primary content area. Using `<main>` inside them creates multiple `<main>` landmarks on the page, which violates the HTML spec (only one visible `<main>` per page is allowed) and confuses screen readers and other assistive technologies. This replaces the `<main>` elements with `<div>` to fix the duplicate landmark issue.