### PR TITLE
fix(seo): scope guides index structured data to the index page

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,9 +54,10 @@ export default defineConfig(
     },
   },
   {
-    // JSON-LD structured data in layouts, shadcn chart styles, and global-error
-    // inline CSS require dangerouslySetInnerHTML
+    // JSON-LD structured data (the shared JsonLd component and layouts), shadcn
+    // chart styles, and global-error inline CSS require dangerouslySetInnerHTML
     files: [
+      "src/components/seo/JsonLd.tsx",
       "src/app/**/layout.tsx",
       "src/app/global-error.tsx",
       "src/components/ui/chart.tsx",

--- a/src/app/guides/layout.tsx
+++ b/src/app/guides/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { GUIDES } from "@/lib/guides";
 
 export const metadata: Metadata = {
   title: "Student Loan Guides — The Stuff They Don't Tell You",
@@ -24,56 +23,15 @@ export const metadata: Metadata = {
   },
 };
 
-const itemListSchema = {
-  "@context": "https://schema.org",
-  "@type": "ItemList",
-  name: "UK Student Loan Guides",
-  description:
-    "In-depth guides to help you understand UK student loan repayment, interest, and how it fits into your wider finances.",
-  numberOfItems: GUIDES.length,
-  itemListElement: GUIDES.map((guide, index) => ({
-    "@type": "ListItem",
-    position: index + 1,
-    name: guide.title,
-    url: `https://studentloanstudy.uk/guides/${guide.slug}`,
-  })),
-};
-
-const breadcrumbSchema = {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  itemListElement: [
-    {
-      "@type": "ListItem",
-      position: 1,
-      name: "Home",
-      item: "https://studentloanstudy.uk",
-    },
-    {
-      "@type": "ListItem",
-      position: 2,
-      name: "Guides",
-      item: "https://studentloanstudy.uk/guides",
-    },
-  ],
-};
-
+// Structured data for the guides index (ItemList + BreadcrumbList) lives in
+// the index page itself (`page.tsx`), not this shared segment layout — a layout
+// wraps every child guide route, so schema declared here would leak an
+// all-guides ItemList and a partial "Home > Guides" BreadcrumbList onto every
+// individual guide page, conflicting with each guide's own BreadcrumbList.
 export default function GuidesLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListSchema) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
-      />
-      {children}
-    </>
-  );
+  return children;
 }

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -2,6 +2,7 @@ import { ArrowRight01Icon, BookOpen01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { PageLayout } from "@/components/layout/PageLayout";
+import { JsonLd } from "@/components/seo/JsonLd";
 import { Heading } from "@/components/typography/Heading";
 import {
   Breadcrumb,
@@ -13,9 +14,45 @@ import {
 } from "@/components/ui/breadcrumb";
 import { GUIDES } from "@/lib/guides";
 
+const itemListSchema = {
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  name: "UK Student Loan Guides",
+  description:
+    "In-depth guides to help you understand UK student loan repayment, interest, and how it fits into your wider finances.",
+  numberOfItems: GUIDES.length,
+  itemListElement: GUIDES.map((guide, index) => ({
+    "@type": "ListItem",
+    position: index + 1,
+    name: guide.title,
+    url: `https://studentloanstudy.uk/guides/${guide.slug}`,
+  })),
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://studentloanstudy.uk",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Guides",
+      item: "https://studentloanstudy.uk/guides",
+    },
+  ],
+};
+
 export default function GuidesPage() {
   return (
     <PageLayout>
+      <JsonLd data={itemListSchema} />
+      <JsonLd data={breadcrumbSchema} />
       <div className="space-y-4">
         <Breadcrumb>
           <BreadcrumbList>

--- a/src/components/seo/JsonLd.tsx
+++ b/src/components/seo/JsonLd.tsx
@@ -1,0 +1,26 @@
+export type JsonLdPrimitive = string | number | boolean | null;
+
+export type JsonLdValue =
+  | JsonLdPrimitive
+  | readonly JsonLdValue[]
+  | { readonly [key: string]: JsonLdValue };
+
+export type JsonLdObject = { readonly [key: string]: JsonLdValue };
+
+/**
+ * Renders a schema.org structured-data block as an inline
+ * `<script type="application/ld+json">` tag for search engines.
+ *
+ * `<` is escaped to `<` per the Next.js JSON-LD guidance so that a stray
+ * `</script>` sequence inside serialized content cannot break out of the tag.
+ */
+export function JsonLd({ data }: { data: JsonLdObject }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replace(/</g, "\\u003c"),
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Why

Search Console's **Search appearance** report is empty for the guides — zero rich results, despite every guide already shipping BreadcrumbList, Article and FAQPage JSON-LD (verified rendering in the built HTML). The task was framed as "add Breadcrumb + Article structured data to the guides", but those schemas already exist and render correctly, so re-adding them would only create duplicates.

The real defect is upstream of that: **`src/app/guides/layout.tsx` is a shared segment layout**, so anything it renders is injected into *every* child guide route — not just the `/guides` index. It was rendering the index's `ItemList` (all 9 guides) and a two-item `Home > Guides` BreadcrumbList. As a result every individual guide page carried **two conflicting BreadcrumbList trails** (a partial `Home > Guides` plus its own correct `Home > Guides > [Title]`) and an irrelevant all-guides `ItemList`.

Breadcrumbs are the one schema type here that can actually populate the Search appearance report — Article rarely surfaces as a rich result for non-news sites, and FAQ rich results are disabled for non-authoritative domains. Two competing breadcrumb trails per page is the most likely reason Google never rendered a breadcrumb rich result.

## What changed

The index-only structured data (ItemList + `Home > Guides` breadcrumb) now lives on the guides **index page** itself, where it belongs, instead of the shared layout. Behaviour by route:

- **Each guide detail page** now emits exactly one `Home > Guides > [Guide title]` BreadcrumbList alongside its existing Article schema — no stray ItemList, no duplicate/partial breadcrumb.
- **`/guides` index** is unchanged in output: still the all-guides ItemList + `Home > Guides` breadcrumb.

The index schema renders through a new shared, typed `JsonLd` component (`src/components/seo/JsonLd.tsx`). It escapes `<` to `<` per the Next.js JSON-LD guidance so a stray `</script>` in serialized content can't break out of the tag. The existing eslint override that allows `dangerouslySetInnerHTML` for JSON-LD in layouts is extended to cover this component.

Deliberately **not** done, to respect existing markup and avoid duplication: no Article/Breadcrumb re-added to guide pages (already present), and FAQPage left untouched.

## Validation

`pnpm lint` (clean, no warnings) · `pnpm typecheck` · `pnpm test` (486 pass) · `pnpm build` · `pnpm format` — all green. Confirmed in the built HTML that each guide detail page now has a single correct BreadcrumbList and the `/guides` index retains its ItemList + breadcrumb; all JSON-LD blocks parse as valid JSON.
