### PR TITLE
chore: migrate file symlinks to .worktreeinclude

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,11 +4,7 @@
     "deny": ["Read(./.env)", "Read(./.env.*)"]
   },
   "worktree": {
-    "symlinkDirectories": [
-      "node_modules",
-      ".claude/settings.local.json",
-      ".env.local"
-    ]
+    "symlinkDirectories": ["node_modules"]
   },
   "showClearContextOnPlanAccept": true,
   "hooks": {

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+.claude/settings.local.json
+.env.local


### PR DESCRIPTION
## Summary

Move `.claude/settings.local.json` and `.env.local` from `worktree.symlinkDirectories` in `.claude/settings.json` to a new `.worktreeinclude` file. The `symlinkDirectories` option is meant for directories (like `node_modules`), so individual files are better handled via `.worktreeinclude`.