### PR TITLE
content(guides): surface current tax-year figure tables on guides

### DIFF
--- a/src/app/sitemap.xml
+++ b/src/app/sitemap.xml
@@ -20,7 +20,7 @@
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/how-interest-works</loc>
-    <lastmod>2026-03-09</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/rpi-vs-cpi</loc>
@@ -44,11 +44,11 @@
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/threshold-freeze</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/interest-rate-cap</loc>
-    <lastmod>2026-04-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/our-data</loc>

--- a/src/components/guides/how-interest-works/CurrentRatesTable.tsx
+++ b/src/components/guides/how-interest-works/CurrentRatesTable.tsx
@@ -1,0 +1,69 @@
+import { ScrollFadeWrapper } from "@/components/shared/ScrollFadeWrapper";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatPercent } from "@/lib/format";
+import { CURRENT_RATES } from "@/lib/loans/plans";
+
+// All rates derive from plans.ts so they track the current GOV.UK / BoE figures.
+const rpi = CURRENT_RATES.rpi;
+const maxRate = rpi + 3;
+const plan1And4Rate = Math.min(rpi, CURRENT_RATES.boeBaseRate + 1);
+
+const rows = [
+  {
+    plan: "Plan 1",
+    formula: "Lower of RPI or Bank of England base rate + 1%",
+    rate: formatPercent(plan1And4Rate),
+  },
+  {
+    plan: "Plan 2",
+    formula: "RPI to RPI + 3% (sliding scale by income)",
+    rate: `${formatPercent(rpi)}–${formatPercent(maxRate)}`,
+  },
+  {
+    plan: "Plan 4",
+    formula: "Lower of RPI or Bank of England base rate + 1%",
+    rate: formatPercent(plan1And4Rate),
+  },
+  {
+    plan: "Plan 5",
+    formula: "RPI only",
+    rate: formatPercent(rpi),
+  },
+  {
+    plan: "Postgraduate",
+    formula: "RPI + 3% (all incomes)",
+    rate: formatPercent(maxRate),
+  },
+];
+
+export function CurrentRatesTable() {
+  return (
+    <ScrollFadeWrapper className="rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead scope="col">Plan</TableHead>
+            <TableHead scope="col">How it&apos;s set</TableHead>
+            <TableHead scope="col">Current rate</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow key={row.plan}>
+              <TableHead scope="row">{row.plan}</TableHead>
+              <TableCell className="whitespace-normal">{row.formula}</TableCell>
+              <TableCell>{row.rate}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </ScrollFadeWrapper>
+  );
+}

--- a/src/components/guides/how-interest-works/InterestGuide.tsx
+++ b/src/components/guides/how-interest-works/InterestGuide.tsx
@@ -12,6 +12,8 @@ import {
 } from "@/components/ui/breadcrumb";
 import { formatGBP, formatPercent } from "@/lib/format";
 import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
+import { getCurrentTaxYearLabel } from "@/lib/taxYear";
+import { CurrentRatesTable } from "./CurrentRatesTable";
 import { InterestRateChart } from "./InterestRateChart";
 
 const EXAMPLE_BALANCE = 45_000;
@@ -20,6 +22,9 @@ const maxRate = rpi + 3;
 const plan1Rate = Math.min(rpi, CURRENT_RATES.boeBaseRate + 1);
 const boeRatePlus1 = CURRENT_RATES.boeBaseRate + 1;
 const monthlyInterest = Math.round((EXAMPLE_BALANCE * maxRate) / 100 / 12);
+
+// Derived from the current date so the label tracks the live plans.ts figures.
+const currentTaxYear = getCurrentTaxYearLabel();
 
 export function InterestGuide() {
   return (
@@ -151,6 +156,22 @@ export function InterestGuide() {
               plan.
             </p>
           </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Current Interest Rates by Plan ({currentTaxYear})
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              Here are the interest rates in force across every plan for the{" "}
+              {currentTaxYear} tax year, based on RPI of {formatPercent(rpi)}.
+              Middle earners on Plan 2 feel this most: they sit on the sliding
+              scale, charged above RPI without earning enough to clear the
+              balance before interest compounds.
+            </p>
+          </div>
+          <CurrentRatesTable />
         </section>
 
         <section className="space-y-3">

--- a/src/components/guides/interest-rate-cap/CurrentCapTable.tsx
+++ b/src/components/guides/interest-rate-cap/CurrentCapTable.tsx
@@ -1,0 +1,63 @@
+import { ScrollFadeWrapper } from "@/components/shared/ScrollFadeWrapper";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatGBP, formatPercent } from "@/lib/format";
+import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
+
+// The 6% cap is a policy figure (Sept 2026), not something plans.ts supplies —
+// kept as a labelled constant, consistent with the rest of this guide.
+const INTEREST_CAP_RATE = 6;
+
+const rpi = CURRENT_RATES.rpi;
+const maxRate = rpi + 3;
+
+const rows = [
+  { figure: "Base RPI", value: formatPercent(rpi) },
+  {
+    figure: "Plan 2 minimum interest rate (RPI, lower earners)",
+    value: formatPercent(rpi),
+  },
+  {
+    figure: "Plan 2 maximum interest rate (RPI + 3%)",
+    value: formatPercent(maxRate),
+  },
+  {
+    figure: "Income at which the maximum rate applies",
+    value: `Above ${formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}`,
+  },
+  {
+    figure: "Interest rate cap (from 1 September 2026)",
+    value: formatPercent(INTEREST_CAP_RATE),
+  },
+];
+
+export function CurrentCapTable() {
+  return (
+    <ScrollFadeWrapper className="rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead scope="col">Figure</TableHead>
+            <TableHead scope="col">Value</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow key={row.figure}>
+              <TableHead scope="row" className="whitespace-normal">
+                {row.figure}
+              </TableHead>
+              <TableCell>{row.value}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </ScrollFadeWrapper>
+  );
+}

--- a/src/components/guides/interest-rate-cap/InterestRateCapGuide.tsx
+++ b/src/components/guides/interest-rate-cap/InterestRateCapGuide.tsx
@@ -12,13 +12,18 @@ import {
 } from "@/components/ui/breadcrumb";
 import { formatGBP, formatPercent } from "@/lib/format";
 import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
+import { getCurrentTaxYearLabel } from "@/lib/taxYear";
 import { BalanceWithCapChart } from "./BalanceWithCapChart";
+import { CurrentCapTable } from "./CurrentCapTable";
 import { TOTAL_YEARS, YEARS_ABOVE_CAP } from "./historical-rates";
 import { HistoricalRatesChart } from "./HistoricalRatesChart";
 import { TotalCostComparisonChart } from "./TotalCostComparisonChart";
 
 const rpi = CURRENT_RATES.rpi;
 const currentMaxRate = rpi + 3;
+
+// Derived from the current date so the label tracks the live plans.ts figures.
+const currentTaxYear = getCurrentTaxYearLabel();
 
 export function InterestRateCapGuide() {
   return (
@@ -85,6 +90,19 @@ export function InterestRateCapGuide() {
               rate will not follow it above 6%.
             </p>
           </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Plan 2 Interest Rates at a Glance ({currentTaxYear})
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              The key Plan 2 interest figures for the {currentTaxYear} tax year,
+              alongside the 6% cap that applies from September 2026.
+            </p>
+          </div>
+          <CurrentCapTable />
         </section>
 
         <section className="space-y-3">

--- a/src/components/guides/threshold-freeze/CurrentThresholdsTable.tsx
+++ b/src/components/guides/threshold-freeze/CurrentThresholdsTable.tsx
@@ -1,0 +1,67 @@
+import { ScrollFadeWrapper } from "@/components/shared/ScrollFadeWrapper";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatGBP, formatPercent } from "@/lib/format";
+import {
+  PLAN_CONFIGS,
+  PLAN_DISPLAY_INFO,
+  POSTGRADUATE_DISPLAY_INFO,
+} from "@/lib/loans/plans";
+
+// All figures derive from plans.ts so they track the current GOV.UK values.
+const plans = [
+  { display: PLAN_DISPLAY_INFO.PLAN_1, config: PLAN_CONFIGS.PLAN_1 },
+  { display: PLAN_DISPLAY_INFO.PLAN_2, config: PLAN_CONFIGS.PLAN_2 },
+  { display: PLAN_DISPLAY_INFO.PLAN_4, config: PLAN_CONFIGS.PLAN_4 },
+  { display: PLAN_DISPLAY_INFO.PLAN_5, config: PLAN_CONFIGS.PLAN_5 },
+  {
+    display: POSTGRADUATE_DISPLAY_INFO,
+    config: PLAN_CONFIGS.POSTGRADUATE,
+  },
+] as const;
+
+const rows = plans.map(({ display, config }) => ({
+  name: display.name,
+  region: display.region,
+  annual: formatGBP(config.monthlyThreshold * 12),
+  monthly: formatGBP(config.monthlyThreshold),
+  rate: formatPercent(config.repaymentRate * 100),
+}));
+
+export function CurrentThresholdsTable() {
+  return (
+    <ScrollFadeWrapper className="rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead scope="col">Plan</TableHead>
+            <TableHead scope="col">Annual threshold</TableHead>
+            <TableHead scope="col">Monthly threshold</TableHead>
+            <TableHead scope="col">Repayment rate</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow key={row.name}>
+              <TableHead scope="row">
+                {row.name}
+                <span className="block text-xs font-normal text-muted-foreground">
+                  {row.region}
+                </span>
+              </TableHead>
+              <TableCell>{row.annual}</TableCell>
+              <TableCell>{row.monthly}</TableCell>
+              <TableCell>{row.rate}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </ScrollFadeWrapper>
+  );
+}

--- a/src/components/guides/threshold-freeze/ThresholdFreezeGuide.tsx
+++ b/src/components/guides/threshold-freeze/ThresholdFreezeGuide.tsx
@@ -15,6 +15,8 @@ import {
 } from "@/components/ui/breadcrumb";
 import { formatGBP } from "@/lib/format";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
+import { getCurrentTaxYearLabel } from "@/lib/taxYear";
+import { CurrentThresholdsTable } from "./CurrentThresholdsTable";
 import { ThresholdComparisonChart } from "./ThresholdComparisonChart";
 
 // Historical thresholds — hardcoded because these are facts about specific
@@ -30,6 +32,9 @@ const REPAYMENT_RATE = 0.09; // 9% for Plan 2
 const PROJECTED_INFLATION_LINKED = 32_250;
 const THRESHOLD_GAP = PROJECTED_INFLATION_LINKED - FREEZE_THRESHOLD;
 const EXTRA_ANNUAL = Math.round(THRESHOLD_GAP * REPAYMENT_RATE);
+
+// Derived from the current date so the label tracks the live plans.ts figures.
+const currentTaxYear = getCurrentTaxYearLabel();
 
 export function ThresholdFreezeGuide() {
   return (
@@ -250,6 +255,23 @@ export function ThresholdFreezeGuide() {
               Plan 2 borrowers.
             </p>
           </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Current Repayment Thresholds ({currentTaxYear})
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              These are the salary thresholds that apply for the{" "}
+              {currentTaxYear} tax year. Undergraduate borrowers repay{" "}
+              {String(REPAYMENT_RATE * 100)}% of everything they earn above
+              their plan&apos;s threshold &mdash; which is exactly why the
+              freeze bites hardest for middle earners, whose pay rises push more
+              of their salary above a line that isn&apos;t moving.
+            </p>
+          </div>
+          <CurrentThresholdsTable />
         </section>
 
         <section className="space-y-3">

--- a/src/lib/taxYear.test.ts
+++ b/src/lib/taxYear.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatTaxYearLabel,
+  getCurrentTaxYearLabel,
+  getCurrentTaxYearStartYear,
+} from "./taxYear";
+
+describe("getCurrentTaxYearStartYear", () => {
+  it("returns the same calendar year for a mid-year date", () => {
+    expect(getCurrentTaxYearStartYear(new Date("2026-07-10"))).toBe(2026);
+  });
+
+  it("treats 6 April as the start of the new tax year", () => {
+    expect(getCurrentTaxYearStartYear(new Date("2026-04-06"))).toBe(2026);
+  });
+
+  it("treats 5 April as still in the previous tax year", () => {
+    expect(getCurrentTaxYearStartYear(new Date("2026-04-05"))).toBe(2025);
+  });
+
+  it("treats January as the previous tax year", () => {
+    expect(getCurrentTaxYearStartYear(new Date("2027-01-01"))).toBe(2026);
+  });
+});
+
+describe("formatTaxYearLabel", () => {
+  it("formats a typical tax year", () => {
+    expect(formatTaxYearLabel(2026)).toBe("2026/27");
+  });
+
+  it("zero-pads the end year across a decade boundary", () => {
+    expect(formatTaxYearLabel(2029)).toBe("2029/30");
+  });
+
+  it("zero-pads the end year across a century boundary", () => {
+    expect(formatTaxYearLabel(2099)).toBe("2099/00");
+  });
+});
+
+describe("getCurrentTaxYearLabel", () => {
+  it("combines the start year and label formatting", () => {
+    expect(getCurrentTaxYearLabel(new Date("2026-07-10"))).toBe("2026/27");
+  });
+
+  it("uses the previous tax year before 6 April", () => {
+    expect(getCurrentTaxYearLabel(new Date("2026-04-05"))).toBe("2025/26");
+  });
+});

--- a/src/lib/taxYear.ts
+++ b/src/lib/taxYear.ts
@@ -1,0 +1,38 @@
+/**
+ * Returns the calendar year in which the current UK tax year begins.
+ *
+ * The UK tax year runs from 6 April to 5 April, so any date before 6 April
+ * belongs to the tax year that started in the previous calendar year.
+ * @example getCurrentTaxYearStartYear(new Date("2026-07-10")) → 2026 (the 2026/27 year)
+ */
+export function getCurrentTaxYearStartYear(now: Date = new Date()): number {
+  const year = now.getFullYear();
+  const month = now.getMonth(); // 0-indexed
+  const day = now.getDate();
+  // Before 6 April → still the previous tax year
+  if (month < 3 || (month === 3 && day < 6)) {
+    return year - 1;
+  }
+  return year;
+}
+
+/**
+ * Formats a tax-year start year as a UK tax-year label.
+ * @example formatTaxYearLabel(2026) → "2026/27"
+ * @example formatTaxYearLabel(2099) → "2099/00"
+ */
+export function formatTaxYearLabel(startYear: number): string {
+  const endYear = (startYear + 1) % 100;
+  return `${String(startYear)}/${String(endYear).padStart(2, "0")}`;
+}
+
+/**
+ * Returns the current UK tax-year label (e.g. "2026/27").
+ *
+ * Figures in {@link file://./loans/plans.ts plans.ts} track whatever GOV.UK
+ * currently publishes, so they always describe the current tax year — this
+ * derives the matching label so it never needs hardcoding.
+ */
+export function getCurrentTaxYearLabel(now: Date = new Date()): string {
+  return formatTaxYearLabel(getCurrentTaxYearStartYear(now));
+}


### PR DESCRIPTION
## Why

Google Search Console shows dozens of long-tail, exact-figure queries sitting at positions 4–12 — people search the literal numbers, e.g. *"student loan plan 2 threshold 2024 2025 27295"* (30 impressions), *"uk student loan plan 2 repayment threshold 2025 2026 27295"* (12), *"uk student loan interest rate cap 6% april 2026"*, *"plan 2 interest rate cap"*. Our guides discussed these topics but buried the current figures in prose, so they weren't the obvious answer for a searcher who just wants the number for this tax year.

This adds clearly-labelled, current-tax-year figure tables to the three guides where those queries land, so the exact numbers (thresholds, repayment rates, interest rates, the 6% cap) are stated directly and grouped under a heading tagged with the tax year (e.g. "2026/27").

## What changed

- **/guides/threshold-freeze** — a "Current Repayment Thresholds" table covering every plan (annual + monthly threshold, repayment rate).
- **/guides/how-interest-works** — a "Current Interest Rates by Plan" table (how each plan's rate is set, plus the current rate).
- **/guides/interest-rate-cap** — a "Plan 2 Interest Rates at a Glance" key-figures table (RPI, min/max Plan 2 rate, upper income threshold, the 6% cap).

Every figure is derived from `src/lib/loans/plans.ts`, so the tables auto-update when the daily GOV.UK/BoE scrape changes the config — no hardcoded numbers. The tax-year label is computed from the date by a new `src/lib/taxYear.ts` helper (with tests), so it tracks the live figures and never goes stale. The intros keep the site's angle intact — middle earners are the ones the freeze and the sliding-scale interest hurt most.

Existing prose is untouched (historical figures like £27,295 stay as fixed facts). Sitemap `lastmod` bumped for the three touched guides only.

## Positioning note

All new copy reinforces "middle earners are hurt most" — it does not reframe the site as a generic repayment calculator.

## Validation

`pnpm lint && pnpm typecheck && pnpm test && pnpm build && pnpm format` — all pass (495 tests, all three guides prerender static).