### PR TITLE
fix: add aria-live region to InsightBadge for screen reader announcements

### DIFF
--- a/src/components/home/InsightCallout.tsx
+++ b/src/components/home/InsightCallout.tsx
@@ -98,6 +98,8 @@ export function InsightBadge() {
   return (
     <div
       className={`hidden items-center gap-1.5 rounded-md border px-2 py-1 sm:flex ${config.bgClass} ${config.borderClass}`}
+      role="status"
+      aria-live="polite"
     >
       <HugeiconsIcon
         icon={config.icon}


### PR DESCRIPTION
## Summary

The `InsightBadge` component displays dynamic status text (e.g. "will be forgiven", "will be repaid", "repaid early") that updates as simulation parameters change. Without ARIA live region attributes, screen readers do not announce these updates, leaving assistive technology users unaware of the badge content. This adds `role="status"` and `aria-live="polite"` to the badge container so changes are announced non-intrusively.