### PR TITLE
chore: remove unused setMode export and narrow peakPct scope

### DIFF
--- a/src/components/detail/BalanceDetailPage.tsx
+++ b/src/components/detail/BalanceDetailPage.tsx
@@ -18,9 +18,6 @@ export function BalanceDetailPage() {
       result.stats;
 
     const peakYears = Math.round(peakBalanceMonth / 12);
-    const peakPct = Math.round(
-      ((peakBalance - initialBalance) / initialBalance) * 100,
-    );
 
     if (peakBalanceMonth === 0) {
       return writtenOff
@@ -29,6 +26,10 @@ export function BalanceDetailPage() {
     }
 
     if (writtenOff) {
+      const peakPct =
+        initialBalance > 0
+          ? Math.round(((peakBalance - initialBalance) / initialBalance) * 100)
+          : 0;
       return `Interest outpaces repayments for the first ${String(peakYears)} years, pushing your balance ${String(peakPct)}% above what you borrowed. The remaining balance is written off after ${String(payoffYears)} years.`;
     }
 

--- a/src/hooks/useInputPanelMode.ts
+++ b/src/hooks/useInputPanelMode.ts
@@ -61,7 +61,6 @@ export function useInputPanelMode(options?: UseInputPanelModeOptions) {
 
   return {
     mode,
-    setMode,
     hasPersonalized,
     handlePersonalise,
     handleWizardComplete,


### PR DESCRIPTION
## Summary

Remove two pieces of dead code: the `setMode` return value from `useInputPanelMode` (used internally but never consumed by callers) and the `peakPct` variable that was computed unconditionally in `BalanceDetailPage` despite only being used in the `writtenOff` branch. Moving `peakPct` into its branch also adds a zero-division guard for when `initialBalance` is 0.