### PR TITLE
refactor: derive footer guide links from GUIDES constant

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"fead69a1-e87b-4b6c-bbbf-3a24edaf7be3","pid":21321,"acquiredAt":1774712800927}


### PR DESCRIPTION
## Summary

The footer was hardcoding all eight guide links, duplicating the same slugs and titles already defined in the `GUIDES` array in `src/lib/guides.ts`. This replaces the static list with a `.map()` over the shared constant, so adding or reordering guides only requires updating one place.