### PR TITLE
test: remove unnecessary context mocks from SalaryExplorer tests

### DIFF
--- a/src/components/home/SalaryExplorer.test.tsx
+++ b/src/components/home/SalaryExplorer.test.tsx
@@ -5,20 +5,8 @@ import { LoanProvider } from "@/context/LoanContext";
 import type { LoanState } from "@/types/store";
 import { SalaryExplorer } from "./SalaryExplorer";
 
-vi.mock("@/context/AssumptionsWizardContext", () => ({
-  useAssumptionsWizard: () => ({ openAssumptions: vi.fn() }),
-}));
-
 vi.mock("@/components/charts/TotalRepaymentChart", () => ({
   TotalRepaymentChart: () => <div data-testid="chart" />,
-}));
-
-vi.mock("@/context/PersonalizedResultsContext", () => ({
-  usePersonalizedResults: () => ({
-    summary: null,
-    insight: null,
-    cards: null,
-  }),
 }));
 
 function createWrapper(overrides?: Partial<LoanState>) {


### PR DESCRIPTION
## Summary

Removes two unnecessary `vi.mock()` calls from `SalaryExplorer.test.tsx` — one for `useAssumptionsWizard` and one for `usePersonalizedResults`. The test already wraps components with a real `LoanProvider` using `initialStateOverride`, so these manual context mocks are redundant and contradict the project's testing convention of using real providers instead of `vi.mock` for context.