### PR TITLE
feat: add breadcrumb navigation to detail pages

### DIFF
--- a/src/components/detail/DetailPageShell.tsx
+++ b/src/components/detail/DetailPageShell.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { PageLayout } from "@/components/layout/PageLayout";
 import { AssumptionsCallout } from "@/components/shared/AssumptionsCallout";
@@ -7,6 +8,14 @@ import { ControlBar } from "@/components/shared/ControlBar";
 import { InsightCards } from "@/components/shared/InsightCards";
 import { PlanFromQuery } from "@/components/shared/PlanFromQuery";
 import { Heading } from "@/components/typography/Heading";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
 import { RelatedContent } from "./RelatedContent";
 
 interface DetailPageShellProps {
@@ -26,11 +35,25 @@ export function DetailPageShell({
     <>
       <PlanFromQuery />
       <PageLayout>
-        <div className="space-y-1">
-          <Heading as="h1">{heading}</Heading>
-          <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
-            {description}
-          </p>
+        <div className="space-y-4">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>{heading}</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+
+          <div className="space-y-1">
+            <Heading as="h1">{heading}</Heading>
+            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+              {description}
+            </p>
+          </div>
         </div>
 
         {children}


### PR DESCRIPTION
## Summary

Adds a breadcrumb trail (Home > page heading) to all detail pages via `DetailPageShell`. This gives users a clear orientation cue and a quick way to navigate back to the home page, improving wayfinding on deeper pages like balance, interest, effective rate, and repaid.

Uses the existing ShadCN `Breadcrumb` component with Next.js `Link` for client-side navigation.