### PR TITLE
chore: remove dead exports and redundant alias

### DIFF
--- a/src/lib/detailPages.ts
+++ b/src/lib/detailPages.ts
@@ -35,24 +35,3 @@ export const DETAIL_PAGES: DetailPageConfig[] = [
 export const DETAIL_PAGE_COLOR: Record<string, string> = Object.fromEntries(
   DETAIL_PAGES.map((p) => [p.href, p.color]),
 );
-
-export interface ToolPageConfig extends DetailPageConfig {
-  separated?: boolean;
-}
-
-export const TOOL_PAGES: ToolPageConfig[] = [
-  {
-    href: "/",
-    label: "Overview",
-    shortLabel: "Overview",
-    color: "var(--primary)",
-  },
-  ...DETAIL_PAGES,
-  {
-    href: "/overpay",
-    label: "Overpay",
-    shortLabel: "Overpay",
-    color: "var(--chart-overpay)",
-    separated: true,
-  },
-];

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -8,7 +8,6 @@ import { decodeParamsToState } from "@/lib/shareUrl";
  * Default values derived from DEFAULT_PRESET to stay in sync.
  */
 const DEFAULT_LOANS: Loan[] = DEFAULT_PRESET.loans;
-const DEFAULT_SALARY_VALUE = DEFAULT_SALARY;
 
 /** Type guard: returns true if the plan type has an entry in PLAN_DISPLAY_INFO */
 function isUndergraduatePlan(
@@ -49,7 +48,7 @@ export function parseMetadataParams(
   const hasShareParams = Object.keys(decoded).length > 0;
 
   const loans = decoded.loans ?? DEFAULT_LOANS;
-  const salary = decoded.salary ?? DEFAULT_SALARY_VALUE;
+  const salary = decoded.salary ?? DEFAULT_SALARY;
 
   const ugLoans = loans.filter((l) => l.planType !== "POSTGRADUATE");
   const pgLoans = loans.filter((l) => l.planType === "POSTGRADUATE");

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -42,7 +42,7 @@ export const PRESETS: Preset[] = [
   },
 ];
 
-export const DEFAULT_PRESET_ID = "plan2-grad";
+const DEFAULT_PRESET_ID = "plan2-grad";
 
 /** Returns true if the given loans exactly match any preset configuration. */
 export function isPresetConfig(loans: Loan[]): boolean {


### PR DESCRIPTION
## Summary

Remove unused `ToolPageConfig` interface and `TOOL_PAGES` array from `detailPages.ts` (zero consumers), eliminate the redundant `DEFAULT_SALARY_VALUE` alias in `metadata.ts` (was just re-aliasing the already-imported `DEFAULT_SALARY`), and narrow `DEFAULT_PRESET_ID` in `presets.ts` from an exported `const` to a module-private one since it is only referenced within the same file.

Reduces the public API surface and removes dead code that could mislead future readers.