### PR TITLE
fix: use semantic <time> elements for date displays

### DIFF
--- a/src/components/layout/GovUkBadge.tsx
+++ b/src/components/layout/GovUkBadge.tsx
@@ -24,13 +24,14 @@ export function GovUkBadge({ className }: { className?: string }) {
         render={
           <Badge render={<button />} className={className}>
             <HugeiconsIcon icon={Tick02Icon} className="size-3" />
-            GOV.UK {formattedDate}
+            GOV.UK <time dateTime={LAST_UPDATED}>{formattedDate}</time>
           </Badge>
         }
       />
       <PopoverContent className="w-auto max-w-64 space-y-1.5">
         <p className="text-sm font-medium">
-          Rates &amp; thresholds as of {formattedDate}
+          Rates &amp; thresholds as of{" "}
+          <time dateTime={LAST_UPDATED}>{formattedDate}</time>
         </p>
         <p className="text-sm text-muted-foreground">
           Verified daily against GOV.UK and the Bank of England.

--- a/src/components/our-data/OurDataPage.tsx
+++ b/src/components/our-data/OurDataPage.tsx
@@ -182,9 +182,12 @@ export function OurDataPage() {
             <HugeiconsIcon icon={Tick02Icon} className="size-4 text-primary" />
             <p className="text-sm text-muted-foreground">
               Figures last updated{" "}
-              <span className="font-medium text-foreground">
+              <time
+                dateTime={LAST_UPDATED}
+                className="font-medium text-foreground"
+              >
                 {formattedLastUpdated}
-              </span>
+              </time>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Replace plain text and `<span>` date displays with semantic HTML `<time>` elements in the GOV.UK badge and Our Data page. The `<time>` elements include a machine-readable `dateTime` attribute with the ISO date string, improving accessibility for screen readers and providing structured date information for search engines.