### PR TITLE
content(seo): rework mortgage guide to match search intent

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -23,7 +23,7 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - [Plan 2 vs Plan 5](https://studentloanstudy.uk/guides/plan-2-vs-plan-5): Compare thresholds, interest rates, and total repayments between Plan 2 and Plan 5
 - [How Interest Works](https://studentloanstudy.uk/guides/how-interest-works): Understand the sliding scale for Plan 2, RPI-only for Plan 5, and why balances grow
 - [RPI vs CPI](https://studentloanstudy.uk/guides/rpi-vs-cpi): Why student loan interest uses RPI while general inflation is measured by CPI, and what that gap means
-- [Student Loan & Mortgage](https://studentloanstudy.uk/guides/student-loan-vs-mortgage): How student loan repayments affect mortgage affordability and borrowing capacity
+- [Student Loan & Mortgage](https://studentloanstudy.uk/guides/student-loan-vs-mortgage): Whether a student loan affects your mortgage — affordability, whether it counts as income, your credit file, and paying it off first
 - [Pay Upfront or Take Loan?](https://studentloanstudy.uk/guides/pay-upfront-or-take-loan): Should parents pay tuition upfront or let their child take the loan?
 - [Moving Abroad](https://studentloanstudy.uk/guides/moving-abroad): What happens to your student loan if you leave the UK
 - [Self-Employment](https://studentloanstudy.uk/guides/self-employment): How repayments work through Self Assessment for freelancers

--- a/scripts/check-govuk-figures/templates.ts
+++ b/scripts/check-govuk-figures/templates.ts
@@ -234,7 +234,7 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - [Plan 2 vs Plan 5](https://studentloanstudy.uk/guides/plan-2-vs-plan-5): Compare thresholds, interest rates, and total repayments between Plan 2 and Plan 5
 - [How Interest Works](https://studentloanstudy.uk/guides/how-interest-works): Understand the sliding scale for Plan 2, RPI-only for Plan 5, and why balances grow
 - [RPI vs CPI](https://studentloanstudy.uk/guides/rpi-vs-cpi): Why student loan interest uses RPI while general inflation is measured by CPI, and what that gap means
-- [Student Loan & Mortgage](https://studentloanstudy.uk/guides/student-loan-vs-mortgage): How student loan repayments affect mortgage affordability and borrowing capacity
+- [Student Loan & Mortgage](https://studentloanstudy.uk/guides/student-loan-vs-mortgage): Whether a student loan affects your mortgage — affordability, whether it counts as income, your credit file, and paying it off first
 - [Pay Upfront or Take Loan?](https://studentloanstudy.uk/guides/pay-upfront-or-take-loan): Should parents pay tuition upfront or let their child take the loan?
 - [Moving Abroad](https://studentloanstudy.uk/guides/moving-abroad): What happens to your student loan if you leave the UK
 - [Self-Employment](https://studentloanstudy.uk/guides/self-employment): How repayments work through Self Assessment for freelancers

--- a/src/app/guides/student-loan-vs-mortgage/layout.tsx
+++ b/src/app/guides/student-loan-vs-mortgage/layout.tsx
@@ -3,24 +3,24 @@ import { formatGBP } from "@/lib/format";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
 
 export const metadata: Metadata = {
-  title: "Does Your Student Loan Affect Your Mortgage?",
+  title: "Does a Student Loan Affect Your Mortgage? (UK)",
   description:
-    "Yes — and it's not about the balance. Lenders care about your monthly repayment, which quietly shrinks how much you can borrow. See the exact impact at your salary.",
+    "A UK student loan won't stop you getting a mortgage, but the monthly repayment cuts how much you can borrow — and it isn't counted as income. Here's what lenders check.",
   keywords: [
-    "student loan mortgage",
-    "mortgage affordability student loan",
-    "student loan affect mortgage",
-    "student loan borrowing power",
-    "Plan 2 mortgage impact",
-    "Plan 5 mortgage impact",
+    "does student loan affect mortgage uk",
+    "do student loans count as income for mortgage",
+    "does student loan affect mortgage application",
+    "do mortgage lenders take student loans into account",
+    "declare student loan on mortgage application",
+    "student loan mortgage affordability",
   ],
   alternates: {
     canonical: "/guides/student-loan-vs-mortgage",
   },
   openGraph: {
-    title: "Does Your Student Loan Affect Your Mortgage?",
+    title: "Does a Student Loan Affect Your Mortgage? (UK)",
     description:
-      "Yes — and it's not about the balance. Lenders care about your monthly repayment, which quietly shrinks how much you can borrow. See the exact impact at your salary.",
+      "A UK student loan won't stop you getting a mortgage, but the monthly repayment cuts how much you can borrow — and it isn't counted as income. Here's what lenders check.",
     url: "https://studentloanstudy.uk/guides/student-loan-vs-mortgage",
     type: "article",
   },
@@ -74,6 +74,22 @@ const faqSchema = {
     },
     {
       "@type": "Question",
+      name: "Do student loans count as income for a mortgage?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "No. A UK student loan is money you borrowed, not income, so lenders will not count your maintenance or tuition loan towards how much you can borrow. The monthly repayment is a deduction from your income — it can only reduce your affordability, never increase it.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Do you have to declare a student loan on a mortgage application?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes. You should disclose your regular outgoings honestly, and your student loan repayment is one of them. If you are employed it already shows on your payslips, so lenders see it during their checks. Exactly where it goes on the form varies by lender, but declare the monthly repayment — it is a deduction from income, not a conventional debt.",
+      },
+    },
+    {
+      "@type": "Question",
       name: "How much does a student loan reduce mortgage borrowing?",
       acceptedAnswer: {
         "@type": "Answer",
@@ -110,9 +126,9 @@ const faqSchema = {
 const articleSchema = {
   "@context": "https://schema.org",
   "@type": "Article",
-  headline: "Does Your Student Loan Affect Your Mortgage?",
+  headline: "Does a Student Loan Affect Your Mortgage?",
   description:
-    "Yes — and it's not about the balance. Lenders care about your monthly repayment, which quietly shrinks how much you can borrow. See the exact impact at your salary.",
+    "A UK student loan won't stop you getting a mortgage, but the monthly repayment cuts how much you can borrow — and it isn't counted as income. Here's what lenders check.",
   url: "https://studentloanstudy.uk/guides/student-loan-vs-mortgage",
   author: {
     "@type": "Organization",
@@ -125,7 +141,7 @@ const articleSchema = {
     url: "https://studentloanstudy.uk",
   },
   datePublished: "2026-02-14",
-  dateModified: "2026-03-09",
+  dateModified: "2026-07-10",
 };
 
 // Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).

--- a/src/app/sitemap.xml
+++ b/src/app/sitemap.xml
@@ -28,7 +28,7 @@
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/student-loan-vs-mortgage</loc>
-    <lastmod>2026-03-09</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/pay-upfront-or-take-loan</loc>

--- a/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
+++ b/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
@@ -1,3 +1,10 @@
+import {
+  CreditCardIcon,
+  Home05Icon,
+  PercentCircleIcon,
+  Wallet01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { PageLayout } from "@/components/layout/PageLayout";
@@ -33,6 +40,39 @@ const example60kMonthly = Math.round(
 const example60kAnnual = example60kMonthly * 12;
 const example60kMortgageReduction = Math.round(example60kAnnual * 4.5);
 
+const goodBadge = "bg-primary/10 text-primary";
+const watchBadge = "bg-destructive/10 text-destructive";
+
+const quickAnswers = [
+  {
+    icon: Home05Icon,
+    question: "Will it stop you getting a mortgage?",
+    answer: "No",
+    answerClass: goodBadge,
+  },
+  {
+    icon: PercentCircleIcon,
+    question: "Does it lower how much you can borrow?",
+    answer: "Yes",
+    answerClass: watchBadge,
+  },
+  {
+    icon: Wallet01Icon,
+    question: "Does it count as income?",
+    answer: "No",
+    answerClass: goodBadge,
+  },
+  {
+    icon: CreditCardIcon,
+    question: "Does it show on your credit file?",
+    answer: "No",
+    answerClass: goodBadge,
+  },
+];
+
+const linkClasses =
+  "text-primary underline underline-offset-4 hover:text-primary/80";
+
 export function MortgageGuide() {
   return (
     <PageLayout>
@@ -51,65 +91,74 @@ export function MortgageGuide() {
               </BreadcrumbItem>
               <BreadcrumbSeparator />
               <BreadcrumbItem>
-                <BreadcrumbPage>Student Loans & Mortgages</BreadcrumbPage>
+                <BreadcrumbPage>Student Loans &amp; Mortgages</BreadcrumbPage>
               </BreadcrumbItem>
             </BreadcrumbList>
           </Breadcrumb>
 
-          <Heading as="h1">
-            Does Your Student Loan Affect Your Mortgage?
-          </Heading>
+          <Heading as="h1">Does a Student Loan Affect Your Mortgage?</Heading>
 
           <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
-            Your student loan won&rsquo;t stop you getting a mortgage, but the
-            monthly repayments reduce how much lenders think you can afford.
-            Here&rsquo;s how it works.
+            A UK student loan won&rsquo;t stop you getting a mortgage, and it
+            isn&rsquo;t treated as normal debt. But the monthly repayment does
+            quietly shrink how much a lender will let you borrow &mdash; and, as
+            ever, it&rsquo;s middle earners who feel the squeeze most.
+            Here&rsquo;s exactly what lenders look at.
           </p>
         </div>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            How Lenders See Your Student Loan
-          </Heading>
-          <div className="space-y-3 text-muted-foreground">
-            <p>
-              Unlike credit cards or car finance, a UK student loan is not
-              treated as conventional debt. It doesn&rsquo;t appear on your
-              credit report and won&rsquo;t lower your credit score.
-            </p>
-            <p>
-              However, mortgage lenders do factor in the monthly repayment. When
-              they assess your affordability, they look at your net disposable
-              income after tax, National Insurance, pension contributions, and
-              student loan repayments. A higher repayment means less income
-              available for mortgage payments.
-            </p>
-          </div>
+        <section className="grid gap-3 sm:grid-cols-2">
+          {quickAnswers.map((item) => (
+            <div
+              key={item.question}
+              className="flex items-center gap-3 rounded-lg border bg-card p-4 ring-1 ring-foreground/10"
+            >
+              <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <HugeiconsIcon icon={item.icon} className="size-5" />
+              </div>
+              <p className="flex-1 text-sm font-medium">{item.question}</p>
+              <span
+                className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-semibold ${item.answerClass}`}
+              >
+                {item.answer}
+              </span>
+            </div>
+          ))}
         </section>
 
         <section className="space-y-3">
           <Heading as="h2" size="section">
-            The Repayment &ldquo;Tax&rdquo;
+            Does a Student Loan Affect Mortgage Affordability?
           </Heading>
           <div className="space-y-3 text-muted-foreground">
             <p>
-              Student loan repayments work like an extra income tax. You pay{" "}
+              Yes &mdash; this is the one real way a student loan touches your
+              mortgage. When you apply, a lender doesn&rsquo;t just look at your
+              salary; they run an affordability assessment. They start from your
+              income and subtract your committed monthly outgoings &mdash; tax,
+              National Insurance, pension contributions, childcare, existing
+              credit, and your student loan repayment &mdash; to see
+              what&rsquo;s genuinely left to cover a mortgage.
+            </p>
+            <p>
+              Your student loan repayment is one of those committed deductions.
+              Because it comes straight off your pay, it lowers the net income
+              figure the lender works from, which can reduce the size of
+              mortgage you&rsquo;re offered. In debt-to-income terms, the
+              repayment nudges your ratio the wrong way.
+            </p>
+            <p>
+              The repayment behaves like an extra slice of income tax: you pay{" "}
               {repaymentRateDisplay} of everything you earn above your
-              plan&rsquo;s repayment threshold. The higher your salary, the more
-              you repay each month, and the bigger the impact on your mortgage
-              affordability.
-            </p>
-            <p>
-              Plan 5 has a lower threshold than Plan 2, so repayments start
-              sooner and are slightly higher at every salary level. The chart
-              below shows exactly how much you&rsquo;d repay each month.
+              plan&rsquo;s threshold. The more you earn, the larger the monthly
+              deduction &mdash; and the bigger the dent in your borrowing power.
             </p>
           </div>
         </section>
 
         <section className="space-y-3">
           <Heading as="h2" size="section">
-            Monthly Repayment by Salary
+            How Much You Repay at Each Salary
           </Heading>
           <div className="h-75 sm:h-90">
             <RepaymentImpactChart />
@@ -117,41 +166,160 @@ export function MortgageGuide() {
           <p className="text-sm text-muted-foreground">
             Based on current thresholds: Plan 2 at {formatGBP(plan2Threshold)}{" "}
             and Plan 5 at {formatGBP(plan5Threshold)} per year. Both charge{" "}
-            {repaymentRateDisplay} on income above the threshold.
+            {repaymentRateDisplay} on income above the threshold, so Plan
+            5&rsquo;s lower threshold means repayments start sooner.
           </p>
         </section>
 
         <section className="space-y-3">
           <Heading as="h2" size="section">
-            What This Means for Your Borrowing Capacity
+            What It Does to Your Borrowing Power
           </Heading>
           <div className="space-y-3 text-muted-foreground">
             <p>
-              Most lenders offer roughly 4 to 4.5 times your annual income as a
-              mortgage. But they calculate that multiple based on your income
-              after committed expenditure, including student loan repayments.
+              Most lenders offer roughly 4 to 4.5 times income as a mortgage,
+              but they apply that multiple after committed expenditure &mdash;
+              including your student loan repayment.
             </p>
             <p>
-              For example, someone earning &pound;40,000 on Plan 2 repays about{" "}
-              {formatGBP(example40kMonthly)} per month. Annualised, that&rsquo;s
-              around {formatGBP(example40kAnnual)} which a lender might
-              effectively subtract from income before applying their multiplier.
-              On a 4.5x basis, that reduces the maximum mortgage by roughly{" "}
-              {formatGBP(example40kMortgageReduction)}.
+              Someone earning &pound;40,000 on Plan 2 repays about{" "}
+              {formatGBP(example40kMonthly)} a month, or around{" "}
+              {formatGBP(example40kAnnual)} a year. On a 4.5x basis that could
+              trim the maximum mortgage by roughly{" "}
+              {formatGBP(example40kMortgageReduction)}. At &pound;60,000 the
+              repayment climbs to about {formatGBP(example60kMonthly)} a month,
+              knocking off closer to {formatGBP(example60kMortgageReduction)} on
+              the same multiplier.
             </p>
             <p>
-              At higher salaries the gap grows. At &pound;60,000 the monthly
-              repayment is roughly {formatGBP(example60kMonthly)}, trimming
-              potential borrowing by about{" "}
-              {formatGBP(example60kMortgageReduction)} on the same multiplier.
-              Use the{" "}
-              <Link
-                href="/"
-                className="text-primary underline underline-offset-4 hover:text-primary/80"
-              >
+              These are illustrative &mdash; every lender assesses affordability
+              slightly differently &mdash; but they show the direction of
+              travel. Use the{" "}
+              <Link href="/" className={linkClasses}>
                 student loan repayment calculator
               </Link>{" "}
               to see your exact monthly repayment at your salary.
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Do Student Loans Count as Income for a Mortgage?
+          </Heading>
+          <div className="space-y-3 text-muted-foreground">
+            <p>
+              No &mdash; and this trips people up in two ways, both with the
+              same answer.
+            </p>
+            <p>
+              A student loan is money you borrowed, not money you earn, so a
+              lender will never count your maintenance loan or tuition loan as
+              income to boost how much you can borrow. Only earned income
+              &mdash; and sometimes guaranteed bonuses or overtime &mdash;
+              counts towards affordability.
+            </p>
+            <p>
+              The repayment isn&rsquo;t income either; it&rsquo;s a deduction.
+              It only ever reduces the income figure a lender uses, and never
+              adds to it. In short, a student loan can lower your affordability
+              but can never raise it.
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Do You Have to Declare Your Student Loan?
+          </Heading>
+          <div className="space-y-3 text-muted-foreground">
+            <p>
+              Yes &mdash; be upfront about it. A mortgage application asks you
+              to set out your income and regular outgoings honestly, and your
+              student loan repayment is one of those outgoings.
+            </p>
+            <p>
+              If you&rsquo;re employed, the repayment already shows on your
+              payslips, so a lender will usually see it during their checks
+              whether or not you list it separately. Leaving it off
+              doesn&rsquo;t help you and can undermine the application.
+            </p>
+            <p>
+              Exactly where it goes on the form is lender-specific: some ask
+              about student loan repayments directly, others fold them into
+              &ldquo;regular commitments&rdquo;. A mortgage broker can tell you
+              how a particular lender treats it. The key point is to declare the
+              monthly amount honestly &mdash; it&rsquo;s a deduction from
+              income, not a conventional debt like a credit card.
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Does a Student Loan Show on Your Credit File?
+          </Heading>
+          <div className="space-y-3 text-muted-foreground">
+            <p>
+              No. Income-contingent UK student loans (Plan 1, 2, 4, 5 and
+              Postgraduate Loans) are run by the Student Loans Company, which
+              doesn&rsquo;t share your balance or repayments with credit
+              reference agencies. The loan won&rsquo;t appear on your credit
+              report and doesn&rsquo;t affect your credit score.
+            </p>
+            <p>
+              That&rsquo;s good news for a mortgage: however large your balance,
+              it can&rsquo;t drag down the credit score a lender checks, and it
+              can&rsquo;t trigger a credit-based rejection. The only way it
+              touches your mortgage is through affordability &mdash; the monthly
+              repayment described above.
+            </p>
+            <p>
+              It&rsquo;s still worth keeping the rest of your credit file
+              healthy &mdash; on-time bills and low card balances &mdash;
+              because that is what lenders actually score.
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Should You Pay Off Your Student Loan Before Applying?
+          </Heading>
+          <div className="space-y-3 text-muted-foreground">
+            <p>
+              It&rsquo;s tempting to think clearing the loan will unlock a
+              bigger mortgage. Occasionally it does: if you&rsquo;re a small
+              amount short of the borrowing you need and close to the end of
+              your loan term, removing the monthly repayment can tip an
+              application over the line.
+            </p>
+            <p>
+              For most people, though, the maths doesn&rsquo;t favour it. Cash
+              you throw at the loan is cash that isn&rsquo;t in your deposit,
+              and a bigger deposit usually does far more for a mortgage &mdash;
+              a lower loan-to-value ratio unlocks better interest rates and more
+              lenders. The affordability you gain by clearing the repayment is
+              often modest next to that.
+            </p>
+            <p>
+              This is where the middle-earner squeeze bites hardest. Low earners
+              repay little, so the affordability hit is small; the highest
+              earners can absorb the repayment easily. It&rsquo;s middle earners
+              &mdash; comfortably over the threshold but nowhere near clearing
+              the balance &mdash; who lose the most borrowing power now and go
+              on to repay the most over the life of the loan. The student loan
+              works against them at exactly the moment they&rsquo;re trying to
+              buy.
+            </p>
+            <p>
+              Before overpaying to boost a mortgage, model it. The{" "}
+              <Link href="/overpay" className={linkClasses}>
+                overpay calculator
+              </Link>{" "}
+              shows whether putting a lump sum against your loan actually pays
+              off, or whether that money is better kept for your deposit. And
+              get independent mortgage advice for your own situation.
             </p>
           </div>
         </section>
@@ -162,33 +330,32 @@ export function MortgageGuide() {
           </Heading>
           <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
             <li>
-              A student loan is <strong>not</strong> conventional debt &mdash;
-              it won&rsquo;t appear on your credit report.
+              A UK student loan <strong>won&rsquo;t stop</strong> you getting a
+              mortgage and isn&rsquo;t treated as conventional debt.
             </li>
             <li>
-              Lenders deduct your monthly repayment when calculating how much
-              you can borrow, reducing your affordability.
+              It <strong>does</strong> affect affordability: lenders deduct your
+              monthly repayment from income, reducing how much you can borrow.
             </li>
             <li>
-              Your credit score is <strong>not</strong> affected by having a
-              student loan.
+              It <strong>doesn&rsquo;t count as income</strong> &mdash; it can
+              only lower the figure a lender uses, never raise it.
             </li>
             <li>
-              Any remaining balance is written off after{" "}
-              {PLAN_CONFIGS.PLAN_2.writeOffYears} years (Plan 2) or{" "}
-              {PLAN_CONFIGS.PLAN_5.writeOffYears} years (Plan 5) &mdash; you are
-              never chased for unpaid amounts.
+              <strong>Declare</strong> the monthly repayment honestly; on PAYE
+              it shows on your payslips anyway.
             </li>
             <li>
-              <Link
-                href="/overpay"
-                className="text-primary underline underline-offset-4 hover:text-primary/80"
-              >
-                Overpaying your student loan
-              </Link>{" "}
-              to boost mortgage affordability rarely makes sense &mdash; the
-              reduction in borrowing power is modest compared to deposit
-              savings.
+              It <strong>doesn&rsquo;t appear</strong> on your credit file or
+              affect your credit score.
+            </li>
+            <li>
+              Paying it off to boost borrowing rarely beats a bigger deposit
+              &mdash; middle earners feel the squeeze most, so model it with the{" "}
+              <Link href="/overpay" className={linkClasses}>
+                overpay calculator
+              </Link>
+              .
             </li>
           </ul>
         </section>
@@ -196,6 +363,12 @@ export function MortgageGuide() {
         <RelatedGuides
           current="student-loan-vs-mortgage"
           order={["plan-2-vs-plan-5", "how-interest-works"]}
+          extraLinks={[
+            {
+              href: "https://www.gov.uk/repaying-your-student-loan/what-you-pay",
+              label: "GOV.UK: What You Pay",
+            },
+          ]}
         />
       </article>
     </PageLayout>

--- a/src/lib/guides.ts
+++ b/src/lib/guides.ts
@@ -41,7 +41,7 @@ export const GUIDES: GuideEntry[] = [
     slug: "student-loan-vs-mortgage",
     title: "Student Loans & Mortgages",
     description:
-      "How lenders factor student loan repayments into your borrowing capacity.",
+      "Does a student loan affect your mortgage? Affordability, income, your credit file, and whether to clear it first.",
   },
   {
     slug: "how-interest-works",


### PR DESCRIPTION
## Why

`/guides/student-loan-vs-mortgage` was pulling ~2,150 impressions but sitting at avg position ~52 with roughly zero clicks. Search Console shows the whole query cluster is people worried a student loan will hurt a mortgage application, not people comparing "loan vs mortgage":

- "does student loan affect mortgage uk" (279)
- "do student loans count as income for mortgage" (223)
- "does student loan affect mortgage application uk" (221)
- "can student loan affect mortgage" (216)
- "do mortgage lenders take student loans into account" (110)
- "do you have to declare student loan on mortgage application" (28)

The old page half-answered affordability but never addressed "counts as income?" or "do I declare it?", and the title/description didn't mirror how people phrase the question. This reworks the page to answer the actual questions while keeping the URL (it has indexing history).

## What changed

- **Retitled** to "Does a Student Loan Affect Your Mortgage? (UK)" across metadata, OpenGraph, Article schema headline and the on-page H1, so the SERP entry mirrors the dominant queries.
- **Restructured content** into query-matching H2s: affordability (yes — repayment reduces net income used in the affordability/DTI assessment), does it count as income (no — it is a deduction, never adds to what you can borrow), do you have to declare it (yes — kept general and hedged, no invented lender policies), does it show on your credit file (no), and should you pay it off first.
- Added a scannable four-card "quick answers" block up top (stops a mortgage? / lowers borrowing? / counts as income? / on credit file?).
- The "pay it off first" section ties back to the site's core thesis — middle earners lose the most borrowing power now *and* repay the most over the life of the loan — and links to the `/overpay` calculator to model it rather than guess.
- Kept the existing repayment-by-salary chart and worked examples (£40k / £60k) that quantify the affordability hit.
- Added two matching entries to the FAQ JSON-LD (counts as income / declaring it) and refreshed the guide-card and `llms.txt` descriptions.
- Bumped this page's `sitemap.xml` lastmod and the Article `dateModified` to reflect the rework.

## Positioning

Kept the site's angle intact — the guide answers the mortgage question but frames the pay-off decision through the "middle earners are hurt most" lens; it does not reposition the site as a generic repayment/affordability calculator.

## Note on llms.txt

`public/llms.txt` is auto-generated from `generateLlmsTxt` in `scripts/check-govuk-figures/templates.ts`. Regenerating requires a live GOV.UK scrape, so I edited the template and applied the identical change to `public/llms.txt` by hand — both are in sync.

## Facts

Claims kept general and hedged where lender-specific: affordability handling, "you usually don't list it like a credit card but disclose the monthly amount", SLC not reporting income-contingent loans to credit reference agencies. No specific lender policies invented.

## Validation

`pnpm lint && pnpm typecheck && pnpm test && pnpm build && pnpm format` — all pass (486 tests, build clean).
