### PR TITLE
content(seo): rewrite titles + meta descriptions of 3 top pages for CTR

### DIFF
--- a/src/app/guides/moving-abroad/layout.tsx
+++ b/src/app/guides/moving-abroad/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "What Happens to Your Student Loan If You Move Abroad?",
+  title: "What Happens to Your Student Loan If You Move Abroad? (UK)",
   description:
-    "Moving overseas doesn't make your student loan disappear — the SLC will find you. Here's what they expect, what the penalties look like, and how repayment thresholds change by country.",
+    "Yes — you still repay your UK student loan abroad, and ignoring the SLC means fixed payments far higher than income-based ones. Here's what to do before you go.",
   keywords: [
     "student loan abroad",
     "SLC overseas",
@@ -16,9 +16,9 @@ export const metadata: Metadata = {
     canonical: "/guides/moving-abroad",
   },
   openGraph: {
-    title: "What Happens to Your Student Loan If You Move Abroad?",
+    title: "What Happens to Your Student Loan If You Move Abroad? (UK)",
     description:
-      "Moving overseas doesn't make your student loan disappear — the SLC will find you. Here's what they expect, what the penalties look like, and how repayment thresholds change by country.",
+      "Yes — you still repay your UK student loan abroad, and ignoring the SLC means fixed payments far higher than income-based ones. Here's what to do before you go.",
     url: "https://studentloanstudy.uk/guides/moving-abroad",
     type: "article",
   },

--- a/src/app/guides/plan-2-vs-plan-5/layout.tsx
+++ b/src/app/guides/plan-2-vs-plan-5/layout.tsx
@@ -3,10 +3,10 @@ import { formatGBP } from "@/lib/format";
 import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
 
 const description =
-  "Plan 2 has higher interest but writes off after 30 years. Plan 5 charges less interest but repays over 40 years with a lower threshold. Compare the total cost at your salary.";
+  "Plan 2 charges more interest but writes off in 30 years; Plan 5 is cheaper but runs 40 years. See which costs you more in 2026 — middle earners lose most.";
 
 export const metadata: Metadata = {
-  title: "Plan 2 vs Plan 5: Which Student Loan Costs More?",
+  title: "Plan 2 vs Plan 5 Student Loans: Which Costs You More? (2026)",
   description,
   keywords: [
     "Plan 2 vs Plan 5",
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
     canonical: "/guides/plan-2-vs-plan-5",
   },
   openGraph: {
-    title: "Plan 2 vs Plan 5: Which Student Loan Costs More?",
+    title: "Plan 2 vs Plan 5 Student Loans: Which Costs You More? (2026)",
     description,
     url: "https://studentloanstudy.uk/guides/plan-2-vs-plan-5",
     type: "article",

--- a/src/app/which-plan/layout.tsx
+++ b/src/app/which-plan/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "What Student Loan Plan Am I On?",
+  title: "What Student Loan Plan Am I On? Find Out in 30 Seconds",
   description:
-    "Not sure which plan you're on? Answer 3 quick questions and we'll tell you — plus what it means for your repayments, interest rate, and write-off date.",
+    "Your plan depends on when and where you studied. Take our free 30-second quiz to find if you're on Plan 1, 2, 4, 5 or Postgraduate — plus your 2026 repayments.",
   keywords: [
     "what student loan plan am I on",
     "which student loan plan",
@@ -17,9 +17,9 @@ export const metadata: Metadata = {
     canonical: "/which-plan",
   },
   openGraph: {
-    title: "What Student Loan Plan Am I On?",
+    title: "What Student Loan Plan Am I On? Find Out in 30 Seconds",
     description:
-      "Not sure which plan you're on? Answer 3 quick questions and we'll tell you — plus what it means for your repayments, interest rate, and write-off date.",
+      "Your plan depends on when and where you studied. Take our free 30-second quiz to find if you're on Plan 1, 2, 4, 5 or Postgraduate — plus your 2026 repayments.",
     url: "https://studentloanstudy.uk/which-plan",
     type: "website",
   },


### PR DESCRIPTION
## Why

GSC (last 3 months) shows these three pages rank well (position 6–11) but bleed clicks: sitewide CTR sits around 0.6% where 2–6% is expected for those positions. The metadata wasn't mirroring how people actually phrase the queries, and the descriptions buried the answer. This rewrites titles + meta descriptions (metadata only — no page content touched) to match search intent, front-load the answer, and add 2026 freshness signals, while keeping the site's "middle earners are hurt most" angle where it fits.

## What changed

**/which-plan** (10,351 imp, 0.77% CTR, pos 10.7 — money query "what student loan plan am i on" converts at only 1.54%)
- Title now literally mirrors the question and sells the interactive quiz: *"What Student Loan Plan Am I On? Find Out in 30 Seconds"*
- Answer-first description leading with the deciding factor (when/where you studied), naming all plan types, with 2026 relevance.

**/guides/moving-abroad** (6,572 imp, 0.87% CTR, pos 9.3)
- Title mirrors the query phrasing including the literal "(UK)" qualifier searchers use: *"What Happens to Your Student Loan If You Move Abroad? (UK)"*
- Description now answer-first ("Yes — you still repay…") with a curiosity/consequence hook about SLC fixed penalty payments.

**/guides/plan-2-vs-plan-5** (4,741 imp, 0.4% CTR — worst of the three, pos 9.2)
- Title matches the "plan 2 vs plan 5 student loan" / "…differences 2026" query shape: *"Plan 2 vs Plan 5 Student Loans: Which Costs You More? (2026)"*
- Description tightened to a direct cost comparison and reinforces the site's core thesis — middle earners lose most.

Titles kept at/under ~60 chars before the *" | UK Student Loan Study"* template suffix; OpenGraph titles/descriptions updated to match. JSON-LD `articleSchema.headline` left aligned to the on-page H1. No content, sitemap, or llms.txt changes needed (the llms.txt link labels are curated short labels, not these `<title>` strings).

## Validation

`pnpm lint && pnpm typecheck && pnpm test && pnpm build && pnpm format` — all pass (486 tests). Format made no changes to the edited files.