### PR TITLE
feat: add Plan 2 interest rate cap guide

### DIFF
--- a/src/app/guides/interest-rate-cap/layout.tsx
+++ b/src/app/guides/interest-rate-cap/layout.tsx
@@ -1,0 +1,130 @@
+import type { Metadata } from "next";
+import {
+  TOTAL_YEARS,
+  YEARS_ABOVE_CAP,
+} from "@/components/guides/interest-rate-cap/historical-rates";
+
+export const metadata: Metadata = {
+  title: "Plan 2 Interest Rate Capped at 6% — What It Means for You",
+  description:
+    "The government is capping Plan 2 student loan interest at 6% from September 2026. See how this affects your balance, who benefits most, and how often rates have exceeded 6% historically.",
+  keywords: [
+    "Plan 2 interest rate cap",
+    "student loan 6% cap",
+    "Plan 2 interest rate 2026",
+    "student loan interest cap UK",
+    "Plan 3 interest rate cap",
+    "student loan RPI cap",
+  ],
+  alternates: {
+    canonical: "/guides/interest-rate-cap",
+  },
+  openGraph: {
+    title: "Plan 2 Interest Rate Capped at 6% — What It Means for You",
+    description:
+      "The government is capping Plan 2 student loan interest at 6% from September 2026. See how this affects your balance, who benefits most, and how often rates have exceeded 6% historically.",
+    url: "https://studentloanstudy.uk/guides/interest-rate-cap",
+    type: "article",
+  },
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://studentloanstudy.uk",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Guides",
+      item: "https://studentloanstudy.uk/guides",
+    },
+    {
+      "@type": "ListItem",
+      position: 3,
+      name: "Interest Rate Cap",
+      item: "https://studentloanstudy.uk/guides/interest-rate-cap",
+    },
+  ],
+};
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "What is the Plan 2 student loan interest rate cap?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "From 1 September 2026, the maximum interest rate on Plan 2 and Plan 3 student loans will be capped at 6% for the 2026/27 academic year, regardless of what the RPI + 3% formula produces.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How often has the Plan 2 interest rate exceeded 6%?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: `The maximum Plan 2 interest rate has exceeded 6% in ${String(YEARS_ABOVE_CAP)} out of ${String(TOTAL_YEARS)} academic years since Plan 2 was introduced in 2012. During the 2022-2024 inflation crisis, rates reached 7.7% even after prevailing market rate interventions.`,
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Does the 6% cap change my monthly student loan repayments?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "No. Monthly repayments are based on your income (9% of earnings above the threshold), not the interest rate. The cap only affects how fast your outstanding balance grows.",
+      },
+    },
+  ],
+};
+
+const articleSchema = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: "Plan 2 Interest Rate Capped at 6% — What It Means for You",
+  description:
+    "The government is capping Plan 2 student loan interest at 6% from September 2026. See how this affects your balance, who benefits most, and how often rates have exceeded 6% historically.",
+  url: "https://studentloanstudy.uk/guides/interest-rate-cap",
+  author: {
+    "@type": "Organization",
+    name: "UK Student Loan Study",
+    url: "https://studentloanstudy.uk",
+  },
+  publisher: {
+    "@type": "Organization",
+    name: "UK Student Loan Study",
+    url: "https://studentloanstudy.uk",
+  },
+  datePublished: "2026-04-08",
+  dateModified: "2026-04-08",
+};
+
+export default function InterestRateCapLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/guides/interest-rate-cap/page.tsx
+++ b/src/app/guides/interest-rate-cap/page.tsx
@@ -1,0 +1,10 @@
+import { InterestRateCapGuide } from "@/components/guides/interest-rate-cap/InterestRateCapGuide";
+import { AppErrorBoundary } from "@/components/shared/ErrorBoundary";
+
+export default function InterestRateCapRoute() {
+  return (
+    <AppErrorBoundary>
+      <InterestRateCapGuide />
+    </AppErrorBoundary>
+  );
+}

--- a/src/app/sitemap.xml
+++ b/src/app/sitemap.xml
@@ -47,6 +47,10 @@
     <lastmod>2026-03-14</lastmod>
   </url>
   <url>
+    <loc>https://studentloanstudy.uk/guides/interest-rate-cap</loc>
+    <lastmod>2026-04-08</lastmod>
+  </url>
+  <url>
     <loc>https://studentloanstudy.uk/our-data</loc>
   </url>
   <url>

--- a/src/components/charts/ChartBase.tsx
+++ b/src/components/charts/ChartBase.tsx
@@ -187,6 +187,22 @@ export function ChartBase({
                 />
               );
             })}
+            {horizontalAnnotations.map((ha) => (
+              <ReferenceLine
+                key={`hline-${String(ha.y)}-${ha.label}`}
+                y={ha.y}
+                stroke={ha.color ?? "var(--muted-foreground)"}
+                strokeWidth={1.5}
+                strokeDasharray={ha.strokeDasharray ?? "6 4"}
+                label={{
+                  value: ha.label,
+                  position: "right" as const,
+                  fill: ha.color ?? "var(--muted-foreground)",
+                  fontSize: 11,
+                  fontWeight: 500,
+                }}
+              />
+            ))}
           </BarChart>
         </ChartContainer>
       </div>

--- a/src/components/guides/interest-rate-cap/BalanceWithCapChart.tsx
+++ b/src/components/guides/interest-rate-cap/BalanceWithCapChart.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState } from "react";
+import type { ChartSeriesConfig } from "@/components/charts/ChartBase";
+import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
+import type { ChartConfig } from "@/components/ui/chart";
+import { getAnnualInterestRate } from "@/lib/loans/interest";
+import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
+import { INTEREST_CAP } from "./historical-rates";
+
+const RPI_OPTIONS = [
+  {
+    value: CURRENT_RATES.rpi,
+    label: `${String(CURRENT_RATES.rpi)}% (current)`,
+  },
+  { value: 5, label: "5%" },
+  { value: 7, label: "7%" },
+  { value: 9, label: "9%" },
+] as const;
+
+type RpiOption = (typeof RPI_OPTIONS)[number]["value"];
+
+const STARTING_BALANCE = 45_000;
+const STARTING_SALARY = 35_000;
+const SALARY_GROWTH = 0.03;
+
+const chartConfig = {
+  uncapped: {
+    label: "Without cap",
+    color: "var(--chart-5)",
+  },
+  capped: {
+    label: "With 6% cap",
+    color: "var(--chart-2)",
+  },
+} satisfies ChartConfig;
+
+const series: ChartSeriesConfig[] = [
+  { dataKey: "uncapped" },
+  { dataKey: "capped" },
+];
+
+function simulateBalance(rpi: number, capRate: number | null) {
+  const boe = CURRENT_RATES.boeBaseRate;
+  const monthlyThreshold = PLAN_CONFIGS.PLAN_2.monthlyThreshold;
+  const repaymentRate = PLAN_CONFIGS.PLAN_2.repaymentRate;
+  const writeOffMonths = PLAN_CONFIGS.PLAN_2.writeOffYears * 12;
+
+  let balance = STARTING_BALANCE;
+  let salary = STARTING_SALARY;
+  const points: number[] = [balance];
+
+  for (let month = 1; month <= writeOffMonths; month++) {
+    if (month > 0 && month % 12 === 0) {
+      salary *= 1 + SALARY_GROWTH;
+    }
+
+    let annualRate = getAnnualInterestRate("PLAN_2", salary, rpi, boe);
+    if (capRate !== null) {
+      annualRate = Math.min(annualRate, capRate);
+    }
+
+    const monthlyInterest = balance * (annualRate / 100 / 12);
+    balance += monthlyInterest;
+
+    const monthlyRepayment = Math.max(
+      0,
+      (salary / 12 - monthlyThreshold) * repaymentRate,
+    );
+    balance = Math.max(0, balance - monthlyRepayment);
+
+    if (balance <= 0) break;
+
+    if (month % 12 === 0) {
+      points.push(balance);
+    }
+  }
+
+  return points;
+}
+
+function buildData(rpi: RpiOption) {
+  const uncappedBalances = simulateBalance(rpi, null);
+  const cappedBalances = simulateBalance(rpi, INTEREST_CAP);
+
+  const maxYears = Math.max(uncappedBalances.length, cappedBalances.length);
+  const data: Array<{ year: number; uncapped: number; capped: number }> = [];
+
+  for (let y = 0; y < maxYears; y++) {
+    data.push({
+      year: y,
+      uncapped: uncappedBalances[y] ?? 0,
+      capped: cappedBalances[y] ?? 0,
+    });
+  }
+
+  return data;
+}
+
+function formatYear(value: number): string {
+  return `${String(Math.round(value))}yr`;
+}
+
+function formatCurrency(value: number): string {
+  return `\u00A3${String(Math.round(value / 1000))}k`;
+}
+
+export function BalanceWithCapChart() {
+  const [rpi, setRpi] = useState<RpiOption>(CURRENT_RATES.rpi);
+  const data = buildData(rpi);
+
+  return (
+    <div className="flex h-full flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <span
+          id="rpi-label"
+          className="text-sm font-medium text-muted-foreground"
+        >
+          RPI:
+        </span>
+        <div className="flex gap-1" role="group" aria-labelledby="rpi-label">
+          {RPI_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => {
+                setRpi(option.value);
+              }}
+              className={`rounded-md px-3 py-1 text-sm font-medium transition-colors ${
+                rpi === option.value
+                  ? "bg-foreground text-background"
+                  : "bg-muted text-muted-foreground hover:bg-muted/80"
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="min-h-0 flex-1">
+        <ChartBase
+          type="area"
+          data={data}
+          xDataKey="year"
+          xLabel="Years since repayment"
+          xFormatter={formatYear}
+          yLabel="Balance"
+          yFormatter={formatCurrency}
+          ariaLabel="Area chart comparing loan balance over time with and without the 6% interest rate cap"
+          chartConfig={chartConfig}
+          series={series}
+          showLegend
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/guides/interest-rate-cap/HistoricalRatesChart.tsx
+++ b/src/components/guides/interest-rate-cap/HistoricalRatesChart.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import type { ChartSeriesConfig } from "@/components/charts/ChartBase";
+import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
+import type { ChartConfig } from "@/components/ui/chart";
+import { HISTORICAL_RATES, INTEREST_CAP } from "./historical-rates";
+
+const chartData = HISTORICAL_RATES.map((d) => ({
+  ...d,
+  above: Math.max(0, d.maxRate - INTEREST_CAP),
+  below: Math.min(d.maxRate, INTEREST_CAP),
+}));
+
+const chartConfig = {
+  below: {
+    label: "Below cap",
+    color: "var(--chart-2)",
+  },
+  above: {
+    label: "Above 6% cap",
+    color: "var(--chart-5)",
+  },
+} satisfies ChartConfig;
+
+const series: ChartSeriesConfig[] = [
+  { dataKey: "below", stackId: "rate" },
+  { dataKey: "above", stackId: "rate" },
+];
+
+function formatYear(value: number): string {
+  const entry = chartData.find((d) => d.year === value);
+  return entry?.label ?? String(value);
+}
+
+function formatRate(value: number): string {
+  return `${value.toFixed(1)}%`;
+}
+
+export function HistoricalRatesChart() {
+  return (
+    <div className="h-75 sm:h-90">
+      <ChartBase
+        type="bar"
+        data={chartData}
+        xDataKey="year"
+        xFormatter={formatYear}
+        yFormatter={formatRate}
+        yDomain={[0, 9]}
+        ariaLabel="Bar chart showing maximum Plan 2 interest rate per academic year from 2012 to 2025, with bars coloured to show portions above and below the 6% cap"
+        chartConfig={chartConfig}
+        series={series}
+        horizontalAnnotations={[
+          {
+            y: INTEREST_CAP,
+            label: "6% cap",
+            color: "var(--chart-1)",
+            strokeDasharray: "6 4",
+          },
+        ]}
+        showLegend
+      />
+    </div>
+  );
+}

--- a/src/components/guides/interest-rate-cap/InterestRateCapGuide.tsx
+++ b/src/components/guides/interest-rate-cap/InterestRateCapGuide.tsx
@@ -1,0 +1,292 @@
+import Link from "next/link";
+import { RelatedGuides } from "@/components/guides/RelatedGuides";
+import { PageLayout } from "@/components/layout/PageLayout";
+import { Heading } from "@/components/typography/Heading";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { formatGBP, formatPercent } from "@/lib/format";
+import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
+import { BalanceWithCapChart } from "./BalanceWithCapChart";
+import { TOTAL_YEARS, YEARS_ABOVE_CAP } from "./historical-rates";
+import { HistoricalRatesChart } from "./HistoricalRatesChart";
+import { TotalCostComparisonChart } from "./TotalCostComparisonChart";
+
+const rpi = CURRENT_RATES.rpi;
+const currentMaxRate = rpi + 3;
+
+export function InterestRateCapGuide() {
+  return (
+    <PageLayout>
+      <article className="space-y-8">
+        <div className="space-y-4">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/guides" />}>
+                  Guides
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>Interest Rate Cap</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+
+          <div className="space-y-2">
+            <Heading as="h1">
+              Plan 2 Interest Rate Capped at 6%: What It Means for You
+            </Heading>
+            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+              On 7 April 2026, the government announced a 6% cap on Plan 2 and
+              Plan 3 student loan interest rates from September 2026. Here is
+              what that means in practice and how much it could save you.
+            </p>
+          </div>
+        </div>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            What Changed
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              Plan 2 loans charge interest on a sliding scale: from RPI
+              (currently {formatPercent(rpi)}) for lower earners up to RPI + 3%
+              (currently {formatPercent(currentMaxRate)}) for those earning
+              above{" "}
+              <strong className="text-foreground">
+                {formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}
+              </strong>
+              . While studying, borrowers are charged the full RPI + 3%.
+            </p>
+            <p>
+              From 1 September 2026, the maximum interest rate on Plan 2 and
+              Plan 3 loans will be capped at{" "}
+              <strong className="text-foreground">6%</strong>, regardless of
+              what the RPI + 3% formula produces. This cap applies for the
+              2026/27 academic year.
+            </p>
+            <p>
+              At current rates, this barely bites &mdash; the maximum is{" "}
+              {formatPercent(currentMaxRate)}, only{" "}
+              {formatPercent(currentMaxRate - 6)} above the cap. But the cap is
+              designed as insurance: if inflation surges again, your interest
+              rate will not follow it above 6%.
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Why the Government Acted
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              Skills Minister Jacqui Smith cited the risk of inflation pressures
+              from Middle East conflicts and global instability. When RPI
+              spikes, the RPI + 3% formula can push interest rates well into
+              double digits &mdash; exactly what happened in 2022&ndash;2024.
+            </p>
+            <p>
+              The government had previously used the &ldquo;prevailing market
+              rate&rdquo; (PMR) mechanism to intervene when rates became
+              unreasonable. The 6% cap formalises this protection with a clear,
+              predictable ceiling instead of ad-hoc adjustments.
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            How Often Has the Rate Exceeded 6%?
+          </Heading>
+          <p className="text-muted-foreground">
+            The maximum Plan 2 interest rate has exceeded 6% in{" "}
+            <strong className="text-foreground">
+              {String(YEARS_ABOVE_CAP)} out of {String(TOTAL_YEARS)} academic
+              years
+            </strong>{" "}
+            since Plan 2 was introduced in 2012. During the inflation crisis of
+            2022&ndash;2024, rates hit 7.7% even after the PMR cap was applied
+            &mdash; without that intervention, the formula rate would have
+            reached 16.5%.
+          </p>
+          <HistoricalRatesChart />
+          <p className="text-sm text-muted-foreground">
+            The bars show the maximum rate actually charged each year (after any
+            PMR intervention). The dashed line marks the new 6% cap.
+          </p>
+        </section>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Impact on Your Balance
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              The real impact of the cap depends on future inflation. At current
+              RPI ({formatPercent(rpi)}), the difference is small. But if
+              inflation returns to levels seen in 2022&ndash;2023, the cap
+              prevents your balance from compounding at extreme rates.
+            </p>
+            <p>
+              The chart below starts at today&apos;s RPI ({formatPercent(rpi)}),
+              where the two lines nearly overlap. Try selecting 7% or 9% to see
+              why the cap was introduced &mdash; at those levels the gap between
+              capped and uncapped balances becomes dramatic. The scenario
+              assumes a {formatGBP(45_000)} loan, a {formatGBP(35_000)} starting
+              salary, and 3% annual growth.
+            </p>
+          </div>
+          <div className="h-80 sm:h-100">
+            <BalanceWithCapChart />
+          </div>
+          <p className="text-sm text-muted-foreground">
+            At higher RPI values, the gap between the capped and uncapped
+            balance widens significantly. At 7% RPI, the uncapped rate would be
+            10% &mdash; the cap saves borrowers from this compounding effect.
+          </p>
+        </section>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            How Much Less Could You Repay?
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              Because Plan 2 loans are written off after 30 years regardless of
+              the remaining balance, most borrowers will not repay in full. The
+              cap matters most for middle-to-high earners who do repay
+              everything &mdash; they accumulate less interest, so their total
+              bill is lower.
+            </p>
+            <p>
+              The chart below compares total repayment across salary levels,
+              assuming a sustained 7% RPI scenario. Lower earners see little
+              difference because their loans are written off either way. Higher
+              earners see meaningful savings.
+            </p>
+          </div>
+          <TotalCostComparisonChart />
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Who Benefits Most?
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <ul className="list-disc space-y-2 pl-6">
+              <li>
+                <strong className="text-foreground">
+                  Current students on Plan 2 or Plan 3
+                </strong>{" "}
+                &mdash; while studying, you are charged the maximum rate (RPI +
+                3%). The cap means this will not exceed 6%, slowing the growth
+                of your balance before you even start repaying.
+              </li>
+              <li>
+                <strong className="text-foreground">
+                  Higher earners with large balances
+                </strong>{" "}
+                &mdash; if you earn above{" "}
+                {formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}, you are
+                on the maximum rate. The cap gives you the biggest absolute
+                reduction in interest.
+              </li>
+              <li>
+                <strong className="text-foreground">
+                  Graduates who will repay in full
+                </strong>{" "}
+                &mdash; if your salary is high enough to clear the loan before
+                the 30-year write-off, lower interest means a lower total cost.
+              </li>
+            </ul>
+            <p>
+              Lower earners who will never repay in full are less directly
+              affected &mdash; the cap reduces the balance that eventually gets
+              written off, but does not change their monthly repayments (which
+              are based purely on income).
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            What This Does Not Change
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <ul className="list-disc space-y-2 pl-6">
+              <li>
+                <strong className="text-foreground">
+                  Monthly repayments are unchanged
+                </strong>{" "}
+                &mdash; you still repay 9% of income above the threshold (
+                {formatGBP(PLAN_CONFIGS.PLAN_2.monthlyThreshold * 12)}/year).
+                The cap only affects how fast your balance grows.
+              </li>
+              <li>
+                <strong className="text-foreground">
+                  Plan 1, 4, and 5 are not affected
+                </strong>{" "}
+                &mdash; Plan 1 and 4 rates are already capped at the lower of
+                RPI or Bank of England base rate + 1%. Plan 5 charges RPI only,
+                with no +3% component.
+              </li>
+              <li>
+                <strong className="text-foreground">
+                  The cap is for 2026/27 only
+                </strong>{" "}
+                &mdash; it has been announced for one academic year. Whether it
+                becomes permanent depends on future policy decisions.
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
+          <Heading as="h2" size="subsection">
+            Key Takeaways
+          </Heading>
+          <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+            <li>
+              Plan 2 and Plan 3 interest will be capped at 6% from September
+              2026
+            </li>
+            <li>
+              The maximum rate has exceeded 6% in {String(YEARS_ABOVE_CAP)} of
+              the {String(TOTAL_YEARS)} years since Plan 2 was introduced
+            </li>
+            <li>
+              The biggest beneficiaries are higher earners and current students,
+              especially if inflation rises again
+            </li>
+            <li>
+              Monthly repayments do not change &mdash; the cap only slows
+              balance growth
+            </li>
+            <li>
+              The cap is announced for one year only (2026/27), though it may be
+              extended
+            </li>
+          </ul>
+        </section>
+
+        <RelatedGuides
+          current="interest-rate-cap"
+          order={["how-interest-works", "rpi-vs-cpi", "plan-2-vs-plan-5"]}
+        />
+      </article>
+    </PageLayout>
+  );
+}

--- a/src/components/guides/interest-rate-cap/TotalCostComparisonChart.tsx
+++ b/src/components/guides/interest-rate-cap/TotalCostComparisonChart.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import type { ChartSeriesConfig } from "@/components/charts/ChartBase";
+import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
+import type { ChartConfig } from "@/components/ui/chart";
+import { getAnnualInterestRate } from "@/lib/loans/interest";
+import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
+import { INTEREST_CAP } from "./historical-rates";
+
+const STARTING_BALANCE = 45_000;
+const SALARY_GROWTH = 0.03;
+const HIGH_RPI = 7;
+
+const chartConfig = {
+  uncapped: {
+    label: "Without cap (7% RPI)",
+    color: "var(--chart-5)",
+  },
+  capped: {
+    label: "With 6% cap",
+    color: "var(--chart-2)",
+  },
+} satisfies ChartConfig;
+
+const series: ChartSeriesConfig[] = [
+  { dataKey: "uncapped" },
+  { dataKey: "capped" },
+];
+
+function simulateTotalPaid(
+  startingSalary: number,
+  capRate: number | null,
+): number {
+  const boe = CURRENT_RATES.boeBaseRate;
+  const monthlyThreshold = PLAN_CONFIGS.PLAN_2.monthlyThreshold;
+  const repaymentRate = PLAN_CONFIGS.PLAN_2.repaymentRate;
+  const writeOffMonths = PLAN_CONFIGS.PLAN_2.writeOffYears * 12;
+
+  let balance = STARTING_BALANCE;
+  let salary = startingSalary;
+  let totalPaid = 0;
+
+  for (let month = 1; month <= writeOffMonths; month++) {
+    if (month > 0 && month % 12 === 0) {
+      salary *= 1 + SALARY_GROWTH;
+    }
+
+    let annualRate = getAnnualInterestRate("PLAN_2", salary, HIGH_RPI, boe);
+    if (capRate !== null) {
+      annualRate = Math.min(annualRate, capRate);
+    }
+
+    const monthlyInterest = balance * (annualRate / 100 / 12);
+    balance += monthlyInterest;
+
+    const monthlyRepayment = Math.min(
+      Math.max(0, (salary / 12 - monthlyThreshold) * repaymentRate),
+      balance,
+    );
+    balance -= monthlyRepayment;
+    totalPaid += monthlyRepayment;
+
+    if (balance <= 0) break;
+  }
+
+  return totalPaid;
+}
+
+function buildData() {
+  const points: Array<{ salary: number; uncapped: number; capped: number }> =
+    [];
+
+  for (let salary = 25000; salary <= 80000; salary += 1000) {
+    points.push({
+      salary,
+      uncapped: simulateTotalPaid(salary, null),
+      capped: simulateTotalPaid(salary, INTEREST_CAP),
+    });
+  }
+
+  return points;
+}
+
+const data = buildData();
+
+function formatSalary(value: number): string {
+  return `\u00A3${String(Math.round(value / 1000))}k`;
+}
+
+function formatCurrency(value: number): string {
+  return `\u00A3${String(Math.round(value / 1000))}k`;
+}
+
+export function TotalCostComparisonChart() {
+  return (
+    <div className="h-75 sm:h-90">
+      <ChartBase
+        type="line"
+        data={data}
+        xDataKey="salary"
+        xLabel="Starting salary"
+        xFormatter={formatSalary}
+        yLabel="Total repaid"
+        yFormatter={formatCurrency}
+        ariaLabel="Line chart comparing total repayment by salary with and without the 6% interest rate cap, assuming 7% RPI"
+        chartConfig={chartConfig}
+        series={series}
+        showLegend
+      />
+    </div>
+  );
+}

--- a/src/components/guides/interest-rate-cap/historical-rates.ts
+++ b/src/components/guides/interest-rate-cap/historical-rates.ts
@@ -1,0 +1,29 @@
+/**
+ * Maximum Plan 2 interest rate actually charged each academic year.
+ * For years where the prevailing market rate (PMR) cap was applied,
+ * the rate shown is after that intervention.
+ */
+export const HISTORICAL_RATES = [
+  { year: 2012, label: "12/13", maxRate: 6.6 },
+  { year: 2013, label: "13/14", maxRate: 6.3 },
+  { year: 2014, label: "14/15", maxRate: 5.5 },
+  { year: 2015, label: "15/16", maxRate: 3.9 },
+  { year: 2016, label: "16/17", maxRate: 4.6 },
+  { year: 2017, label: "17/18", maxRate: 6.1 },
+  { year: 2018, label: "18/19", maxRate: 6.3 },
+  { year: 2019, label: "19/20", maxRate: 5.4 },
+  { year: 2020, label: "20/21", maxRate: 5.6 },
+  { year: 2021, label: "21/22", maxRate: 4.5 },
+  { year: 2022, label: "22/23", maxRate: 6.9 },
+  { year: 2023, label: "23/24", maxRate: 7.7 },
+  { year: 2024, label: "24/25", maxRate: 7.3 },
+  { year: 2025, label: "25/26", maxRate: 6.2 },
+] as const;
+
+export const INTEREST_CAP = 6;
+
+export const YEARS_ABOVE_CAP = HISTORICAL_RATES.filter(
+  (d) => d.maxRate > INTEREST_CAP,
+).length;
+
+export const TOTAL_YEARS = HISTORICAL_RATES.length;

--- a/src/components/home/ToolLinks.tsx
+++ b/src/components/home/ToolLinks.tsx
@@ -77,12 +77,12 @@ const TOOLS: ToolCardProps[] = [
 
 /** Slugs of guides to feature on the homepage, in display order. */
 const FEATURED_GUIDE_SLUGS: GuideSlug[] = [
+  "interest-rate-cap",
   "threshold-freeze",
   "plan-2-vs-plan-5",
   "how-interest-works",
   "student-loan-vs-mortgage",
   "moving-abroad",
-  "self-employment",
 ];
 
 /** Derive featured guides from the canonical GUIDES array to keep titles/descriptions in sync. */

--- a/src/lib/guides.ts
+++ b/src/lib/guides.ts
@@ -29,6 +29,7 @@ export const GUIDES: GuideEntry[] = [
     title: "Threshold Freeze Explained",
     description:
       "How frozen repayment thresholds cost you more each month, and what the 2026 parliamentary inquiry means.",
+    newUntil: "2026-06-01",
   },
   {
     slug: "plan-2-vs-plan-5",

--- a/src/lib/guides.ts
+++ b/src/lib/guides.ts
@@ -22,7 +22,7 @@ export const GUIDES: GuideEntry[] = [
     title: "Plan 2 Interest Rate Cap",
     description:
       "The government is capping Plan 2 interest at 6% from September 2026. What it means for your loan.",
-    newUntil: "2026-10-01",
+    newUntil: "2026-07-08",
   },
   {
     slug: "threshold-freeze",

--- a/src/lib/guides.ts
+++ b/src/lib/guides.ts
@@ -6,7 +6,8 @@ export type GuideSlug =
   | "rpi-vs-cpi"
   | "pay-upfront-or-take-loan"
   | "moving-abroad"
-  | "self-employment";
+  | "self-employment"
+  | "interest-rate-cap";
 
 export interface GuideEntry {
   slug: GuideSlug;
@@ -64,5 +65,12 @@ export const GUIDES: GuideEntry[] = [
     title: "Self-Employment",
     description:
       "How Self Assessment changes your repayments and common mistakes to avoid.",
+  },
+  {
+    slug: "interest-rate-cap",
+    title: "Plan 2 Interest Rate Cap",
+    description:
+      "The government is capping Plan 2 interest at 6% from September 2026. What it means for your loan.",
+    newUntil: "2026-10-01",
   },
 ];

--- a/src/lib/guides.ts
+++ b/src/lib/guides.ts
@@ -18,11 +18,17 @@ export interface GuideEntry {
 
 export const GUIDES: GuideEntry[] = [
   {
+    slug: "interest-rate-cap",
+    title: "Plan 2 Interest Rate Cap",
+    description:
+      "The government is capping Plan 2 interest at 6% from September 2026. What it means for your loan.",
+    newUntil: "2026-10-01",
+  },
+  {
     slug: "threshold-freeze",
     title: "Threshold Freeze Explained",
     description:
       "How frozen repayment thresholds cost you more each month, and what the 2026 parliamentary inquiry means.",
-    newUntil: "2026-06-01",
   },
   {
     slug: "plan-2-vs-plan-5",
@@ -65,12 +71,5 @@ export const GUIDES: GuideEntry[] = [
     title: "Self-Employment",
     description:
       "How Self Assessment changes your repayments and common mistakes to avoid.",
-  },
-  {
-    slug: "interest-rate-cap",
-    title: "Plan 2 Interest Rate Cap",
-    description:
-      "The government is capping Plan 2 interest at 6% from September 2026. What it means for your loan.",
-    newUntil: "2026-10-01",
   },
 ];


### PR DESCRIPTION
## Summary

Adds a new guide at `/guides/interest-rate-cap` to inform Plan 2 borrowers about the UK government's upcoming 6% interest rate cap, effective September 2026. The guide includes three interactive charts — a bar chart of historical maximum rates per year, an area chart comparing projected balance growth with and without the cap (with an RPI selector), and a line chart showing total repayment cost by salary. A shared `historical-rates.ts` data module backs all three charts. The guide is registered in the guides index with a "New" badge and is fully covered by SEO metadata (Open Graph, JSON-LD breadcrumb/FAQ/article schemas, sitemap entry). `ChartBase` also received a minor enhancement to support horizontal annotations on bar charts.

## Context

The guide was written in response to the government announcement on 7 April 2026 capping Plan 2 and Plan 3 student loan interest rates at 6% from September 2026. Historical rate data shows the max rate exceeded 6% in 8 of 14 academic years since Plan 2 was introduced. The BalanceWithCapChart defaults to current RPI with guidance text encouraging users to try higher values to see the cap's impact. The ChartBase enhancement adds horizontalAnnotations rendering to the bar chart code path (previously only supported in line/area charts).