### PR TITLE
fix: add missing footer to which-plan page

### DIFF
--- a/src/app/which-plan/page.tsx
+++ b/src/app/which-plan/page.tsx
@@ -1,3 +1,4 @@
+import { Footer } from "@/components/layout/Footer";
 import { QuizContainer } from "@/components/quiz/QuizContainer";
 import { Heading } from "@/components/typography/Heading";
 import { currencyFormatter } from "@/constants";
@@ -13,51 +14,54 @@ const ALL_PLANS = [
 
 export default function WhichPlanPage() {
   return (
-    <main id="main-content">
-      <QuizContainer />
-      <section className="border-t bg-muted/30">
-        <div className="mx-auto max-w-4xl px-3 py-12">
-          <div className="mb-8 text-center">
-            <Heading as="h2" size="section">
-              All UK Student Loan Plans
-            </Heading>
-            <p className="mt-2 text-muted-foreground">
-              A quick reference for every UK student loan plan type —
-              thresholds, repayment rates, and write-off periods at a glance.
-            </p>
+    <div className="flex min-h-screen flex-col">
+      <main id="main-content" className="flex-1">
+        <QuizContainer />
+        <section className="border-t bg-muted/30">
+          <div className="mx-auto max-w-4xl px-3 py-12">
+            <div className="mb-8 text-center">
+              <Heading as="h2" size="section">
+                All UK Student Loan Plans
+              </Heading>
+              <p className="mt-2 text-muted-foreground">
+                A quick reference for every UK student loan plan type —
+                thresholds, repayment rates, and write-off periods at a glance.
+              </p>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {ALL_PLANS.map((plan) => (
+                <div key={plan.name} className="rounded-xl border bg-card p-5">
+                  <h3 className="font-semibold">{plan.name}</h3>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {plan.description}
+                  </p>
+                  <dl className="mt-4 space-y-2 text-sm">
+                    <div className="flex items-baseline justify-between gap-2">
+                      <dt className="text-muted-foreground">Threshold</dt>
+                      <dd className="font-mono font-semibold tabular-nums">
+                        {currencyFormatter.format(plan.yearlyThreshold)}/yr
+                      </dd>
+                    </div>
+                    <div className="flex items-baseline justify-between gap-2">
+                      <dt className="text-muted-foreground">Rate</dt>
+                      <dd className="font-mono font-semibold tabular-nums">
+                        {String(plan.repaymentRate * 100)}%
+                      </dd>
+                    </div>
+                    <div className="flex items-baseline justify-between gap-2">
+                      <dt className="text-muted-foreground">Write-off</dt>
+                      <dd className="font-mono font-semibold tabular-nums">
+                        {String(plan.writeOffYears)} years
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+              ))}
+            </div>
           </div>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {ALL_PLANS.map((plan) => (
-              <div key={plan.name} className="rounded-xl border bg-card p-5">
-                <h3 className="font-semibold">{plan.name}</h3>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {plan.description}
-                </p>
-                <dl className="mt-4 space-y-2 text-sm">
-                  <div className="flex items-baseline justify-between gap-2">
-                    <dt className="text-muted-foreground">Threshold</dt>
-                    <dd className="font-mono font-semibold tabular-nums">
-                      {currencyFormatter.format(plan.yearlyThreshold)}/yr
-                    </dd>
-                  </div>
-                  <div className="flex items-baseline justify-between gap-2">
-                    <dt className="text-muted-foreground">Rate</dt>
-                    <dd className="font-mono font-semibold tabular-nums">
-                      {String(plan.repaymentRate * 100)}%
-                    </dd>
-                  </div>
-                  <div className="flex items-baseline justify-between gap-2">
-                    <dt className="text-muted-foreground">Write-off</dt>
-                    <dd className="font-mono font-semibold tabular-nums">
-                      {String(plan.writeOffYears)} years
-                    </dd>
-                  </div>
-                </dl>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-    </main>
+        </section>
+      </main>
+      <Footer />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

The which-plan page was the only page missing a site footer, creating an inconsistent experience compared to every other page that uses `PageLayout`. This adds the `Footer` component and wraps the page content in a `flex min-h-screen flex-col` container so the footer is pushed to the bottom of the viewport, matching the layout pattern used elsewhere.