### PR TITLE
chore: remove dead resetAction and ResetAction from loanReducer

### DIFF
--- a/src/context/loanReducer.test.ts
+++ b/src/context/loanReducer.test.ts
@@ -5,7 +5,6 @@ import {
   loanReducer,
   initialState,
   updateFieldAction,
-  resetAction,
   applyPresetAction,
 } from "./loanReducer";
 
@@ -122,50 +121,6 @@ describe("loanReducer", () => {
       );
       expect(newState.rpiRate).toBe(6.0);
       expect(newState.boeBaseRate).toBe(5.5);
-    });
-  });
-
-  describe("RESET action", () => {
-    it("should reset all fields to initial values", () => {
-      // Start with modified state
-      let state = loanReducer(
-        initialState,
-        updateFieldAction("loans", [
-          { planType: "PLAN_5", balance: 100_000 },
-          { planType: "POSTGRADUATE", balance: 30_000 },
-        ]),
-      );
-      state = loanReducer(state, updateFieldAction("salary", 60_000));
-
-      // Reset
-      const resetState = loanReducer(state, resetAction());
-
-      // Verify all fields are back to initial values
-      expect(resetState.loans).toEqual([
-        { planType: "PLAN_2", balance: 45_000 },
-      ]);
-      expect(resetState.salary).toBe(45_000);
-    });
-
-    it("should restore showPresentValue and discountRate to initial values", () => {
-      let state = loanReducer(
-        initialState,
-        updateFieldAction("showPresentValue", true),
-      );
-      state = loanReducer(state, updateFieldAction("discountRate", 0.1));
-
-      const resetState = loanReducer(state, resetAction());
-      expect(resetState.showPresentValue).toBe(false);
-      expect(resetState.discountRate).toBe(CURRENT_RATES.cpi / 100);
-    });
-
-    it("should restore rpiRate and boeBaseRate to initial values", () => {
-      let state = loanReducer(initialState, updateFieldAction("rpiRate", 7.0));
-      state = loanReducer(state, updateFieldAction("boeBaseRate", 6.0));
-
-      const resetState = loanReducer(state, resetAction());
-      expect(resetState.rpiRate).toBe(CURRENT_RATES.rpi);
-      expect(resetState.boeBaseRate).toBe(CURRENT_RATES.boeBaseRate);
     });
   });
 });

--- a/src/context/loanReducer.ts
+++ b/src/context/loanReducer.ts
@@ -29,16 +29,12 @@ type UpdateFieldAction<K extends keyof LoanState = keyof LoanState> = {
   value: LoanState[K];
 };
 
-type ResetAction = {
-  type: "RESET";
-};
-
 type ApplyPresetAction = {
   type: "APPLY_PRESET";
   preset: Preset;
 };
 
-export type LoanAction = UpdateFieldAction | ResetAction | ApplyPresetAction;
+export type LoanAction = UpdateFieldAction | ApplyPresetAction;
 
 // Action creators
 export function updateFieldAction<K extends keyof LoanState>(
@@ -46,10 +42,6 @@ export function updateFieldAction<K extends keyof LoanState>(
   value: LoanState[K],
 ): UpdateFieldAction<K> {
   return { type: "UPDATE_FIELD", key, value };
-}
-
-export function resetAction(): ResetAction {
-  return { type: "RESET" };
 }
 
 export function applyPresetAction(preset: Preset): ApplyPresetAction {
@@ -61,14 +53,10 @@ export function loanReducer(state: LoanState, action: LoanAction): LoanState {
   switch (action.type) {
     case "UPDATE_FIELD":
       return { ...state, [action.key]: action.value };
-    case "RESET":
-      return initialState;
     case "APPLY_PRESET":
       return {
         ...state,
         loans: action.preset.loans,
       };
-    default:
-      return state;
   }
 }


### PR DESCRIPTION
## Summary

The `resetAction` action creator and `ResetAction` type were never dispatched from any component — they were dead code left over from an earlier iteration. This removes them along with the `"RESET"` switch case in the reducer and the corresponding test block (3 tests). The unreachable `default` case is also removed since TypeScript exhaustive checking now covers the discriminated union.

Continues the dead code cleanup effort from recent PRs (#310, #312, #313, #314).