### PR TITLE
fix: allow Vite to serve resolved node_modules in git worktrees

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,6 @@
+import { realpathSync } from "node:fs";
 import { createRequire } from "node:module";
+import { dirname } from "node:path";
 import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
@@ -8,14 +10,29 @@ import { defineConfig } from "vitest/config";
 // worktree (where .git is a file pointing back to the primary checkout).
 const require = createRequire(import.meta.url);
 
+// In git worktrees, node_modules is a symlink to the main repo's node_modules.
+// require.resolve follows the symlink and returns the real path inside the main
+// repo, which is outside the worktree root. Vite's dev server blocks /@fs/
+// requests to paths outside the allowed roots, so we must explicitly allow the
+// real node_modules directory.
+const resolvedWebWorker = require.resolve("@vitest/web-worker");
+const realNodeModulesDir = dirname(
+  realpathSync(new URL("node_modules", import.meta.url)),
+);
+
 export default defineConfig({
   plugins: [
     react({ babel: { plugins: ["babel-plugin-react-compiler"] } }),
     tsconfigPaths(),
   ],
+  server: {
+    fs: {
+      allow: [realNodeModulesDir],
+    },
+  },
   test: {
     environment: "jsdom",
-    setupFiles: [require.resolve("@vitest/web-worker"), "./src/test/setup.ts"],
+    setupFiles: [resolvedWebWorker, "./src/test/setup.ts"],
     exclude: ["e2e/**", "scripts/**", "node_modules/**"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary

In git worktrees, `node_modules` is a symlink pointing back to the main repository. When `require.resolve` follows this symlink (e.g. for `@vitest/web-worker`), it returns a real path outside the worktree root. Vite's dev server security blocks `/@fs/` requests to paths outside its allowed roots, causing test setup failures.

This fix resolves the real `node_modules` directory path and adds it to `server.fs.allow`, so Vite can serve files from the symlinked `node_modules` regardless of where the real path lives.