### PR TITLE
test: derive expected values from PLAN_CONFIGS instead of hardcoded figures

### DIFF
--- a/src/lib/loans/engine.test.ts
+++ b/src/lib/loans/engine.test.ts
@@ -79,8 +79,9 @@ describe("simulate engine", () => {
       const firstSnapshot = result.snapshots[0];
       const loanState = firstSnapshot.loans[0];
 
-      // Expected: (50000/12 - 2172) * 0.09 = (4166.67 - 2172) * 0.09 = 179.52
-      expect(loanState.repayment).toBeCloseTo(179.52, 0);
+      const { monthlyThreshold, repaymentRate } = PLAN_CONFIGS.PLAN_1;
+      const expected = (50000 / 12 - monthlyThreshold) * repaymentRate;
+      expect(loanState.repayment).toBeCloseTo(expected, 1);
     });
   });
 
@@ -111,8 +112,9 @@ describe("simulate engine", () => {
       const firstSnapshot = result.snapshots[0];
       const loanState = firstSnapshot.loans[0];
 
-      // Expected: (50000/12 - 2372) * 0.09 = (4166.67 - 2372) * 0.09 = 161.52
-      expect(loanState.repayment).toBeCloseTo(161.52, 0);
+      const { monthlyThreshold, repaymentRate } = PLAN_CONFIGS.PLAN_2;
+      const expected = (50000 / 12 - monthlyThreshold) * repaymentRate;
+      expect(loanState.repayment).toBeCloseTo(expected, 1);
     });
   });
 
@@ -191,7 +193,17 @@ describe("simulate engine", () => {
     });
 
     it("has lowest threshold", () => {
-      expect(PLAN_CONFIGS.POSTGRADUATE.monthlyThreshold).toBe(1750);
+      const pgThreshold = PLAN_CONFIGS.POSTGRADUATE.monthlyThreshold;
+      for (const planType of [
+        "PLAN_1",
+        "PLAN_2",
+        "PLAN_4",
+        "PLAN_5",
+      ] as const) {
+        expect(pgThreshold).toBeLessThan(
+          PLAN_CONFIGS[planType].monthlyThreshold,
+        );
+      }
     });
 
     it("calculates monthly repayment using 6% rate", () => {
@@ -199,8 +211,9 @@ describe("simulate engine", () => {
       const firstSnapshot = result.snapshots[0];
       const loanState = firstSnapshot.loans[0];
 
-      // Expected: (50000/12 - 1750) * 0.06 = (4166.67 - 1750) * 0.06 = 145
-      expect(loanState.repayment).toBeCloseTo(145, 0);
+      const { monthlyThreshold, repaymentRate } = PLAN_CONFIGS.POSTGRADUATE;
+      const expected = (50000 / 12 - monthlyThreshold) * repaymentRate;
+      expect(loanState.repayment).toBeCloseTo(expected, 1);
     });
   });
 
@@ -229,11 +242,15 @@ describe("simulate engine", () => {
       expect(plan2State).toBeDefined();
       expect(pgState).toBeDefined();
 
-      // Plan 2: (60000/12 - 2372) * 0.09 = (5000 - 2372) * 0.09 = 236.52
-      expect(plan2State?.repayment).toBeCloseTo(236.52, 0);
+      const expectedPlan2 =
+        (60000 / 12 - PLAN_CONFIGS.PLAN_2.monthlyThreshold) *
+        PLAN_CONFIGS.PLAN_2.repaymentRate;
+      expect(plan2State?.repayment).toBeCloseTo(expectedPlan2, 1);
 
-      // Postgraduate: (60000/12 - 1750) * 0.06 = (5000 - 1750) * 0.06 = 195
-      expect(pgState?.repayment).toBeCloseTo(195, 0);
+      const expectedPg =
+        (60000 / 12 - PLAN_CONFIGS.POSTGRADUATE.monthlyThreshold) *
+        PLAN_CONFIGS.POSTGRADUATE.repaymentRate;
+      expect(pgState?.repayment).toBeCloseTo(expectedPg, 1);
     });
 
     it("total monthly repayment is sum of individual repayments", () => {

--- a/src/utils/insights.test.ts
+++ b/src/utils/insights.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect } from "vitest";
+import { PLAN_CONFIGS } from "@/lib/loans/plans";
 import type { Loan } from "@/lib/loans/types";
 import { generateInsight } from "./insights";
 
 const plan2Loan: Loan = { planType: "PLAN_2", balance: 50_000 };
+
+// Middle-earner zone tracks the Plan 2 threshold: roughly £30k–£50k above
+// annual threshold lands a £50k loan in the peak repayment zone. Deriving
+// from PLAN_CONFIGS keeps the test robust to GOV.UK threshold updates.
+const MIDDLE_EARNER_SALARY = PLAN_CONFIGS.PLAN_2.monthlyThreshold * 12 + 40_000;
 
 describe("generateInsight", () => {
   it("returns null for zero balance", () => {
@@ -18,7 +24,9 @@ describe("generateInsight", () => {
   });
 
   it("classifies middle-earner in peak repayment zone", () => {
-    const result = generateInsight(60_000, { loans: [plan2Loan] });
+    const result = generateInsight(MIDDLE_EARNER_SALARY, {
+      loans: [plan2Loan],
+    });
     expect(result).not.toBeNull();
     expect(result?.type).toBe("middle-earner");
     expect(result?.title).toContain("peak repayment zone");
@@ -56,8 +64,10 @@ describe("generateInsight", () => {
   });
 
   it("shows lower figures when discountRate is applied", () => {
-    const nominal = generateInsight(60_000, { loans: [plan2Loan] });
-    const pvAdjusted = generateInsight(60_000, {
+    const nominal = generateInsight(MIDDLE_EARNER_SALARY, {
+      loans: [plan2Loan],
+    });
+    const pvAdjusted = generateInsight(MIDDLE_EARNER_SALARY, {
       loans: [plan2Loan],
       discountRate: 0.05,
     });


### PR DESCRIPTION
## Summary

Five tests in `engine.test.ts` and `insights.test.ts` hardcoded the old Plan 1 and Plan 2 monthly thresholds (2172, 2372) and a £60k salary that stopped landing in the middle-earner zone after the daily GOV.UK scraper raised those thresholds — breaking CI ([run #26327382566](https://github.com/QingqiShi/uk-student-loan-study/actions/runs/26327382566)). The tests now derive all expected repayments from `PLAN_CONFIGS.{PLAN_1,PLAN_2,POSTGRADUATE}.{monthlyThreshold,repaymentRate}` and compute the insights salary as `monthlyThreshold * 12 + 40_000` so it stays firmly in the peak repayment zone regardless of future threshold changes.

## Notes

The "postgraduate has lowest threshold" assertion was previously a `toBe(1750)` literal; it now compares against all other plans' thresholds, which is the invariant that actually matters.