### PR TITLE
chore: remove unused accordion keyframes and table sub-components

### DIFF
--- a/src/app/shadcn.css
+++ b/src/app/shadcn.css
@@ -1,29 +1,4 @@
 /* Vendored from shadcn/tailwind.css */
-@theme inline {
-  @keyframes accordion-down {
-    from {
-      height: 0;
-    }
-    to {
-      height: var(
-        --radix-accordion-content-height,
-        var(--accordion-panel-height, auto)
-      );
-    }
-  }
-
-  @keyframes accordion-up {
-    from {
-      height: var(
-        --radix-accordion-content-height,
-        var(--accordion-panel-height, auto)
-      );
-    }
-    to {
-      height: 0;
-    }
-  }
-}
 
 @custom-variant data-open {
   &:where([data-state="open"]),

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -38,19 +38,6 @@ function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
   );
 }
 
-function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
-  return (
-    <tfoot
-      data-slot="table-footer"
-      className={cn(
-        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
-        className,
-      )}
-      {...props}
-    />
-  );
-}
-
 function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
   return (
     <tr
@@ -92,26 +79,4 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
   );
 }
 
-function TableCaption({
-  className,
-  ...props
-}: React.ComponentProps<"caption">) {
-  return (
-    <caption
-      data-slot="table-caption"
-      className={cn("mt-4 text-sm text-muted-foreground", className)}
-      {...props}
-    />
-  );
-}
-
-export {
-  Table,
-  TableHeader,
-  TableBody,
-  TableFooter,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableCaption,
-};
+export { Table, TableHeader, TableBody, TableHead, TableRow, TableCell };


### PR DESCRIPTION
## Summary

Removes dead shadcn/ui artifacts that are no longer referenced anywhere in the codebase: the `accordion-down` / `accordion-up` CSS keyframe animations from `shadcn.css`, and the `TableFooter` / `TableCaption` components from `table.tsx`. These were left behind after the Accordion component and other unused shadcn/ui components were removed in earlier cleanups (#312).