### PR TITLE
ci: bump pnpm to 11 and add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,13 @@ updates:
     schedule:
       interval: "daily"
       time: "15:00"
+    # Wait until a version has aged before opening a PR, so it has cleared
+    # pnpm 11's default 24h `minimumReleaseAge` supply-chain gate by the time
+    # CI runs `pnpm install`. Cooldown applies to version updates only —
+    # security updates still flow immediately.
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
     assignees:
       - "QingqiShi"
     open-pull-requests-limit: 10

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "packageManager": "pnpm@10.30.3+sha512.c961d1e0a2d8e354ecaa5166b822516668b7f44cb5bd95122d590dd81922f606f5473b6d23ec4a5be05e7fcd18e8488d47d978bbe981872f1145d06e9a740017",
+  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -67,15 +67,5 @@
     "vite": "^8.0.16",
     "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.8"
-  },
-  "pnpm": {
-    "overrides": {
-      "react-is": "^19.2.4",
-      "rollup": "^4.59.0",
-      "picomatch": "^4.0.4",
-      "flatted": "^3.4.2",
-      "yaml": "^2.8.3",
-      "brace-expansion": "^5.0.5"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,16 @@
+# pnpm 11 no longer reads the `pnpm` field in package.json — settings live here.
+# https://pnpm.io/settings
+overrides:
+  react-is: ^19.2.4
+  rollup: ^4.59.0
+  picomatch: ^4.0.4
+  flatted: ^3.4.2
+  yaml: ^2.8.3
+  brace-expansion: ^5.0.5
+# These postinstall build scripts stay disabled (they were ignored under pnpm
+# 10 and the app builds fine without them); pnpm 11 requires an explicit choice.
+allowBuilds:
+  "@parcel/watcher": false
+  esbuild: false
+  msw: false
+  sharp: false


### PR DESCRIPTION
## Why

Bumps pnpm from 10.30.3 to 11.11.0 (latest). pnpm 11 introduces a supply-chain guard — a built-in default `minimumReleaseAge` of 24 hours — that refuses to install any package version younger than a day old. Dependabot opens PRs the instant a version publishes, so without a matching delay every Dependabot PR would land inside pnpm's 24h window and CI's `pnpm install` would fail with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`. The two changes here are therefore coupled: the pnpm bump requires the Dependabot cooldown to keep CI green.

Mirrors QingqiShi/shiqingqi.com#2484.

## Dependabot cooldown

Adds a `cooldown` to the npm ecosystem entry (`default-days: 3`, `semver-major-days: 7`). Dependabot now waits for a version to age before opening a PR, so it has cleared pnpm's 24h gate by the time CI installs. The 3-day default adds a buffer past the gate and a window for bad releases to be yanked; majors settle for 7 days. Cooldown applies to version updates only — security/CVE updates still flow immediately.

## pnpm 11 migration

pnpm 11 no longer reads the `pnpm` field in `package.json`, so the `overrides` block moves verbatim into a new `pnpm-workspace.yaml`. pnpm 11 also promotes ignored build scripts from a warning to a hard `ERR_PNPM_IGNORED_BUILDS` error, so an `allowBuilds` block explicitly disables the same postinstall scripts (`@parcel/watcher`, `esbuild`, `msw`, `sharp`) that were already ignored under pnpm 10 — the app builds fine without them, so this preserves prior behaviour while satisfying pnpm 11's requirement for an explicit choice.

The lockfile is unchanged: same format, same resolved versions.
