### PR TITLE
chore: remove dead eslint override for deleted calendar component

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,13 +54,6 @@ export default defineConfig(
     },
   },
   {
-    // shadcn calendar uses inline component definitions for react-day-picker's components prop
-    files: ["src/components/ui/calendar.tsx"],
-    rules: {
-      "@eslint-react/no-nested-component-definitions": "off",
-    },
-  },
-  {
     // JSON-LD structured data in layouts and shadcn chart styles require dangerouslySetInnerHTML
     files: ["src/app/**/layout.tsx", "src/components/ui/chart.tsx"],
     rules: {


### PR DESCRIPTION
## Summary

The `calendar.tsx` shadcn/ui component was removed in #312, but the eslint config override that disabled `@eslint-react/no-nested-component-definitions` for that file was left behind. This removes the stale override block from `eslint.config.js`.