### PR TITLE
fix: link lump sum max hint to input via aria-describedby

### DIFF
--- a/src/components/overpay/OverpayPrimaryInputs.tsx
+++ b/src/components/overpay/OverpayPrimaryInputs.tsx
@@ -80,9 +80,10 @@ export function OverpayPrimaryInputs({
                 placeholder="0"
                 className="pl-6"
                 aria-label="Enter one-off lump sum payment"
+                aria-describedby="lump-sum-max"
               />
             </div>
-            <p className="text-xs text-muted-foreground">
+            <p id="lump-sum-max" className="text-xs text-muted-foreground">
               Max: {currencyFormatter.format(totalBalance)}
             </p>
           </>


### PR DESCRIPTION
## Summary

Screen readers did not announce the maximum allowed lump sum value when users focused the input field. This adds an `aria-describedby` association between the lump sum input and its "Max: ..." helper text, so assistive technology users hear the constraint when interacting with the field.