### PR TITLE
fix: add radiogroup role and aria-label to wizard option groups

### DIFF
--- a/src/components/wizard/BoeBaseRateStep.tsx
+++ b/src/components/wizard/BoeBaseRateStep.tsx
@@ -46,7 +46,11 @@ export function BoeBaseRateStep({
     >
       <div className="space-y-6">
         <div className="space-y-3">
-          <div className="grid grid-cols-1 gap-3 xs:grid-cols-2">
+          <div
+            role="radiogroup"
+            aria-label="Bank of England base rate"
+            className="grid grid-cols-1 gap-3 xs:grid-cols-2"
+          >
             {BOE_BASE_RATE_OPTIONS.map((option) => (
               <OptionCard
                 key={option.label}

--- a/src/components/wizard/RpiStep.tsx
+++ b/src/components/wizard/RpiStep.tsx
@@ -41,7 +41,11 @@ export function RpiStep({ direction, onNext, done }: RpiStepProps) {
     >
       <div className="space-y-6">
         <div className="space-y-3">
-          <div className="grid grid-cols-1 gap-3 xs:grid-cols-2">
+          <div
+            role="radiogroup"
+            aria-label="RPI rate"
+            className="grid grid-cols-1 gap-3 xs:grid-cols-2"
+          >
             {RPI_OPTIONS.map((option) => (
               <OptionCard
                 key={option.label}

--- a/src/components/wizard/SalaryGrowthStep.tsx
+++ b/src/components/wizard/SalaryGrowthStep.tsx
@@ -41,7 +41,11 @@ export function SalaryGrowthStep({ direction, onNext }: SalaryGrowthStepProps) {
     >
       <div className="space-y-6">
         <div className="space-y-3">
-          <div className="grid grid-cols-1 gap-3 xs:grid-cols-2">
+          <div
+            role="radiogroup"
+            aria-label="Salary growth rate"
+            className="grid grid-cols-1 gap-3 xs:grid-cols-2"
+          >
             {SALARY_GROWTH_OPTIONS.map((option) => (
               <OptionCard
                 key={option.label}

--- a/src/components/wizard/ThresholdGrowthStep.tsx
+++ b/src/components/wizard/ThresholdGrowthStep.tsx
@@ -89,7 +89,11 @@ export function ThresholdGrowthStep({
         )}
 
         <div className="space-y-3">
-          <div className="grid grid-cols-1 gap-3 xs:grid-cols-2">
+          <div
+            role="radiogroup"
+            aria-label="Threshold growth rate"
+            className="grid grid-cols-1 gap-3 xs:grid-cols-2"
+          >
             {THRESHOLD_GROWTH_OPTIONS.map((option) => (
               <OptionCard
                 key={option.label}


### PR DESCRIPTION
## Summary

The OptionCard groups in wizard steps (BoeBaseRateStep, RpiStep, SalaryGrowthStep, ThresholdGrowthStep) behave as radio buttons but their container divs lacked the `role="radiogroup"` attribute and a descriptive `aria-label`. Without these, screen readers cannot convey that the options form a mutually exclusive group or communicate the group's purpose. This adds the missing ARIA semantics to all four wizard step components.