### PR TITLE
fix: respect prefers-reduced-motion for body transitions

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -182,6 +182,10 @@ body {
   transition:
     background-color 300ms ease,
     color 300ms ease;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 }
 
 /* Quiz step animations */


### PR DESCRIPTION
## Summary

The body element applies a 300ms ease transition on `background-color` and `color` for smooth theme switching. However, this animation plays even for users who have enabled "reduce motion" in their OS accessibility settings. This adds a `prefers-reduced-motion: reduce` media query that disables the transition entirely, respecting the user's motion preference.