### PR TITLE
docs: add code quality rule to preserve ShadCN components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@ Local steps:
 
 ## Code Quality
 
+- **Do not modify ShadCN components** (`src/components/ui/`) — exceptions: auto-formatting and bug fixes (bug fixes require an explicit comment explaining the fix)
+
 **Never use:**
 
 - `eslint-disable`, `@ts-ignore`, `@ts-expect-error`


### PR DESCRIPTION
## Summary

Add an AGENTS.md rule that ShadCN UI components (`src/components/ui/`) should not be modified, with exceptions for auto-formatting and bug fixes (which require an explicit comment explaining the fix). This prevents accidental drift from upstream ShadCN defaults, making future component upgrades straightforward and keeping the UI library consistent.