### PR TITLE
ci: use fine-grained PAT to trigger CI on auto-created PRs

### DIFF
--- a/.github/workflows/check-govuk-figures.yml
+++ b/.github/workflows/check-govuk-figures.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.PR_TOKEN }}
 
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
@@ -60,7 +62,7 @@ jobs:
       - name: Create Pull Request
         if: steps.result.outputs.status == 'mismatch' && steps.verify.outcome == 'success'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PR_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary

Switches the GOV.UK figures workflow from `GITHUB_TOKEN` to a fine-grained PAT (`PR_TOKEN`) for both the checkout step and `gh pr create`, so that auto-created PRs trigger the `PR Checks` workflow — GitHub suppresses workflow runs on events caused by the default token.

## Notes

The `PR_TOKEN` secret needs Contents: write and Pull requests: write on this repo. Existing PR #431 will need to be closed and reopened (or superseded by the next daily run force-pushing the branch) for CI to fire under the new token.