### PR TITLE
feat: add OpenGraph metadata to overpay page

### DIFF
--- a/src/app/overpay/page.tsx
+++ b/src/app/overpay/page.tsx
@@ -32,6 +32,12 @@ export async function generateMetadata({
     alternates: {
       canonical: "/overpay",
     },
+    openGraph: {
+      title,
+      description,
+      url: "https://studentloanstudy.uk/overpay",
+      type: "website",
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

Adds OpenGraph metadata to the overpay page so that social media platforms (Facebook, LinkedIn, etc.) display a proper title, description, and URL when the page is shared. The overpay page was missing these tags, meaning shared links would fall back to generic defaults or auto-scraped content.