### PR TITLE
chore: install deps on session start instead of symlinking node_modules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,11 +3,19 @@
     "defaultMode": "bypassPermissions",
     "deny": ["Read(./.env)", "Read(./.env.*)"]
   },
-  "worktree": {
-    "symlinkDirectories": ["node_modules"]
-  },
   "showClearContextOnPlanAccept": true,
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c '[[ \"$CLAUDE_PROJECT_DIR\" == *\".claude/worktrees/\"* ]] || exit 0; [ -L \"$CLAUDE_PROJECT_DIR/node_modules/typescript\" ] && exit 0; cd \"$CLAUDE_PROJECT_DIR\" && pnpm install --prefer-offline'"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",
@@ -15,6 +23,15 @@
           {
             "type": "command",
             "command": "bash -c 'CMD=$(jq -r .tool_input.command) && if echo \"$CMD\" | grep -qE \"\\bnpm\\b|\\bnpx\\b\"; then echo \"Use pnpm/pnpx instead of npm/npx. This project uses pnpm.\" >&2; exit 2; fi'"
+          }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'FILE=$(jq -r \".tool_input.file_path // empty\") && if [ -n \"$FILE\" ] && basename \"$FILE\" | grep -qE \"^\\.env(\\.|$)\"; then echo \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"Reading .env files is not allowed\\\"}}\"; fi'"
           }
         ]
       },


### PR DESCRIPTION
## Summary

Switches worktrees from symlinking `node_modules` to the main repo over to running `pnpm install --prefer-offline` on session start. The symlinked `node_modules` was triggering pnpm's "modules directory will be removed and reinstalled from scratch" prompt every time `pnpm i` ran from inside a worktree, because pnpm doesn't trust a `node_modules` that symlinks outside the project root. Removes `worktree.symlinkDirectories`, adds a `SessionStart` hook that installs deps when the worktree's `node_modules/typescript` symlink doesn't exist yet, and adds a `PreToolUse` `Read` hook that denies `.env*` reads via `hookSpecificOutput` as a belt-and-suspenders companion to the existing `permissions.deny` entry.

## Notes

Existing worktrees that already have a `node_modules` symlink are unaffected — they'll continue using the symlinked `node_modules` until the symlink is removed manually. Only newly-created worktrees pick up the new behavior.