### PR TITLE
fix: add homepage link to global error page

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,6 +66,14 @@ export default defineConfig(
     },
   },
   {
+    // global-error.tsx renders a standalone HTML document outside the Next.js
+    // router context, so next/link is unavailable — plain <a> is correct here.
+    files: ["src/app/global-error.tsx"],
+    rules: {
+      "@next/next/no-html-link-for-pages": "off",
+    },
+  },
+  {
     ignores: [
       "node_modules",
       ".next",

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -38,10 +38,10 @@ export default function GlobalError({
                   --ge-hover-border: #666;
                 }
               }
-              button[data-ge]:hover {
+              [data-ge]:hover {
                 border-color: var(--ge-hover-border);
               }
-              button[data-ge]:focus-visible {
+              [data-ge]:focus-visible {
                 outline: 2px solid var(--ge-fg);
                 outline-offset: 2px;
               }
@@ -85,23 +85,50 @@ export default function GlobalError({
             An unexpected error prevented the page from loading. Please try
             again.
           </p>
-          <button
-            type="button"
-            data-ge=""
-            onClick={reset}
+          <div
             style={{
-              padding: "0.625rem 1.25rem",
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              borderRadius: "0.5rem",
-              border: "1px solid var(--ge-border)",
-              backgroundColor: "transparent",
-              color: "var(--ge-fg)",
-              cursor: "pointer",
+              display: "flex",
+              gap: "0.75rem",
+              justifyContent: "center",
             }}
           >
-            Try again
-          </button>
+            <button
+              type="button"
+              data-ge=""
+              onClick={reset}
+              style={{
+                padding: "0.625rem 1.25rem",
+                fontSize: "0.875rem",
+                fontWeight: 500,
+                borderRadius: "0.5rem",
+                border: "1px solid var(--ge-border)",
+                backgroundColor: "transparent",
+                color: "var(--ge-fg)",
+                cursor: "pointer",
+              }}
+            >
+              Try again
+            </button>
+            <a
+              href="/"
+              data-ge=""
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                padding: "0.625rem 1.25rem",
+                fontSize: "0.875rem",
+                fontWeight: 500,
+                borderRadius: "0.5rem",
+                border: "1px solid var(--ge-border)",
+                backgroundColor: "transparent",
+                color: "var(--ge-fg)",
+                textDecoration: "none",
+                cursor: "pointer",
+              }}
+            >
+              Go to homepage
+            </a>
+          </div>
         </div>
       </body>
     </html>


### PR DESCRIPTION
## Summary

The global error page only offered a "Try again" button (`reset()`), which left users stuck in a loop if the error persisted. This adds a "Go to homepage" anchor alongside the retry button so users always have an escape hatch. The CSS hover/focus selectors are broadened from `button[data-ge]` to `[data-ge]` so the styles apply to both elements, and an ESLint override disables the `no-html-link-for-pages` rule for this file since `global-error.tsx` renders a standalone HTML document outside the Next.js router where `next/link` is unavailable.