### PR TITLE
refactor: clear all eslint warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -62,7 +62,7 @@ export default defineConfig(
       "src/components/ui/chart.tsx",
     ],
     rules: {
-      "@eslint-react/dom/no-dangerously-set-innerhtml": "off",
+      "@eslint-react/dom-no-dangerously-set-innerhtml": "off",
     },
   },
   {

--- a/src/components/home/ToolLinks.tsx
+++ b/src/components/home/ToolLinks.tsx
@@ -14,7 +14,7 @@ interface ToolCardProps {
   title: string;
   description: string;
   cta: string;
-  newUntil?: string;
+  isNew?: boolean;
 }
 
 function ToolCard({
@@ -23,7 +23,7 @@ function ToolCard({
   title,
   description,
   cta,
-  newUntil,
+  isNew,
 }: ToolCardProps) {
   return (
     <Link href={href} className="group block h-full">
@@ -34,7 +34,7 @@ function ToolCard({
           </div>
           <h3 className="font-medium">
             {title}
-            {newUntil && new Date() < new Date(newUntil) && (
+            {isNew && (
               <span className="ml-2 inline-block rounded-full bg-primary/5 px-2 py-0.5 align-middle text-xs font-medium text-primary">
                 New
               </span>
@@ -85,11 +85,20 @@ const FEATURED_GUIDE_SLUGS: GuideSlug[] = [
   "moving-abroad",
 ];
 
-/** Derive featured guides from the canonical GUIDES array to keep titles/descriptions in sync. */
+/**
+ * Derive featured guides from the canonical GUIDES array to keep titles/descriptions in sync.
+ * Evaluated at module load (build time for SSG), so the "New" badge is fixed per build.
+ */
+const BUILD_TIME = new Date();
 const FEATURED_GUIDES = FEATURED_GUIDE_SLUGS.flatMap((slug) => {
   const guide = GUIDES.find((g) => g.slug === slug);
   if (!guide) return [];
-  return [guide];
+  return [
+    {
+      ...guide,
+      isNew: !!guide.newUntil && BUILD_TIME < new Date(guide.newUntil),
+    },
+  ];
 });
 
 export function ToolLinks() {
@@ -114,7 +123,7 @@ export function ToolLinks() {
               title={guide.title}
               description={guide.description}
               cta="Read Guide"
-              newUntil={guide.newUntil}
+              isNew={guide.isNew}
             />
           ))}
         </div>

--- a/src/components/shared/ScrollFadeWrapper.tsx
+++ b/src/components/shared/ScrollFadeWrapper.tsx
@@ -27,7 +27,7 @@ function ScrollFadeWrapper({
       setShowFade(scrollLeft + clientWidth < scrollWidth - 1);
     };
 
-    update();
+    // ResizeObserver fires update() on initial observe(), so no synchronous call needed.
     scrollable.addEventListener("scroll", update, { passive: true });
     const observer = new ResizeObserver(update);
     observer.observe(scrollable);

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -71,7 +71,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-muted-foreground [&:has([role=checkbox])]:pr-0",
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-muted-foreground has-[[role=checkbox]]:pr-0",
         className,
       )}
       {...props}
@@ -84,7 +84,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        "p-2 align-middle whitespace-nowrap has-[[role=checkbox]]:pr-0",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary

Fixes all 52 ESLint warnings across four sites, each caused by a different issue.

- **`eslint.config.js`** — the `@eslint-react/dom/no-dangerously-set-innerhtml` override used a slash in the rule ID where a dash is required; the rule was never suppressed, leaving 45 warnings on JSON-LD scripts in layouts, `global-error.tsx`, and `chart.tsx`.
- **`ToolLinks.tsx`** — the `newUntil` date comparison ran inside render on every call; moving `new Date()` to module scope (evaluated at build time for SSG) and passing a precomputed `isNew` boolean fixes the `@eslint-react/purity` warning.
- **`ScrollFadeWrapper.tsx`** — a synchronous `update()` call inside the effect was redundant because `ResizeObserver.observe()` already fires an initial measurement; removing it fixes the `@eslint-react/set-state-in-effect` warning.
- **`table.tsx`** — ESLint `--fix` migrated two `[&:has([role=checkbox])]:pr-0` selectors to the canonical `has-[[role=checkbox]]:pr-0` form (auto-formatting, permitted for ShadCN components per project rules).