### PR TITLE
test: add accessibility e2e tests for detail and content pages

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -55,6 +55,60 @@ test.describe("Accessibility", () => {
     expect(results.violations).toEqual([]);
   });
 
+  test("balance detail page has no WCAG 2.1 AA violations", async ({
+    page,
+  }) => {
+    await page.goto("/balance");
+    await waitForResults(page);
+
+    const results = await axeScan(page).analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test("repaid detail page has no WCAG 2.1 AA violations", async ({ page }) => {
+    await page.goto("/repaid");
+    await waitForResults(page);
+
+    const results = await axeScan(page).analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test("interest detail page has no WCAG 2.1 AA violations", async ({
+    page,
+  }) => {
+    await page.goto("/interest");
+    await waitForResults(page);
+
+    const results = await axeScan(page).analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test("effective rate detail page has no WCAG 2.1 AA violations", async ({
+    page,
+  }) => {
+    await page.goto("/effective-rate");
+    await waitForResults(page);
+
+    const results = await axeScan(page).analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test("guides index page has no WCAG 2.1 AA violations", async ({ page }) => {
+    await page.goto("/guides");
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+
+    const results = await axeScan(page).analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test("our data page has no WCAG 2.1 AA violations", async ({ page }) => {
+    await page.goto("/our-data");
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+
+    const results = await axeScan(page).analyze();
+    expect(results.violations).toEqual([]);
+  });
+
   test("skip-to-content link is keyboard accessible", async ({ page }) => {
     await page.goto("/");
     await waitForResults(page);


### PR DESCRIPTION
## Summary

The existing accessibility e2e tests only covered the home page and the which-plan quiz page. This adds WCAG 2.1 AA axe-core scans for the remaining public pages — balance, repaid, interest, effective-rate, guides index, and our-data — to catch accessibility regressions across the full site.