### PR TITLE
refactor: eliminate unsafe type assertions in share URL and metadata

### DIFF
--- a/src/components/shared/PlanFromQuery.tsx
+++ b/src/components/shared/PlanFromQuery.tsx
@@ -11,11 +11,7 @@ import {
   trackSharedLumpSumLoaded,
   trackSharedRepaymentYearLoaded,
 } from "@/lib/analytics";
-import {
-  decodeParamsToState,
-  ASSUMPTION_PARAMS,
-  type DecodedState,
-} from "@/lib/shareUrl";
+import { decodeParamsToState, ASSUMPTION_PARAMS } from "@/lib/shareUrl";
 
 interface PlanFromQueryProps {
   onRepaymentYearChange?: (year: number) => void;
@@ -49,10 +45,10 @@ function PlanFromQueryInner({ onRepaymentYearChange }: PlanFromQueryProps) {
       updateField("monthlyOverpayment", decoded.monthlyOverpayment);
     }
     for (const field of ASSUMPTION_PARAMS) {
-      const value = decoded[field.stateKey as keyof DecodedState];
+      const value = decoded[field.stateKey];
       if (value !== undefined) {
-        trackSharedAssumptionLoaded(field.analyticsName, value as number);
-        updateField(field.stateKey, value as number);
+        trackSharedAssumptionLoaded(field.analyticsName, value);
+        updateField(field.stateKey, value);
       }
     }
     if (decoded.applyPlan2Freeze !== undefined) {

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,6 +1,6 @@
 import { currencyFormatter, DEFAULT_SALARY } from "@/constants";
 import { PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
-import type { Loan } from "@/lib/loans/types";
+import type { Loan, PlanType } from "@/lib/loans/types";
 import { DEFAULT_PRESET } from "@/lib/presets";
 import { decodeParamsToState } from "@/lib/shareUrl";
 
@@ -9,6 +9,13 @@ import { decodeParamsToState } from "@/lib/shareUrl";
  */
 const DEFAULT_LOANS: Loan[] = DEFAULT_PRESET.loans;
 const DEFAULT_SALARY_VALUE = DEFAULT_SALARY;
+
+/** Type guard: returns true if the plan type has an entry in PLAN_DISPLAY_INFO */
+function isUndergraduatePlan(
+  planType: PlanType,
+): planType is keyof typeof PLAN_DISPLAY_INFO {
+  return planType in PLAN_DISPLAY_INFO;
+}
 
 export interface DecodedMetadataParams {
   planName: string;
@@ -51,10 +58,10 @@ export function parseMetadataParams(
   const totalBalance = balance + pgBalance;
 
   const firstUgLoan = ugLoans.length > 0 ? ugLoans[0] : undefined;
-  const planName = firstUgLoan
-    ? PLAN_DISPLAY_INFO[firstUgLoan.planType as keyof typeof PLAN_DISPLAY_INFO]
-        .name
-    : "Postgraduate";
+  const planName =
+    firstUgLoan && isUndergraduatePlan(firstUgLoan.planType)
+      ? PLAN_DISPLAY_INFO[firstUgLoan.planType].name
+      : "Postgraduate";
 
   return {
     planName,

--- a/src/lib/shareUrl.test.ts
+++ b/src/lib/shareUrl.test.ts
@@ -61,7 +61,7 @@ describe("encodeStateToParams", () => {
     "always includes assumption field $urlParam",
     (field) => {
       const params = encodeStateToParams(mockState);
-      const expected = mockState[field.stateKey] as number;
+      const expected = mockState[field.stateKey];
       expect(params.get(field.urlParam)).toBe(String(expected));
     },
   );

--- a/src/lib/shareUrl.ts
+++ b/src/lib/shareUrl.ts
@@ -45,9 +45,19 @@ const LEGACY_SALARY_GROWTH_MAPPING: Record<string, number> = {
 // Config-driven assumption params
 // ---------------------------------------------------------------------------
 
+/** LoanState keys that hold numeric assumption values (used in URL encoding) */
+export type NumericAssumptionKey = Extract<
+  keyof LoanState,
+  | "salaryGrowthRate"
+  | "thresholdGrowthRate"
+  | "rpiRate"
+  | "boeBaseRate"
+  | "discountRate"
+>;
+
 export interface AssumptionParamConfig {
-  /** LoanState field name */
-  stateKey: keyof LoanState;
+  /** LoanState field name (restricted to numeric assumption fields) */
+  stateKey: NumericAssumptionKey;
   /** Short URL param key */
   urlParam: string;
   /** Analytics event name suffix, e.g. "salary_growth" → "shared_salary_growth_loaded" */
@@ -143,7 +153,7 @@ export function encodeStateToParams(
 
   // Assumption fields — always included
   for (const field of ASSUMPTION_PARAMS) {
-    const value = state[field.stateKey] as number;
+    const value = state[field.stateKey];
     params.set(field.urlParam, String(value));
   }
 
@@ -178,6 +188,31 @@ export interface DecodedState {
   repaymentYear?: number;
   showPresentValue?: boolean;
   discountRate?: number;
+}
+
+/** Type-safe setter for numeric assumption fields on DecodedState. */
+function setDecodedNumericField(
+  target: DecodedState,
+  key: NumericAssumptionKey,
+  value: number,
+): void {
+  switch (key) {
+    case "salaryGrowthRate":
+      target.salaryGrowthRate = value;
+      break;
+    case "thresholdGrowthRate":
+      target.thresholdGrowthRate = value;
+      break;
+    case "rpiRate":
+      target.rpiRate = value;
+      break;
+    case "boeBaseRate":
+      target.boeBaseRate = value;
+      break;
+    case "discountRate":
+      target.discountRate = value;
+      break;
+  }
 }
 
 /**
@@ -268,10 +303,13 @@ export function decodeParamsToState(params: URLSearchParams): DecodedState {
     if (raw !== null) {
       const num = parseFloat(raw);
       if (!isNaN(num)) {
-        (result as Record<string, unknown>)[field.stateKey] = num;
+        setDecodedNumericField(result, field.stateKey, num);
       } else if (field.legacyMapping && raw in field.legacyMapping) {
-        (result as Record<string, unknown>)[field.stateKey] =
-          field.legacyMapping[raw];
+        setDecodedNumericField(
+          result,
+          field.stateKey,
+          field.legacyMapping[raw],
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary

Replace unsafe type assertions (`as number`, `as Record<string, unknown>`, `as keyof typeof ...`) in the share URL encoding/decoding and metadata modules with proper type narrowing. This ensures the TypeScript compiler catches type mismatches at build time rather than silently allowing incorrect types through at runtime.

Key changes:
- Introduce `NumericAssumptionKey` type to restrict `AssumptionParamConfig.stateKey` to only the 5 numeric assumption fields, eliminating `as number` casts in consumers
- Add `setDecodedNumericField` type-safe setter to replace `(result as Record<string, unknown>)[field.stateKey]` casts in `decodeParamsToState`
- Add `isUndergraduatePlan` type guard in metadata module to replace `as keyof typeof PLAN_DISPLAY_INFO` cast
- Remove now-unnecessary `DecodedState` import and casts in `PlanFromQuery`