### PR TITLE
fix: improve related guide relevance for detail pages

### DIFF
--- a/src/components/detail/RelatedContent.tsx
+++ b/src/components/detail/RelatedContent.tsx
@@ -9,11 +9,11 @@ import type { GuideEntry, GuideSlug } from "@/lib/guides";
 import { GUIDES } from "@/lib/guides";
 
 const RELATED_GUIDES: Partial<Record<string, GuideSlug[]>> = {
-  "/repaid": ["how-interest-works", "plan-2-vs-plan-5"],
-  "/balance": ["how-interest-works", "plan-2-vs-plan-5"],
+  "/repaid": ["threshold-freeze", "plan-2-vs-plan-5"],
+  "/balance": ["threshold-freeze", "plan-2-vs-plan-5"],
   "/interest": ["how-interest-works", "rpi-vs-cpi"],
   "/effective-rate": ["rpi-vs-cpi", "student-loan-vs-mortgage"],
-  "/overpay": ["how-interest-works", "student-loan-vs-mortgage"],
+  "/overpay": ["pay-upfront-or-take-loan", "how-interest-works"],
 };
 
 export function RelatedContent() {


### PR DESCRIPTION
## Summary

The related guide recommendations on several detail pages were not as contextually relevant as they could be. This updates the mappings so that:

- **/repaid** and **/balance** pages now suggest the "threshold freeze" guide instead of "how interest works" — threshold freezes directly impact repayment timelines and balance growth, making this guide more actionable for users viewing these pages.
- **/overpay** page now leads with the "pay upfront or take loan" guide instead of "how interest works" — users considering overpayments benefit more from the cost-benefit framing of the upfront-vs-loan guide.