### PR TITLE
feat(seo): add country-specific threshold sections to moving-abroad guide

### DIFF
--- a/src/app/guides/moving-abroad/layout.tsx
+++ b/src/app/guides/moving-abroad/layout.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from "next";
+import { movingAbroadFaqs } from "@/components/guides/moving-abroad/overseas-data";
+
+const description =
+  "Moving overseas doesn't wipe your UK student loan. See how SLC repayment thresholds change in Australia, Canada, the USA, Dubai and Spain, what the overseas income assessment involves, and what happens if you don't tell SLC.";
 
 export const metadata: Metadata = {
   title: "What Happens to Your Student Loan If You Move Abroad?",
-  description:
-    "Moving overseas doesn't make your student loan disappear — the SLC will find you. Here's what they expect, what the penalties look like, and how repayment thresholds change by country.",
+  description,
   keywords: [
     "student loan abroad",
     "SLC overseas",
@@ -11,14 +14,18 @@ export const metadata: Metadata = {
     "UK student loan overseas repayment",
     "student loan living abroad",
     "SLC overseas income assessment",
+    "student loan moving to Australia",
+    "student loan moving to Canada",
+    "student loan Dubai UAE",
+    "student loan Spain",
+    "student loan wiped moving abroad",
   ],
   alternates: {
     canonical: "/guides/moving-abroad",
   },
   openGraph: {
     title: "What Happens to Your Student Loan If You Move Abroad?",
-    description:
-      "Moving overseas doesn't make your student loan disappear — the SLC will find you. Here's what they expect, what the penalties look like, and how repayment thresholds change by country.",
+    description,
     url: "https://studentloanstudy.uk/guides/moving-abroad",
     type: "article",
   },
@@ -52,56 +59,21 @@ const breadcrumbSchema = {
 const faqSchema = {
   "@context": "https://schema.org",
   "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "Do I still pay my student loan if I move abroad?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Yes. Moving abroad does not cancel your student loan. You must notify the Student Loans Company within three months of leaving the UK, provide evidence of your overseas income, and make repayments based on country-specific thresholds set by SLC.",
-      },
+  mainEntity: movingAbroadFaqs.map((faq) => ({
+    "@type": "Question",
+    name: faq.question,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: faq.answer,
     },
-    {
-      "@type": "Question",
-      name: "What happens if I don't tell SLC I've moved abroad?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "If you fail to provide income evidence, SLC will apply fixed repayment amounts that can be significantly higher than what you would pay based on your actual income. They may also take legal action, pass your debt to collection agencies, or apply penalties and additional interest.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "How are student loan repayments calculated when living overseas?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "SLC sets country-specific repayment thresholds based on the cost of living in your country of residence. You still repay 9% of income above the threshold (6% for Postgraduate loans), but the threshold itself varies by country rather than using the standard UK figure.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "What happens to my student loan if I emigrate from the UK?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Your loan remains active regardless of where you live. When you emigrate, you must contact the Student Loans Company within three months, complete an overseas income assessment, and switch to country-specific repayment thresholds. The write-off date stays the same — emigrating does not reset or extend it.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Can I avoid paying my student loan by moving abroad?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "No. The Student Loans Company actively tracks overseas borrowers and has legal powers to pursue repayment internationally. If you do not respond to income assessments, SLC will impose fixed repayment amounts that are often much higher than income-based repayments. They may also refer your account to debt collection agencies or take court action.",
-      },
-    },
-  ],
+  })),
 };
 
 const articleSchema = {
   "@context": "https://schema.org",
   "@type": "Article",
   headline: "What Happens to Your Student Loan If You Move Abroad?",
-  description:
-    "Moving overseas doesn't make your student loan disappear — the SLC will find you. Here's what they expect, what the penalties look like, and how repayment thresholds change by country.",
+  description,
   url: "https://studentloanstudy.uk/guides/moving-abroad",
   author: {
     "@type": "Organization",
@@ -114,7 +86,7 @@ const articleSchema = {
     url: "https://studentloanstudy.uk",
   },
   datePublished: "2026-02-14",
-  dateModified: "2026-03-09",
+  dateModified: "2026-07-10",
 };
 
 // Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).

--- a/src/app/sitemap.xml
+++ b/src/app/sitemap.xml
@@ -36,7 +36,7 @@
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/moving-abroad</loc>
-    <lastmod>2026-03-09</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/self-employment</loc>

--- a/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
+++ b/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
@@ -8,6 +8,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { PageLayout } from "@/components/layout/PageLayout";
+import { ScrollFadeWrapper } from "@/components/shared/ScrollFadeWrapper";
 import { Heading } from "@/components/typography/Heading";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
@@ -18,7 +19,23 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatGBP } from "@/lib/format";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
+import {
+  govUkOverseasThresholdsLink,
+  movingAbroadFaqs,
+  overseasComparisonLabel,
+  overseasThresholds,
+  UK_PLAN2_THRESHOLD,
+} from "./overseas-data";
 
 const undergradRate = `${String(PLAN_CONFIGS.PLAN_2.repaymentRate * 100)}%`;
 const postgradRate = `${String(PLAN_CONFIGS.POSTGRADUATE.repaymentRate * 100)}%`;
@@ -158,6 +175,94 @@ export function MovingAbroadGuide() {
         </section>
 
         <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Country-by-Country: How Your Threshold Changes
+          </Heading>
+          <p className="text-sm text-muted-foreground sm:text-base">
+            SLC doesn&rsquo;t use a single overseas threshold for everyone.
+            Every country is placed into a price-level band that multiplies the
+            UK threshold up or down based on local living costs, so the salary
+            at which you start repaying can sit below or above the UK&rsquo;s{" "}
+            {formatGBP(UK_PLAN2_THRESHOLD)}. This is where{" "}
+            <strong>middle earners abroad feel it most</strong> &mdash; in a
+            lower-threshold country, a mid-range salary that would barely
+            trigger repayments at home can pull a much bigger slice into the{" "}
+            {undergradRate} repayment band.
+          </p>
+          <p className="text-sm text-muted-foreground sm:text-base">
+            The process is the same wherever you go: notify SLC within three
+            months, complete the overseas income assessment on your worldwide
+            income (converted into pounds), and re-submit evidence every year.
+            Only the threshold changes by country. Skip the assessment and SLC
+            falls back to fixed repayment amounts that are usually higher than
+            income-based ones.
+          </p>
+          <ScrollFadeWrapper className="rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead scope="col">Destination</TableHead>
+                  <TableHead scope="col">Plan 2 threshold (2026/27)</TableHead>
+                  <TableHead scope="col">Compared to the UK</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {overseasThresholds.map((row) => (
+                  <TableRow key={row.country}>
+                    <TableHead scope="row">{row.country}</TableHead>
+                    <TableCell>{formatGBP(row.threshold)}</TableCell>
+                    <TableCell>
+                      {overseasComparisonLabel(row.threshold)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </ScrollFadeWrapper>
+          <p className="text-xs text-muted-foreground sm:text-sm">
+            Figures are SLC&rsquo;s Plan 2 (undergraduate) overseas thresholds
+            for 2026/27, set against the UK threshold of{" "}
+            {formatGBP(UK_PLAN2_THRESHOLD)}. Other plans use a different base
+            figure, and SLC revises every country each April &mdash; always{" "}
+            <a
+              href={govUkOverseasThresholdsLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={linkClasses}
+            >
+              check the latest figures on GOV.UK
+            </a>
+            .
+          </p>
+          <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+            <li>
+              <strong className="text-foreground">
+                Australia, Canada &amp; New Zealand:
+              </strong>{" "}
+              currently sit in the same band as the UK, so your threshold
+              matches the home figure and repayments feel much like they did in
+              the UK.
+            </li>
+            <li>
+              <strong className="text-foreground">Spain:</strong> a lower band
+              pulls the threshold below the UK&rsquo;s, so repayments start
+              earlier &mdash; a classic squeeze on middle earners.
+            </li>
+            <li>
+              <strong className="text-foreground">UAE (Dubai):</strong> there is
+              no local income tax, but your UK student loan is separate from
+              that &mdash; the SLC threshold is still lower than the UK&rsquo;s,
+              so a tax-free salary is caught sooner, not exempted.
+            </li>
+            <li>
+              <strong className="text-foreground">United States:</strong> a
+              higher band lifts the threshold above the UK&rsquo;s, so you keep
+              more of your salary before repayments begin.
+            </li>
+          </ul>
+        </section>
+
+        <section className="space-y-4">
           <Alert variant="destructive">
             <HugeiconsIcon icon={AlertCircleIcon} className="size-4" />
             <AlertTitle>
@@ -272,6 +377,25 @@ export function MovingAbroadGuide() {
                     {step.description}
                   </p>
                 </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Moving Abroad: Frequently Asked Questions
+          </Heading>
+          <div className="space-y-3">
+            {movingAbroadFaqs.map((faq) => (
+              <div
+                key={faq.question}
+                className="rounded-lg border bg-card p-4 ring-1 ring-foreground/10 sm:p-5"
+              >
+                <p className="font-medium text-foreground">{faq.question}</p>
+                <p className="mt-2 text-sm text-muted-foreground sm:text-base">
+                  {faq.answer}
+                </p>
               </div>
             ))}
           </div>

--- a/src/components/guides/moving-abroad/overseas-data.ts
+++ b/src/components/guides/moving-abroad/overseas-data.ts
@@ -1,0 +1,97 @@
+import { formatGBP } from "@/lib/format";
+
+// SLC sets a separate repayment threshold for each country by placing it in a
+// price-level band that multiplies the UK threshold. The figures below are the
+// Plan 2 (undergraduate) overseas thresholds for the 2026/27 tax year, as
+// published by SLC on GOV.UK. They are hardcoded because they describe a
+// specific tax year and must not shift when the live UK config updates — SLC
+// revises them every April, hence the "check the latest" caveat shown in the UI.
+export const UK_PLAN2_THRESHOLD = 29_385; // 2026/27 UK Plan 2 threshold
+const LOWER_BAND_THRESHOLD = 23_510; // e.g. Spain, UAE (~0.8× the UK band)
+const HIGHER_BAND_THRESHOLD = 35_260; // e.g. USA (~1.2× the UK band)
+
+export const govUkOverseasThresholdsLink =
+  "https://www.gov.uk/government/publications/overseas-earnings-thresholds-for-plan-2-student-loans";
+
+export type OverseasThreshold = {
+  country: string;
+  threshold: number;
+};
+
+// Ordered by band (lower → UK → higher) so the middle-earner story reads down
+// the table: a lower threshold pulls more of a mid-range salary into the 9% band.
+export const overseasThresholds: OverseasThreshold[] = [
+  { country: "Spain", threshold: LOWER_BAND_THRESHOLD },
+  { country: "UAE (Dubai)", threshold: LOWER_BAND_THRESHOLD },
+  { country: "Australia", threshold: UK_PLAN2_THRESHOLD },
+  { country: "Canada", threshold: UK_PLAN2_THRESHOLD },
+  { country: "New Zealand", threshold: UK_PLAN2_THRESHOLD },
+  { country: "United States", threshold: HIGHER_BAND_THRESHOLD },
+];
+
+// How each country's threshold compares to the UK band, derived from the figures
+// above so the label can never drift from the number shown next to it.
+export function overseasComparisonLabel(threshold: number): string {
+  if (threshold === UK_PLAN2_THRESHOLD) {
+    return "Matches the UK threshold";
+  }
+  const multiplier = (threshold / UK_PLAN2_THRESHOLD).toFixed(1);
+  return threshold > UK_PLAN2_THRESHOLD
+    ? `Higher — about ${multiplier}× the UK band`
+    : `Lower — about ${multiplier}× the UK band`;
+}
+
+export type MovingAbroadFaq = {
+  question: string;
+  answer: string;
+};
+
+// Single source of truth for the visible FAQ and the FAQPage JSON-LD in
+// layout.tsx, so the structured data can never drift from what the page shows.
+// The country-specific questions lead because they mirror real search queries.
+export const movingAbroadFaqs: MovingAbroadFaq[] = [
+  {
+    question: "Does your student loan get wiped if you move abroad?",
+    answer: `No. Moving abroad does not cancel your student loan or wipe the balance, and there is no rule that writes it off after three years overseas. Your loan is only cleared at the end of your plan's write-off period — typically 25, 30 or 40 years depending on your plan — and that clock keeps ticking wherever you live, whether or not you make repayments. Living abroad changes how much you repay, not whether the debt still exists.`,
+  },
+  {
+    question:
+      "What happens to my student loan if I move to Canada, Australia or New Zealand?",
+    answer: `You must tell the Student Loans Company within three months of leaving and complete the overseas income assessment. Australia, Canada and New Zealand currently sit in the same price band as the UK, so your repayment threshold stays close to the UK figure (${formatGBP(UK_PLAN2_THRESHOLD)} for Plan 2 in 2026/27). You then repay 9% of income above that threshold, with your overseas earnings converted into pounds.`,
+  },
+  {
+    question:
+      "Do I still repay my student loan in Dubai if there's no income tax?",
+    answer: `Yes. UK student loan repayments are completely separate from local income tax, so a tax-free salary in the UAE does not exempt you. The UAE threshold is actually lower than the UK's (${formatGBP(LOWER_BAND_THRESHOLD)} versus ${formatGBP(UK_PLAN2_THRESHOLD)} for Plan 2 in 2026/27), so a Dubai salary can trigger repayments earlier than the same salary would at home.`,
+  },
+  {
+    question: "Which countries have a lower student loan repayment threshold?",
+    answer: `Countries with a lower cost of living than the UK are placed in a lower price band, which reduces the salary at which repayments begin. For Plan 2 in 2026/27, Spain and the UAE sit around ${formatGBP(LOWER_BAND_THRESHOLD)} — below the UK's ${formatGBP(UK_PLAN2_THRESHOLD)} — while higher-cost countries such as the United States are higher, at ${formatGBP(HIGHER_BAND_THRESHOLD)}. A lower threshold hits middle earners hardest, because more of a mid-range salary falls into the 9% repayment band.`,
+  },
+  {
+    question: "Do I still pay my student loan if I move abroad?",
+    answer:
+      "Yes. Moving abroad does not cancel your student loan. You must notify the Student Loans Company within three months of leaving the UK, provide evidence of your overseas income, and make repayments based on country-specific thresholds set by SLC.",
+  },
+  {
+    question: "What happens if I don't tell SLC I've moved abroad?",
+    answer:
+      "If you fail to provide income evidence, SLC will apply fixed repayment amounts that can be significantly higher than what you would pay based on your actual income. They may also take legal action, pass your debt to collection agencies, or apply penalties and additional interest.",
+  },
+  {
+    question:
+      "How are student loan repayments calculated when living overseas?",
+    answer:
+      "SLC sets country-specific repayment thresholds based on the cost of living in your country of residence. You still repay 9% of income above the threshold (6% for Postgraduate loans), but the threshold itself varies by country rather than using the standard UK figure.",
+  },
+  {
+    question: "What happens to my student loan if I emigrate from the UK?",
+    answer:
+      "Your loan remains active regardless of where you live. When you emigrate, you must contact the Student Loans Company within three months, complete an overseas income assessment, and switch to country-specific repayment thresholds. The write-off date stays the same — emigrating does not reset or extend it.",
+  },
+  {
+    question: "Can I avoid paying my student loan by moving abroad?",
+    answer:
+      "No. The Student Loans Company actively tracks overseas borrowers and has legal powers to pursue repayment internationally. If you do not respond to income assessments, SLC will impose fixed repayment amounts that are often much higher than income-based repayments. They may also refer your account to debt collection agencies or take court action.",
+  },
+];


### PR DESCRIPTION
## Why

`/guides/moving-abroad` is our **top page by visitors** (194, ahead of the homepage) and **#2 by Search Console clicks** (57 clicks, 6,572 impressions, avg position 9.3) — but until now it only explained the overseas rules generically. The demand is overwhelmingly destination-specific:

- Australia alone: 12 clicks, 2.97% CTR, position 5.4
- Long-tail queries like "if i move to canada", "student loan in spain", "student loan wiped after 3 years abroad"
- Someone even hit a non-existent `/guides/moving dubai` URL

Sitting at position 9.3 on thousands of impressions means the content nearly ranks but doesn't yet answer the country-level question searchers are actually asking. This closes that gap without repositioning the guide as a generic calculator — the framing keeps our angle that **middle earners are hit hardest**, since a lower overseas threshold pulls more of a mid-range salary into the repayment band.

## What changed

- A new **Country-by-Country** section explains the mechanism accurately: SLC places each country in a price-level band that multiplies the UK threshold up or down, so repayments can start below or above the UK figure. Only the threshold changes by country — the overseas income assessment and non-compliance rules are the same everywhere.
- A destination table covering the most-demanded countries (Australia, Canada, New Zealand, USA, Spain, UAE/Dubai) with each threshold and how it compares to the UK band, plus grouped call-outs (e.g. Dubai's no-income-tax myth, Spain's earlier repayment start).
- A visible **FAQ** section mirroring real query phrasing — leading with "Does your student loan get wiped if you move abroad?" (answer: no — the write-off clock keeps ticking, there's no three-years-abroad rule), plus Canada/Australia/NZ, Dubai, and "which countries have a lower threshold".
- The page's FAQPage JSON-LD now renders from the same source as the visible FAQ, so structured data can no longer drift from what users see.
- Metadata description and keywords updated to name the destinations searchers use; `dateModified` and sitemap `lastmod` refreshed for this page only.

## On the figures

Country thresholds are verified against GOV.UK's published **Plan 2 overseas earnings thresholds for 2026/27** (UK base £29,385; Spain/UAE £23,510 ≈ 0.8×; USA £35,260 ≈ 1.2×; Australia/Canada/NZ match the UK band). They're hardcoded with a comment (like the threshold-freeze guide's tax-year facts) and carry a visible "SLC revises every April — check the latest on GOV.UK" caveat linking to the source publication. No `llms.txt` or `plans.ts` changes were needed.

## Validation

`pnpm lint && pnpm typecheck && pnpm test && pnpm build && pnpm format` all pass (486 tests; `/guides/moving-abroad` prerenders static).