### PR TITLE
chore: gitignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ scripts/check-govuk-figures/results/
 
 # Claude Code worktrees
 .claude/worktrees/
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary
- Add `.claude/scheduled_tasks.lock` to `.gitignore` to prevent it from being accidentally committed

## Context
This file was accidentally included in #370. It's a runtime lock file created by Claude Code's scheduled tasks and should not be tracked in version control.