### PR TITLE
chore: remove dead mainClassName prop and fix eslint override

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,8 +54,13 @@ export default defineConfig(
     },
   },
   {
-    // JSON-LD structured data in layouts and shadcn chart styles require dangerouslySetInnerHTML
-    files: ["src/app/**/layout.tsx", "src/components/ui/chart.tsx"],
+    // JSON-LD structured data in layouts, shadcn chart styles, and global-error
+    // inline CSS require dangerouslySetInnerHTML
+    files: [
+      "src/app/**/layout.tsx",
+      "src/app/global-error.tsx",
+      "src/components/ui/chart.tsx",
+    ],
     rules: {
       "@eslint-react/dom/no-dangerously-set-innerhtml": "off",
     },

--- a/src/components/layout/PageLayout.tsx
+++ b/src/components/layout/PageLayout.tsx
@@ -1,27 +1,18 @@
 import { Footer } from "@/components/layout/Footer";
 import { Header } from "@/components/layout/Header";
-import { cn } from "@/lib/utils";
 
 interface PageLayoutProps {
   children: React.ReactNode;
   repaymentYear?: number;
-  mainClassName?: string;
 }
 
-export function PageLayout({
-  children,
-  repaymentYear,
-  mainClassName,
-}: PageLayoutProps) {
+export function PageLayout({ children, repaymentYear }: PageLayoutProps) {
   return (
     <div className="flex min-h-screen flex-col">
       <Header repaymentYear={repaymentYear} />
       <main
         id="main-content"
-        className={cn(
-          "mx-auto w-full max-w-4xl flex-1 space-y-6 px-3 pt-8 pb-6 sm:pt-18 md:pb-8",
-          mainClassName,
-        )}
+        className="mx-auto w-full max-w-4xl flex-1 space-y-6 px-3 pt-8 pb-6 sm:pt-18 md:pb-8"
       >
         {children}
       </main>


### PR DESCRIPTION
## Summary

Remove the unused `mainClassName` prop from `PageLayout` — no consumers pass it, so it's dead code along with the `cn()` wrapper it required. Also add `src/app/global-error.tsx` to the `dangerouslySetInnerHTML` ESLint override, since it legitimately uses inline CSS for the global error boundary and would otherwise be flagged.