### PR TITLE
feat: add OpenGraph metadata to detail page shared URLs

### DIFF
--- a/src/app/balance/page.tsx
+++ b/src/app/balance/page.tsx
@@ -1,5 +1,36 @@
+import type { Metadata } from "next";
 import { BalanceDetailPage } from "@/components/detail/BalanceDetailPage";
 import { AppErrorBoundary } from "@/components/shared/ErrorBoundary";
+import { parseMetadataParams } from "@/lib/metadata";
+
+interface Props {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export async function generateMetadata({
+  searchParams,
+}: Props): Promise<Metadata> {
+  const params = await searchParams;
+  const meta = parseMetadataParams(params);
+
+  if (!meta.hasShareParams) {
+    return {};
+  }
+
+  const title = `${meta.planName} loan of ${meta.formattedBalance} at ${meta.formattedSalary} — Payoff Timeline`;
+  const description = `See how long it takes to pay off a ${meta.planName} UK student loan with ${meta.formattedBalance} balance and ${meta.formattedSalary} annual salary.`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: "https://studentloanstudy.uk/balance",
+      type: "website",
+    },
+  };
+}
 
 export default function BalanceRoute() {
   return (

--- a/src/app/effective-rate/page.tsx
+++ b/src/app/effective-rate/page.tsx
@@ -1,5 +1,36 @@
+import type { Metadata } from "next";
 import { EffectiveRateDetailPage } from "@/components/detail/EffectiveRateDetailPage";
 import { AppErrorBoundary } from "@/components/shared/ErrorBoundary";
+import { parseMetadataParams } from "@/lib/metadata";
+
+interface Props {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export async function generateMetadata({
+  searchParams,
+}: Props): Promise<Metadata> {
+  const params = await searchParams;
+  const meta = parseMetadataParams(params);
+
+  if (!meta.hasShareParams) {
+    return {};
+  }
+
+  const title = `${meta.planName} loan of ${meta.formattedBalance} at ${meta.formattedSalary} — Effective Rate`;
+  const description = `See the true effective annual rate of a ${meta.planName} UK student loan with ${meta.formattedBalance} balance and ${meta.formattedSalary} annual salary.`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: "https://studentloanstudy.uk/effective-rate",
+      type: "website",
+    },
+  };
+}
 
 export default function EffectiveRateRoute() {
   return (

--- a/src/app/interest/page.tsx
+++ b/src/app/interest/page.tsx
@@ -1,5 +1,36 @@
+import type { Metadata } from "next";
 import { InterestDetailPage } from "@/components/detail/InterestDetailPage";
 import { AppErrorBoundary } from "@/components/shared/ErrorBoundary";
+import { parseMetadataParams } from "@/lib/metadata";
+
+interface Props {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export async function generateMetadata({
+  searchParams,
+}: Props): Promise<Metadata> {
+  const params = await searchParams;
+  const meta = parseMetadataParams(params);
+
+  if (!meta.hasShareParams) {
+    return {};
+  }
+
+  const title = `${meta.planName} loan of ${meta.formattedBalance} at ${meta.formattedSalary} — Interest Breakdown`;
+  const description = `See how much interest you pay on a ${meta.planName} UK student loan with ${meta.formattedBalance} balance and ${meta.formattedSalary} annual salary.`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: "https://studentloanstudy.uk/interest",
+      type: "website",
+    },
+  };
+}
 
 export default function InterestRoute() {
   return (

--- a/src/app/repaid/page.tsx
+++ b/src/app/repaid/page.tsx
@@ -1,5 +1,36 @@
+import type { Metadata } from "next";
 import { RepaidDetailPage } from "@/components/detail/RepaidDetailPage";
 import { AppErrorBoundary } from "@/components/shared/ErrorBoundary";
+import { parseMetadataParams } from "@/lib/metadata";
+
+interface Props {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export async function generateMetadata({
+  searchParams,
+}: Props): Promise<Metadata> {
+  const params = await searchParams;
+  const meta = parseMetadataParams(params);
+
+  if (!meta.hasShareParams) {
+    return {};
+  }
+
+  const title = `${meta.planName} loan of ${meta.formattedBalance} at ${meta.formattedSalary} — Total Repayments`;
+  const description = `See the total repayment cost for a ${meta.planName} UK student loan with ${meta.formattedBalance} balance and ${meta.formattedSalary} annual salary.`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: "https://studentloanstudy.uk/repaid",
+      type: "website",
+    },
+  };
+}
 
 export default function RepaidRoute() {
   return (


### PR DESCRIPTION
## Summary

The homepage already generates dynamic OpenGraph metadata when users share URLs with query parameters (plan, balance, salary) via #315, but the four detail pages (balance, effective-rate, interest, repaid) returned generic metadata for shared links. This adds the same `generateMetadata` pattern to all detail routes so social previews show personalized titles and descriptions — e.g. "Plan 2 loan of £30,000 at £35,000 — Payoff Timeline" instead of the default page title.

Each detail page uses `parseMetadataParams` from `src/lib/metadata.ts` to extract share parameters and generates page-specific titles and descriptions (Payoff Timeline, Effective Rate, Interest Breakdown, Total Repayments).