### PR TITLE
feat(seo): add per-plan pages and hub for UK student loan plans

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -29,6 +29,15 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - [Self-Employment](https://studentloanstudy.uk/guides/self-employment): How repayments work through Self Assessment for freelancers
 - [Threshold Freeze Explained](https://studentloanstudy.uk/guides/threshold-freeze): How the Plan 2 threshold freeze from 2027-2030 increases monthly repayments and what the parliamentary inquiry means
 
+## Plan Pages
+
+- [UK Student Loan Plans Explained](https://studentloanstudy.uk/plans): Every UK student loan plan compared at a glance — thresholds, repayment rates, interest and write-off periods
+- [Plan 1 Explained](https://studentloanstudy.uk/plans/plan-1): Plan 1 threshold, capped interest and 25-year write-off for pre-2012 England/Wales and all Northern Irish students
+- [Plan 2 Explained](https://studentloanstudy.uk/plans/plan-2): Plan 2 threshold, RPI + 3% sliding-scale interest and why middle earners repay the most over 30 years
+- [Plan 4 Explained](https://studentloanstudy.uk/plans/plan-4): Plan 4 for Scottish students — the highest threshold of any plan, capped interest and 30-year write-off
+- [Plan 5 Explained](https://studentloanstudy.uk/plans/plan-5): Plan 5 threshold, RPI-only interest and the longest 40-year write-off
+- [Postgraduate Loan Explained](https://studentloanstudy.uk/plans/postgraduate): Postgraduate Master's and Doctoral loan — 6% repayment rate, RPI + 3% interest, repaid alongside any undergraduate loan
+
 ## Key Facts
 
 - UK student loans support multiple plan types: Plan 1, Plan 2, Plan 4, Plan 5, and Postgraduate Loans

--- a/scripts/check-govuk-figures/templates.ts
+++ b/scripts/check-govuk-figures/templates.ts
@@ -240,6 +240,15 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - [Self-Employment](https://studentloanstudy.uk/guides/self-employment): How repayments work through Self Assessment for freelancers
 - [Threshold Freeze Explained](https://studentloanstudy.uk/guides/threshold-freeze): How the Plan 2 threshold freeze from 2027-2030 increases monthly repayments and what the parliamentary inquiry means
 
+## Plan Pages
+
+- [UK Student Loan Plans Explained](https://studentloanstudy.uk/plans): Every UK student loan plan compared at a glance — thresholds, repayment rates, interest and write-off periods
+- [Plan 1 Explained](https://studentloanstudy.uk/plans/plan-1): Plan 1 threshold, capped interest and ${plan1WriteOff}-year write-off for pre-2012 England/Wales and all Northern Irish students
+- [Plan 2 Explained](https://studentloanstudy.uk/plans/plan-2): Plan 2 threshold, RPI + 3% sliding-scale interest and why middle earners repay the most over ${plan2WriteOff} years
+- [Plan 4 Explained](https://studentloanstudy.uk/plans/plan-4): Plan 4 for Scottish students — the highest threshold of any plan, capped interest and ${plan4WriteOff}-year write-off
+- [Plan 5 Explained](https://studentloanstudy.uk/plans/plan-5): Plan 5 threshold, RPI-only interest and the longest ${plan5WriteOff}-year write-off
+- [Postgraduate Loan Explained](https://studentloanstudy.uk/plans/postgraduate): Postgraduate Master's and Doctoral loan — ${fmtRate(postgradRate)} repayment rate, RPI + 3% interest, repaid alongside any undergraduate loan
+
 ## Key Facts
 
 - UK student loans support multiple plan types: Plan 1, Plan 2, Plan 4, Plan 5, and Postgraduate Loans

--- a/src/app/plans/layout.tsx
+++ b/src/app/plans/layout.tsx
@@ -1,0 +1,74 @@
+import type { Metadata } from "next";
+import { PLAN_PAGE_ORDER, PLAN_PAGES } from "@/lib/planContent";
+
+const title =
+  "UK Student Loan Plans Explained: Plan 1, 2, 4, 5 & Postgraduate (2026)";
+const description =
+  "Every UK student loan plan compared at a glance — Plan 1, 2, 4, 5 and Postgraduate thresholds, repayment rates, interest and write-off periods. Find your plan and see why middle earners repay the most.";
+const SITE = "https://studentloanstudy.uk";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  keywords: [
+    "student loan plans",
+    "student loan plan types",
+    "uk student loan plans",
+    "types of student loan",
+    "student loan plans explained",
+    "plan 1 plan 2 plan 4 plan 5",
+  ],
+  alternates: { canonical: "/plans" },
+  openGraph: { title, description, url: `${SITE}/plans`, type: "website" },
+};
+
+const itemListSchema = {
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  name: "UK Student Loan Plans",
+  description:
+    "The five UK student loan plan types compared: thresholds, repayment rates, interest and write-off periods.",
+  numberOfItems: PLAN_PAGE_ORDER.length,
+  itemListElement: PLAN_PAGE_ORDER.map((key, index) => ({
+    "@type": "ListItem",
+    position: index + 1,
+    name: `${PLAN_PAGES[key].name} student loan`,
+    url: `${SITE}/plans/${PLAN_PAGES[key].slug}`,
+  })),
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "Home", item: SITE },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Loan Plans",
+      item: `${SITE}/plans`,
+    },
+  ],
+};
+
+// Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
+// Google reads JSON-LD from anywhere in the document, so this is equivalent.
+export default function PlansLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -1,0 +1,169 @@
+import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
+import { PageLayout } from "@/components/layout/PageLayout";
+import { AllPlansTable } from "@/components/plans/AllPlansTable";
+import { PlanCtaCards } from "@/components/plans/PlanCtaCards";
+import { Heading } from "@/components/typography/Heading";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { currencyFormatter } from "@/constants";
+import { formatPercent } from "@/lib/format";
+import { PLAN_PAGE_ORDER, PLAN_PAGES } from "@/lib/planContent";
+
+const LINK_CLASS =
+  "text-primary underline underline-offset-4 hover:text-primary/80";
+
+export default function PlansHubPage() {
+  return (
+    <PageLayout>
+      <div className="space-y-8">
+        <div className="space-y-4">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>Loan Plans</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+
+          <div className="space-y-2">
+            <Heading as="h1">UK Student Loan Plans Explained</Heading>
+            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+              The UK has five student loan plans, and which one you are on
+              decides your repayment threshold, interest rate and write-off
+              date. Compare Plan 1, Plan 2, Plan 4, Plan 5 and the Postgraduate
+              Loan below, then open a plan for the full detail. Whatever your
+              plan, it is middle earners who repay the most.
+            </p>
+          </div>
+        </div>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            All UK student loan plans compared
+          </Heading>
+          <p className="text-sm text-muted-foreground sm:text-base">
+            Every plan&rsquo;s repayment threshold, rate, interest and write-off
+            period at a glance. Figures update automatically from GOV.UK and the
+            Bank of England.
+          </p>
+          <AllPlansTable />
+        </section>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Explore each plan
+          </Heading>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {PLAN_PAGE_ORDER.map((key) => {
+              const plan = PLAN_PAGES[key];
+              return (
+                <Link
+                  key={key}
+                  href={`/plans/${plan.slug}`}
+                  className="group block h-full"
+                >
+                  <div className="flex h-full flex-col rounded-xl bg-card p-5 ring-1 ring-foreground/10 transition-all duration-200 hover:bg-accent hover:ring-primary/30">
+                    <h3 className="font-semibold">{plan.name}</h3>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {plan.region} &middot; {plan.years}
+                    </p>
+                    <dl className="mt-4 space-y-2 text-sm">
+                      <div className="flex items-baseline justify-between gap-2">
+                        <dt className="text-muted-foreground">Threshold</dt>
+                        <dd className="font-mono font-semibold tabular-nums">
+                          {currencyFormatter.format(plan.yearlyThreshold)}/yr
+                        </dd>
+                      </div>
+                      <div className="flex items-baseline justify-between gap-2">
+                        <dt className="text-muted-foreground">Rate</dt>
+                        <dd className="font-mono font-semibold tabular-nums">
+                          {formatPercent(plan.repaymentRate * 100)}
+                        </dd>
+                      </div>
+                      <div className="flex items-baseline justify-between gap-2">
+                        <dt className="text-muted-foreground">Write-off</dt>
+                        <dd className="font-mono font-semibold tabular-nums">
+                          {String(plan.writeOffYears)} years
+                        </dd>
+                      </div>
+                    </dl>
+                    <div className="mt-4 flex items-center gap-1 text-sm font-medium text-primary">
+                      {plan.name} explained
+                      <HugeiconsIcon
+                        icon={ArrowRight01Icon}
+                        className="size-4 transition-transform group-hover:translate-x-0.5"
+                      />
+                    </div>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Which plan am I on?
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            <p>
+              You cannot choose your plan &mdash; it is set by when and where
+              you started studying. English students who began before September
+              2012 are on Plan 1; those who started between 2012 and 2023 are on
+              Plan 2; and those from September 2023 are on Plan 5. Scottish
+              students are on Plan 4, and Northern Irish students are on Plan 1.
+              A Postgraduate Loan sits on top of any of these.
+            </p>
+            <p>
+              Not sure?{" "}
+              <Link href="/which-plan" className={LINK_CLASS}>
+                Take the 3-question which plan quiz
+              </Link>{" "}
+              to find out in under a minute.
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
+          <Heading as="h2" size="subsection">
+            Why middle earners repay the most
+          </Heading>
+          <p className="text-muted-foreground">
+            Whichever plan you are on, the total you repay follows the same
+            shape. Low earners repay little and reach the write-off with a
+            balance forgiven. High earners clear the loan quickly, before much
+            interest builds. It is the middle &mdash; graduates earning enough
+            to make real repayments, but not enough to outrun the interest
+            &mdash; who repay the most, often far more than they borrowed.
+          </p>
+          <p className="text-muted-foreground">
+            That is the whole reason this site exists. Put your salary into the{" "}
+            <Link href="/" className={LINK_CLASS}>
+              student loan repayment calculator
+            </Link>{" "}
+            to see where you fall on the curve for your plan.
+          </p>
+        </section>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Work out your repayments
+          </Heading>
+          <PlanCtaCards />
+        </section>
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/app/plans/plan-1/layout.tsx
+++ b/src/app/plans/plan-1/layout.tsx
@@ -1,0 +1,33 @@
+import {
+  buildPlanMetadata,
+  planBreadcrumbSchema,
+  planFaqSchema,
+} from "@/lib/planContent";
+
+export const metadata = buildPlanMetadata("PLAN_1");
+
+// Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
+// Google reads JSON-LD from anywhere in the document, so this is equivalent.
+export default function Plan1Layout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(planBreadcrumbSchema("PLAN_1")),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(planFaqSchema("PLAN_1")),
+        }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/plans/plan-1/page.tsx
+++ b/src/app/plans/plan-1/page.tsx
@@ -1,0 +1,5 @@
+import { PlanDetailPage } from "@/components/plans/PlanDetailPage";
+
+export default function Plan1Page() {
+  return <PlanDetailPage planKey="PLAN_1" />;
+}

--- a/src/app/plans/plan-2/layout.tsx
+++ b/src/app/plans/plan-2/layout.tsx
@@ -1,0 +1,33 @@
+import {
+  buildPlanMetadata,
+  planBreadcrumbSchema,
+  planFaqSchema,
+} from "@/lib/planContent";
+
+export const metadata = buildPlanMetadata("PLAN_2");
+
+// Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
+// Google reads JSON-LD from anywhere in the document, so this is equivalent.
+export default function Plan2Layout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(planBreadcrumbSchema("PLAN_2")),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(planFaqSchema("PLAN_2")),
+        }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/plans/plan-2/page.tsx
+++ b/src/app/plans/plan-2/page.tsx
@@ -1,0 +1,5 @@
+import { PlanDetailPage } from "@/components/plans/PlanDetailPage";
+
+export default function Plan2Page() {
+  return <PlanDetailPage planKey="PLAN_2" />;
+}

--- a/src/app/plans/plan-4/layout.tsx
+++ b/src/app/plans/plan-4/layout.tsx
@@ -1,0 +1,33 @@
+import {
+  buildPlanMetadata,
+  planBreadcrumbSchema,
+  planFaqSchema,
+} from "@/lib/planContent";
+
+export const metadata = buildPlanMetadata("PLAN_4");
+
+// Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
+// Google reads JSON-LD from anywhere in the document, so this is equivalent.
+export default function Plan4Layout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(planBreadcrumbSchema("PLAN_4")),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(planFaqSchema("PLAN_4")),
+        }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/plans/plan-4/page.tsx
+++ b/src/app/plans/plan-4/page.tsx
@@ -1,0 +1,5 @@
+import { PlanDetailPage } from "@/components/plans/PlanDetailPage";
+
+export default function Plan4Page() {
+  return <PlanDetailPage planKey="PLAN_4" />;
+}

--- a/src/app/plans/plan-5/layout.tsx
+++ b/src/app/plans/plan-5/layout.tsx
@@ -1,0 +1,33 @@
+import {
+  buildPlanMetadata,
+  planBreadcrumbSchema,
+  planFaqSchema,
+} from "@/lib/planContent";
+
+export const metadata = buildPlanMetadata("PLAN_5");
+
+// Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
+// Google reads JSON-LD from anywhere in the document, so this is equivalent.
+export default function Plan5Layout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(planBreadcrumbSchema("PLAN_5")),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(planFaqSchema("PLAN_5")),
+        }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/plans/plan-5/page.tsx
+++ b/src/app/plans/plan-5/page.tsx
@@ -1,0 +1,5 @@
+import { PlanDetailPage } from "@/components/plans/PlanDetailPage";
+
+export default function Plan5Page() {
+  return <PlanDetailPage planKey="PLAN_5" />;
+}

--- a/src/app/plans/postgraduate/layout.tsx
+++ b/src/app/plans/postgraduate/layout.tsx
@@ -1,0 +1,33 @@
+import {
+  buildPlanMetadata,
+  planBreadcrumbSchema,
+  planFaqSchema,
+} from "@/lib/planContent";
+
+export const metadata = buildPlanMetadata("POSTGRADUATE");
+
+// Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).
+// Google reads JSON-LD from anywhere in the document, so this is equivalent.
+export default function PostgraduateLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(planBreadcrumbSchema("POSTGRADUATE")),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(planFaqSchema("POSTGRADUATE")),
+        }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/plans/postgraduate/page.tsx
+++ b/src/app/plans/postgraduate/page.tsx
@@ -1,0 +1,5 @@
+import { PlanDetailPage } from "@/components/plans/PlanDetailPage";
+
+export default function PostgraduatePage() {
+  return <PlanDetailPage planKey="POSTGRADUATE" />;
+}

--- a/src/app/sitemap.xml
+++ b/src/app/sitemap.xml
@@ -8,6 +8,30 @@
     <loc>https://studentloanstudy.uk/which-plan</loc>
   </url>
   <url>
+    <loc>https://studentloanstudy.uk/plans</loc>
+    <lastmod>2026-07-10</lastmod>
+  </url>
+  <url>
+    <loc>https://studentloanstudy.uk/plans/plan-1</loc>
+    <lastmod>2026-07-10</lastmod>
+  </url>
+  <url>
+    <loc>https://studentloanstudy.uk/plans/plan-2</loc>
+    <lastmod>2026-07-10</lastmod>
+  </url>
+  <url>
+    <loc>https://studentloanstudy.uk/plans/plan-4</loc>
+    <lastmod>2026-07-10</lastmod>
+  </url>
+  <url>
+    <loc>https://studentloanstudy.uk/plans/plan-5</loc>
+    <lastmod>2026-07-10</lastmod>
+  </url>
+  <url>
+    <loc>https://studentloanstudy.uk/plans/postgraduate</loc>
+    <lastmod>2026-07-10</lastmod>
+  </url>
+  <url>
     <loc>https://studentloanstudy.uk/overpay</loc>
     <lastmod>2026-02-28</lastmod>
   </url>

--- a/src/app/which-plan/page.tsx
+++ b/src/app/which-plan/page.tsx
@@ -1,3 +1,6 @@
+import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
 import { Footer } from "@/components/layout/Footer";
 import { QuizContainer } from "@/components/quiz/QuizContainer";
 import { Heading } from "@/components/typography/Heading";
@@ -6,11 +9,15 @@ import {
   PLAN_DISPLAY_INFO,
   POSTGRADUATE_DISPLAY_INFO,
 } from "@/lib/loans/plans";
+import { PLAN_PAGE_ORDER, PLAN_PAGES } from "@/lib/planContent";
 
-const ALL_PLANS = [
-  ...Object.values(PLAN_DISPLAY_INFO),
-  POSTGRADUATE_DISPLAY_INFO,
-];
+const DISPLAY_BY_KEY = {
+  PLAN_1: PLAN_DISPLAY_INFO.PLAN_1,
+  PLAN_2: PLAN_DISPLAY_INFO.PLAN_2,
+  PLAN_4: PLAN_DISPLAY_INFO.PLAN_4,
+  PLAN_5: PLAN_DISPLAY_INFO.PLAN_5,
+  POSTGRADUATE: POSTGRADUATE_DISPLAY_INFO,
+} as const;
 
 export default function WhichPlanPage() {
   return (
@@ -26,37 +33,64 @@ export default function WhichPlanPage() {
               <p className="mt-2 text-muted-foreground">
                 A quick reference for every UK student loan plan type —
                 thresholds, repayment rates, and write-off periods at a glance.
+                Tap any plan for the full breakdown.
               </p>
             </div>
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {ALL_PLANS.map((plan) => (
-                <div key={plan.name} className="rounded-xl border bg-card p-5">
-                  <h3 className="font-semibold">{plan.name}</h3>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    {plan.description}
-                  </p>
-                  <dl className="mt-4 space-y-2 text-sm">
-                    <div className="flex items-baseline justify-between gap-2">
-                      <dt className="text-muted-foreground">Threshold</dt>
-                      <dd className="font-mono font-semibold tabular-nums">
-                        {currencyFormatter.format(plan.yearlyThreshold)}/yr
-                      </dd>
+              {PLAN_PAGE_ORDER.map((key) => {
+                const plan = DISPLAY_BY_KEY[key];
+                const slug = PLAN_PAGES[key].slug;
+                return (
+                  <Link
+                    key={key}
+                    href={`/plans/${slug}`}
+                    className="group block h-full"
+                  >
+                    <div className="flex h-full flex-col rounded-xl border bg-card p-5 transition-all duration-200 hover:bg-accent hover:ring-1 hover:ring-primary/30">
+                      <h3 className="font-semibold">{plan.name}</h3>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        {plan.description}
+                      </p>
+                      <dl className="mt-4 space-y-2 text-sm">
+                        <div className="flex items-baseline justify-between gap-2">
+                          <dt className="text-muted-foreground">Threshold</dt>
+                          <dd className="font-mono font-semibold tabular-nums">
+                            {currencyFormatter.format(plan.yearlyThreshold)}/yr
+                          </dd>
+                        </div>
+                        <div className="flex items-baseline justify-between gap-2">
+                          <dt className="text-muted-foreground">Rate</dt>
+                          <dd className="font-mono font-semibold tabular-nums">
+                            {String(plan.repaymentRate * 100)}%
+                          </dd>
+                        </div>
+                        <div className="flex items-baseline justify-between gap-2">
+                          <dt className="text-muted-foreground">Write-off</dt>
+                          <dd className="font-mono font-semibold tabular-nums">
+                            {String(plan.writeOffYears)} years
+                          </dd>
+                        </div>
+                      </dl>
+                      <div className="mt-4 flex items-center gap-1 text-sm font-medium text-primary">
+                        {plan.name} explained
+                        <HugeiconsIcon
+                          icon={ArrowRight01Icon}
+                          className="size-4 transition-transform group-hover:translate-x-0.5"
+                        />
+                      </div>
                     </div>
-                    <div className="flex items-baseline justify-between gap-2">
-                      <dt className="text-muted-foreground">Rate</dt>
-                      <dd className="font-mono font-semibold tabular-nums">
-                        {String(plan.repaymentRate * 100)}%
-                      </dd>
-                    </div>
-                    <div className="flex items-baseline justify-between gap-2">
-                      <dt className="text-muted-foreground">Write-off</dt>
-                      <dd className="font-mono font-semibold tabular-nums">
-                        {String(plan.writeOffYears)} years
-                      </dd>
-                    </div>
-                  </dl>
-                </div>
-              ))}
+                  </Link>
+                );
+              })}
+            </div>
+            <div className="mt-8 text-center">
+              <Link
+                href="/plans"
+                className="inline-flex items-center gap-1 text-sm font-medium text-primary underline underline-offset-4 hover:text-primary/80"
+              >
+                Compare all UK student loan plans
+                <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
+              </Link>
             </div>
           </div>
         </section>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -32,6 +32,11 @@ export function Footer() {
                   Which Plan Quiz
                 </Link>
               </li>
+              <li>
+                <Link href="/plans" className={NAV_LINK_CLASS}>
+                  Loan Plans Explained
+                </Link>
+              </li>
             </ul>
           </div>
           <div className="space-y-3">

--- a/src/components/plans/AllPlansTable.tsx
+++ b/src/components/plans/AllPlansTable.tsx
@@ -1,0 +1,101 @@
+import Link from "next/link";
+import { currencyFormatter } from "@/constants";
+import { formatPercent } from "@/lib/format";
+import type { PlanPageKey } from "@/lib/planContent";
+import { PLAN_PAGE_ORDER, PLAN_PAGES } from "@/lib/planContent";
+import { cn } from "@/lib/utils";
+
+interface AllPlansTableProps {
+  /** Plan whose row should be visually emphasised (its own page). */
+  highlight?: PlanPageKey;
+}
+
+/**
+ * At-a-glance comparison of every UK student loan plan. All figures are derived
+ * from src/lib/loans/plans.ts via the plan content module, so they stay in sync
+ * with the daily GOV.UK automation. Reused on the /plans hub and each plan page.
+ */
+export function AllPlansTable({ highlight }: AllPlansTableProps) {
+  return (
+    <div className="overflow-x-auto rounded-xl border">
+      <table className="w-full border-collapse text-sm">
+        <caption className="sr-only">
+          Comparison of UK student loan plans: repayment threshold, rate,
+          interest and write-off period.
+        </caption>
+        <thead>
+          <tr className="border-b bg-muted/50 text-left">
+            <th scope="col" className="px-4 py-3 font-semibold">
+              Plan
+            </th>
+            <th scope="col" className="px-4 py-3 font-semibold">
+              Who &amp; when
+            </th>
+            <th scope="col" className="px-4 py-3 text-right font-semibold">
+              Threshold
+            </th>
+            <th scope="col" className="px-4 py-3 text-right font-semibold">
+              Rate
+            </th>
+            <th scope="col" className="px-4 py-3 font-semibold">
+              Interest
+            </th>
+            <th scope="col" className="px-4 py-3 text-right font-semibold">
+              Write-off
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {PLAN_PAGE_ORDER.map((key) => {
+            const plan = PLAN_PAGES[key];
+            const isActive = key === highlight;
+            return (
+              <tr
+                key={key}
+                className={cn(
+                  "border-b last:border-b-0",
+                  isActive && "bg-primary/5",
+                )}
+              >
+                <th
+                  scope="row"
+                  className="px-4 py-3 text-left align-top font-medium whitespace-nowrap"
+                >
+                  {isActive ? (
+                    <span className="text-primary">{plan.name}</span>
+                  ) : (
+                    <Link
+                      href={`/plans/${plan.slug}`}
+                      className="text-primary underline underline-offset-4 hover:text-primary/80"
+                    >
+                      {plan.name}
+                    </Link>
+                  )}
+                </th>
+                <td className="px-4 py-3 align-top text-muted-foreground">
+                  <span className="block">{plan.region}</span>
+                  <span className="block text-xs">{plan.years}</span>
+                </td>
+                <td className="px-4 py-3 text-right align-top font-mono tabular-nums">
+                  {currencyFormatter.format(plan.yearlyThreshold)}
+                </td>
+                <td className="px-4 py-3 text-right align-top font-mono tabular-nums">
+                  {formatPercent(plan.repaymentRate * 100)}
+                </td>
+                <td className="px-4 py-3 align-top text-muted-foreground">
+                  <span className="block">{plan.interestShort}</span>
+                  <span className="block text-xs">
+                    {plan.interestCurrent} now
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-right align-top font-mono whitespace-nowrap tabular-nums">
+                  {String(plan.writeOffYears)} yrs
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/plans/PlanCtaCards.tsx
+++ b/src/components/plans/PlanCtaCards.tsx
@@ -1,0 +1,64 @@
+import {
+  AnalyticsUpIcon,
+  ArrowRight01Icon,
+  Calculator01Icon,
+  Quiz01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
+
+interface CtaCard {
+  href: string;
+  title: string;
+  description: string;
+  icon: typeof Calculator01Icon;
+}
+
+const CARDS: CtaCard[] = [
+  {
+    href: "/",
+    title: "Student Loan Repayment Calculator",
+    description: "See exactly how much you'll repay in total at your salary.",
+    icon: Calculator01Icon,
+  },
+  {
+    href: "/which-plan",
+    title: "Which Plan Am I On?",
+    description: "Answer 3 quick questions to confirm your plan type.",
+    icon: Quiz01Icon,
+  },
+  {
+    href: "/overpay",
+    title: "Overpay Calculator",
+    description: "Should you pay your loan off faster or invest instead?",
+    icon: AnalyticsUpIcon,
+  },
+];
+
+/** Prominent links to the core tools, shown at the foot of each plan page. */
+export function PlanCtaCards() {
+  return (
+    <div className="grid gap-3 sm:grid-cols-3">
+      {CARDS.map((card) => (
+        <Link key={card.href} href={card.href} className="group block h-full">
+          <div className="flex h-full flex-col rounded-xl bg-card p-4 ring-1 ring-foreground/10 transition-all duration-200 hover:bg-accent hover:ring-primary/30">
+            <div className="mb-3 flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
+              <HugeiconsIcon icon={card.icon} className="size-5" />
+            </div>
+            <h3 className="text-sm font-medium">{card.title}</h3>
+            <p className="mt-1 mb-3 flex-1 text-xs text-muted-foreground">
+              {card.description}
+            </p>
+            <div className="flex items-center gap-1 text-xs font-medium text-primary">
+              Open
+              <HugeiconsIcon
+                icon={ArrowRight01Icon}
+                className="size-3.5 transition-transform group-hover:translate-x-0.5"
+              />
+            </div>
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/src/components/plans/PlanDetailPage.tsx
+++ b/src/components/plans/PlanDetailPage.tsx
@@ -1,0 +1,228 @@
+import Link from "next/link";
+import { PageLayout } from "@/components/layout/PageLayout";
+import { Heading } from "@/components/typography/Heading";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { currencyFormatter } from "@/constants";
+import { formatGBP, formatPercent } from "@/lib/format";
+import type { PlanPageKey } from "@/lib/planContent";
+import { PLAN_PAGES } from "@/lib/planContent";
+import { AllPlansTable } from "./AllPlansTable";
+import { PlanCtaCards } from "./PlanCtaCards";
+
+interface StatItem {
+  label: string;
+  value: string;
+  sub?: string;
+}
+
+interface PlanDetailPageProps {
+  planKey: PlanPageKey;
+}
+
+const LINK_CLASS =
+  "text-primary underline underline-offset-4 hover:text-primary/80";
+
+export function PlanDetailPage({ planKey }: PlanDetailPageProps) {
+  const plan = PLAN_PAGES[planKey];
+
+  const stats: StatItem[] = [
+    { label: "Who", value: plan.region, sub: plan.years },
+    {
+      label: "Repayment threshold",
+      value: `${currencyFormatter.format(plan.yearlyThreshold)}/yr`,
+      sub: `${formatGBP(plan.monthlyThreshold)}/mo`,
+    },
+    {
+      label: "Repayment rate",
+      value: formatPercent(plan.repaymentRate * 100),
+      sub: "of income above threshold",
+    },
+    {
+      label: "Interest",
+      value: plan.interestShort,
+      sub: `${plan.interestCurrent} now`,
+    },
+    {
+      label: "Written off after",
+      value: `${String(plan.writeOffYears)} years`,
+    },
+  ];
+
+  return (
+    <PageLayout>
+      <article className="space-y-8">
+        <div className="space-y-4">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/plans" />}>
+                  Loan Plans
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>{plan.name}</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+
+          <div className="space-y-2">
+            <Heading as="h1">What Is a {plan.name} Student Loan?</Heading>
+            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+              {plan.heroIntro}
+            </p>
+          </div>
+        </div>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            {plan.name} at a Glance
+          </Heading>
+          <dl className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {stats.map((stat) => (
+              <div key={stat.label} className="rounded-xl border bg-card p-4">
+                <dt className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                  {stat.label}
+                </dt>
+                <dd className="mt-1 font-semibold">{stat.value}</dd>
+                {stat.sub && (
+                  <dd className="text-sm text-muted-foreground">{stat.sub}</dd>
+                )}
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            What {plan.name} means
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            {plan.whatItIs.map((para) => (
+              <p key={para}>{para}</p>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Who is on {plan.name}?
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            {plan.whoItIsFor.map((para) => (
+              <p key={para}>{para}</p>
+            ))}
+            <p>
+              Not sure this is you?{" "}
+              <Link href="/which-plan" className={LINK_CLASS}>
+                Take the 3-question which plan quiz
+              </Link>{" "}
+              to confirm.
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            {plan.name} interest rate
+          </Heading>
+          <div className="space-y-2 text-muted-foreground">
+            {plan.interestParagraphs.map((para) => (
+              <p key={para}>{para}</p>
+            ))}
+            {planKey === "PLAN_2" && (
+              <p>
+                From September 2026 the government is capping Plan 2 interest at
+                6% &mdash; see our{" "}
+                <Link href="/guides/interest-rate-cap" className={LINK_CLASS}>
+                  Plan 2 interest rate cap guide
+                </Link>{" "}
+                for what changes.
+              </p>
+            )}
+            <p>
+              For a full walkthrough of how student loan interest compounds,
+              read{" "}
+              <Link href="/guides/how-interest-works" className={LINK_CLASS}>
+                how student loan interest works
+              </Link>
+              .
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            How {plan.name} compares to other plans
+          </Heading>
+          <p className="text-muted-foreground">{plan.compareParagraph}</p>
+          <AllPlansTable highlight={planKey} />
+          <p className="text-sm text-muted-foreground">
+            See the full breakdown on the{" "}
+            <Link href="/plans" className={LINK_CLASS}>
+              UK student loan plans hub
+            </Link>
+            {planKey === "PLAN_2" || planKey === "PLAN_5" ? (
+              <>
+                {" "}
+                or read the in-depth{" "}
+                <Link href="/guides/plan-2-vs-plan-5" className={LINK_CLASS}>
+                  Plan 2 vs Plan 5 comparison
+                </Link>
+              </>
+            ) : null}
+            .
+          </p>
+        </section>
+
+        <section className="space-y-3 rounded-lg border bg-muted/30 p-4 sm:p-6">
+          <Heading as="h2" size="subsection">
+            Why middle earners feel {plan.name} the most
+          </Heading>
+          <p className="text-muted-foreground">{plan.middleEarner}</p>
+          <p className="text-muted-foreground">
+            Middle earners repay the most across every UK plan &mdash; enough to
+            make real repayments, but not enough to clear the balance before
+            interest bites. Put your own salary into the{" "}
+            <Link href="/" className={LINK_CLASS}>
+              student loan repayment calculator
+            </Link>{" "}
+            to see exactly where you fall.
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            {plan.name} FAQs
+          </Heading>
+          <dl className="space-y-4">
+            {plan.faqs.map((faq) => (
+              <div key={faq.question} className="space-y-1">
+                <dt className="font-medium">{faq.question}</dt>
+                <dd className="text-muted-foreground">{faq.answer}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Work out your {plan.name} repayments
+          </Heading>
+          <PlanCtaCards />
+        </section>
+      </article>
+    </PageLayout>
+  );
+}

--- a/src/lib/planContent.ts
+++ b/src/lib/planContent.ts
@@ -1,0 +1,459 @@
+import type { Metadata } from "next";
+import { formatGBP, formatPercent } from "@/lib/format";
+import {
+  CURRENT_RATES,
+  PLAN_CONFIGS,
+  PLAN_DISPLAY_INFO,
+  POSTGRADUATE_DISPLAY_INFO,
+} from "@/lib/loans/plans";
+
+/**
+ * Content for the dedicated per-plan SEO pages under /plans.
+ *
+ * Every monetary figure, rate, and write-off period is DERIVED from
+ * src/lib/loans/plans.ts (which the daily GOV.UK automation regenerates).
+ * Never hardcode thresholds, rates, or interest figures here.
+ */
+
+export type PlanPageKey =
+  "PLAN_1" | "PLAN_2" | "PLAN_4" | "PLAN_5" | "POSTGRADUATE";
+
+export interface PlanFaq {
+  question: string;
+  answer: string;
+}
+
+export interface PlanPageContent {
+  key: PlanPageKey;
+  slug: string;
+  /** Full display name, e.g. "Plan 1" or "Postgraduate Loan". */
+  name: string;
+  /** Short label used in tables/badges, e.g. "Plan 1" or "Postgraduate". */
+  shortName: string;
+  region: string;
+  years: string;
+  monthlyThreshold: number;
+  yearlyThreshold: number;
+  repaymentRate: number;
+  writeOffYears: number;
+  /** One-line description of how interest is charged. */
+  interestShort: string;
+  /** The interest rate that applies right now, e.g. "3.2%". */
+  interestCurrent: string;
+  metaTitle: string;
+  metaDescription: string;
+  keywords: string[];
+  heroIntro: string;
+  whatItIs: string[];
+  whoItIsFor: string[];
+  interestParagraphs: string[];
+  compareParagraph: string;
+  middleEarner: string;
+  faqs: PlanFaq[];
+}
+
+/** Fixed left-to-right order for the hub grid, comparison table, and cards. */
+export const PLAN_PAGE_ORDER: PlanPageKey[] = [
+  "PLAN_1",
+  "PLAN_2",
+  "PLAN_4",
+  "PLAN_5",
+  "POSTGRADUATE",
+];
+
+const SITE_URL = "https://studentloanstudy.uk";
+
+/** Builds Next.js route metadata for a per-plan page from its content. */
+export function buildPlanMetadata(key: PlanPageKey): Metadata {
+  const plan = PLAN_PAGES[key];
+  const url = `${SITE_URL}/plans/${plan.slug}`;
+  return {
+    title: plan.metaTitle,
+    description: plan.metaDescription,
+    keywords: plan.keywords,
+    alternates: { canonical: `/plans/${plan.slug}` },
+    openGraph: {
+      title: plan.metaTitle,
+      description: plan.metaDescription,
+      url,
+      type: "article",
+    },
+  };
+}
+
+/** BreadcrumbList JSON-LD (Home › Loan Plans › <Plan>) for a per-plan page. */
+export function planBreadcrumbSchema(key: PlanPageKey) {
+  const plan = PLAN_PAGES[key];
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: SITE_URL },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Loan Plans",
+        item: `${SITE_URL}/plans`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: `${plan.name} student loan`,
+        item: `${SITE_URL}/plans/${plan.slug}`,
+      },
+    ],
+  };
+}
+
+/** FAQPage JSON-LD built from a plan's on-page FAQs. */
+export function planFaqSchema(key: PlanPageKey) {
+  const plan = PLAN_PAGES[key];
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: plan.faqs.map((faq) => ({
+      "@type": "Question",
+      name: faq.question,
+      acceptedAnswer: { "@type": "Answer", text: faq.answer },
+    })),
+  };
+}
+
+const { rpi, boeBaseRate } = CURRENT_RATES;
+
+// Current effective rates derived from the live figures in plans.ts.
+const cappedRate = Math.min(rpi, boeBaseRate + 1); // Plan 1 & Plan 4
+const plan2LowRate = rpi;
+const plan2HighRate = rpi + 3;
+const postgradRate = rpi + 3;
+
+const plan2InterestLower = PLAN_CONFIGS.PLAN_2.interestLowerThreshold;
+const plan2InterestUpper = PLAN_CONFIGS.PLAN_2.interestUpperThreshold;
+
+const rpiPct = formatPercent(rpi);
+const basePlusOnePct = formatPercent(boeBaseRate + 1);
+const cappedPct = formatPercent(cappedRate);
+const plan2LowPct = formatPercent(plan2LowRate);
+const plan2HighPct = formatPercent(plan2HighRate);
+const postgradPct = formatPercent(postgradRate);
+
+const p1 = PLAN_DISPLAY_INFO.PLAN_1;
+const p2 = PLAN_DISPLAY_INFO.PLAN_2;
+const p4 = PLAN_DISPLAY_INFO.PLAN_4;
+const p5 = PLAN_DISPLAY_INFO.PLAN_5;
+const pg = POSTGRADUATE_DISPLAY_INFO;
+
+const p1MonthlyGBP = formatGBP(PLAN_CONFIGS.PLAN_1.monthlyThreshold);
+const p2MonthlyGBP = formatGBP(PLAN_CONFIGS.PLAN_2.monthlyThreshold);
+const p4MonthlyGBP = formatGBP(PLAN_CONFIGS.PLAN_4.monthlyThreshold);
+const p5MonthlyGBP = formatGBP(PLAN_CONFIGS.PLAN_5.monthlyThreshold);
+const pgMonthlyGBP = formatGBP(PLAN_CONFIGS.POSTGRADUATE.monthlyThreshold);
+
+const p1YearGBP = formatGBP(p1.yearlyThreshold);
+const p2YearGBP = formatGBP(p2.yearlyThreshold);
+const p4YearGBP = formatGBP(p4.yearlyThreshold);
+const p5YearGBP = formatGBP(p5.yearlyThreshold);
+const pgYearGBP = formatGBP(pg.yearlyThreshold);
+
+const p1Rate = formatPercent(p1.repaymentRate * 100);
+const pgRatePct = formatPercent(pg.repaymentRate * 100);
+
+const p1WriteOff = String(p1.writeOffYears);
+const p2WriteOff = String(p2.writeOffYears);
+const p4WriteOff = String(p4.writeOffYears);
+const p5WriteOff = String(p5.writeOffYears);
+const pgWriteOff = String(pg.writeOffYears);
+
+export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
+  PLAN_1: {
+    key: "PLAN_1",
+    slug: "plan-1",
+    name: "Plan 1",
+    shortName: "Plan 1",
+    region: p1.region,
+    years: p1.years,
+    monthlyThreshold: PLAN_CONFIGS.PLAN_1.monthlyThreshold,
+    yearlyThreshold: p1.yearlyThreshold,
+    repaymentRate: p1.repaymentRate,
+    writeOffYears: p1.writeOffYears,
+    interestShort: "Lower of RPI or base rate + 1%",
+    interestCurrent: cappedPct,
+    metaTitle:
+      "What Is a Plan 1 Student Loan? Threshold, Interest & Write-Off (2026)",
+    metaDescription: `Plan 1 student loans: ${p1YearGBP} repayment threshold, ${p1Rate} rate, capped interest (${cappedPct} now) and a ${p1WriteOff}-year write-off. Who's on Plan 1 and how it compares.`,
+    keywords: [
+      "what is plan 1 student loan",
+      "plan 1 student loan",
+      "plan 1 student loan threshold",
+      "plan 1 student loan interest rate",
+      "plan 1 repayment threshold",
+      "plan 1 write off",
+    ],
+    heroIntro: `Plan 1 is the oldest UK student loan type still being repaid. It covers English and Welsh students who started before September 2012, and every Northern Irish student regardless of start year. You repay ${p1Rate} of everything you earn above ${p1YearGBP} a year, and any balance left after ${p1WriteOff} years is written off.`,
+    whatItIs: [
+      `A Plan 1 student loan is repaid at ${p1Rate} of your income above the ${p1YearGBP}-a-year (${p1MonthlyGBP} a month) repayment threshold. It has the lowest interest of any plan because the rate is capped at the lower of RPI or the Bank of England base rate plus 1%.`,
+      `Because Plan 1 is the oldest plan, many borrowers are now well into their ${p1WriteOff}-year term. Any remaining balance is cancelled once that write-off period is reached, with nothing left to pay.`,
+    ],
+    whoItIsFor: [
+      "You are on Plan 1 if you are an English or Welsh student who started an undergraduate course before September 2012.",
+      "You are also on Plan 1 if you are a Northern Irish student, whenever you started — Northern Ireland kept Plan 1 rather than moving to Plan 2 or Plan 5.",
+    ],
+    interestParagraphs: [
+      `Plan 1 interest is charged at the lower of RPI (${rpiPct}) or the Bank of England base rate plus 1% (${basePlusOnePct}). Right now that works out at ${cappedPct}.`,
+      `This cap keeps Plan 1 interest low and predictable — it never runs away the way a purely inflation-linked rate can, which makes Plan 1 the cheapest plan to carry pound for pound.`,
+    ],
+    compareParagraph: `Plan 1 has a lower threshold than Plan 2 (${p2YearGBP}) or Plan 4 (${p4YearGBP}), so you start repaying earlier, but its capped interest and shorter ${p1WriteOff}-year write-off make it far cheaper over a lifetime than the newer ${p5WriteOff}-year Plan 5.`,
+    middleEarner: `Plan 1's low, capped interest means the balance rarely balloons, so the middle-earner trap that hits Plan 2 and Plan 5 borrowers is much weaker here. The people most likely to clear a Plan 1 loan in full are steady middle earners — low earners often reach the ${p1WriteOff}-year write-off first, while high earners clear it quickly. Model your own salary to see where you land.`,
+    faqs: [
+      {
+        question: "What is a Plan 1 student loan?",
+        answer: `Plan 1 is a UK undergraduate loan for English and Welsh students who started before September 2012, and for all Northern Irish students. You repay ${p1Rate} of income above ${p1YearGBP} a year, interest is capped at the lower of RPI or base rate + 1% (currently ${cappedPct}), and any balance is written off after ${p1WriteOff} years.`,
+      },
+      {
+        question: "What is the Plan 1 repayment threshold?",
+        answer: `The Plan 1 threshold is ${p1YearGBP} a year (${p1MonthlyGBP} a month). You repay ${p1Rate} of everything you earn above it, so on Plan 1 someone earning below ${p1YearGBP} makes no repayments at all.`,
+      },
+      {
+        question: "What is the Plan 1 interest rate?",
+        answer: `Plan 1 interest is the lower of RPI (${rpiPct}) or the Bank of England base rate plus 1% (${basePlusOnePct}), which currently means ${cappedPct}. It is the lowest interest rate of any UK student loan plan.`,
+      },
+      {
+        question: "When is a Plan 1 loan written off?",
+        answer: `A Plan 1 loan is written off ${p1WriteOff} years after the April you were first due to repay. Anything still outstanding at that point is cancelled and you stop paying.`,
+      },
+    ],
+  },
+  PLAN_2: {
+    key: "PLAN_2",
+    slug: "plan-2",
+    name: "Plan 2",
+    shortName: "Plan 2",
+    region: p2.region,
+    years: p2.years,
+    monthlyThreshold: PLAN_CONFIGS.PLAN_2.monthlyThreshold,
+    yearlyThreshold: p2.yearlyThreshold,
+    repaymentRate: p2.repaymentRate,
+    writeOffYears: p2.writeOffYears,
+    interestShort: "RPI to RPI + 3% (income-based)",
+    interestCurrent: `${plan2LowPct}–${plan2HighPct}`,
+    metaTitle:
+      "What Is a Plan 2 Student Loan? Threshold, Interest & Write-Off (2026)",
+    metaDescription: `Plan 2 student loans: ${p2YearGBP} threshold, ${p1Rate} rate, income-based interest from ${plan2LowPct} to ${plan2HighPct}, and a ${p2WriteOff}-year write-off. Why middle earners repay the most.`,
+    keywords: [
+      "what is plan 2 student loan",
+      "plan 2 student loan",
+      "plan 2 student loan threshold",
+      "plan 2 student loan interest rate",
+      "plan 2 repayment threshold",
+      "plan 2 write off",
+    ],
+    heroIntro: `Plan 2 covers English and Welsh students who started university between September 2012 and July 2023 — the £9,000-plus tuition fee generation. You repay ${p1Rate} of income above ${p2YearGBP} a year, and interest runs on a sliding scale up to RPI + 3%, which is exactly why Plan 2 middle earners so often repay more than anyone else.`,
+    whatItIs: [
+      `A Plan 2 student loan is repaid at ${p1Rate} of your income above ${p2YearGBP} a year (${p2MonthlyGBP} a month). Unlike Plan 1, interest is income-based: it climbs from RPI up to RPI + 3% as your salary rises.`,
+      `Any balance still outstanding ${p2WriteOff} years after you were first due to repay is written off. But because of the high interest, most Plan 2 borrowers never reach a zero balance through minimum repayments alone.`,
+    ],
+    whoItIsFor: [
+      "You are on Plan 2 if you are an English or Welsh student who started an undergraduate course between 1 September 2012 and 31 July 2023.",
+      "English students who started from September 2023 onwards are on Plan 5 instead. Welsh students who started after August 2023 stay on Plan 2, because Plan 5 is England-only.",
+    ],
+    interestParagraphs: [
+      `Plan 2 interest is charged on a sliding scale. While you are studying, and on income up to ${p2YearGBP}, you pay RPI (${rpiPct}). Between ${formatGBP(plan2InterestLower)} and ${formatGBP(plan2InterestUpper)} the rate rises linearly, reaching RPI + 3% (${plan2HighPct}) once you earn ${formatGBP(plan2InterestUpper)} or more.`,
+      `That RPI + 3% ceiling is the single biggest reason Plan 2 is so expensive: the balance can grow faster than a typical borrower repays it, so the debt keeps compounding for years.`,
+    ],
+    compareParagraph: `Plan 2 has a higher threshold than Plan 1 (${p1YearGBP}) or Plan 5 (${p5YearGBP}), so you repay less each month at the same salary — but its RPI + 3% interest ceiling makes it the most expensive plan for middle earners, more than offsetting the shorter ${p2WriteOff}-year term versus Plan 5's ${p5WriteOff} years.`,
+    middleEarner: `Plan 2 is the clearest example of the middle-earner trap. Low earners repay little and reach the ${p2WriteOff}-year write-off with plenty forgiven; high earners clear the balance fast before much interest builds. It is the middle — graduates earning enough to make real repayments, but not enough to outrun RPI + 3% interest — who repay the most in total, often far more than they originally borrowed.`,
+    faqs: [
+      {
+        question: "What is a Plan 2 student loan?",
+        answer: `Plan 2 is a UK undergraduate loan for English and Welsh students who started between September 2012 and July 2023. You repay ${p1Rate} of income above ${p2YearGBP} a year, interest runs from RPI (${rpiPct}) up to RPI + 3% (${plan2HighPct}) depending on income, and any balance is written off after ${p2WriteOff} years.`,
+      },
+      {
+        question: "What is the Plan 2 repayment threshold?",
+        answer: `The Plan 2 threshold is ${p2YearGBP} a year (${p2MonthlyGBP} a month) — the highest of the England/Wales undergraduate plans. You repay ${p1Rate} of everything above it.`,
+      },
+      {
+        question: "What is the Plan 2 interest rate?",
+        answer: `Plan 2 interest is income-based, from RPI (${rpiPct}) at or below ${formatGBP(plan2InterestLower)} up to RPI + 3% (${plan2HighPct}) at ${formatGBP(plan2InterestUpper)} or more, interpolated in between. A separate cap can lower the headline rate when market rates are low.`,
+      },
+      {
+        question: "Why do Plan 2 middle earners repay the most?",
+        answer: `Because Plan 2 interest reaches RPI + 3%, middle earners repay steadily but not fast enough to stop the balance compounding, and they earn too much for the ${p2WriteOff}-year write-off to help. High earners clear the loan quickly; low earners have it written off — so the middle pays the most in total.`,
+      },
+    ],
+  },
+  PLAN_4: {
+    key: "PLAN_4",
+    slug: "plan-4",
+    name: "Plan 4",
+    shortName: "Plan 4",
+    region: p4.region,
+    years: p4.years,
+    monthlyThreshold: PLAN_CONFIGS.PLAN_4.monthlyThreshold,
+    yearlyThreshold: p4.yearlyThreshold,
+    repaymentRate: p4.repaymentRate,
+    writeOffYears: p4.writeOffYears,
+    interestShort: "Lower of RPI or base rate + 1%",
+    interestCurrent: cappedPct,
+    metaTitle:
+      "What Is a Plan 4 Student Loan? Threshold, Interest & Write-Off (2026)",
+    metaDescription: `Plan 4 is the Scottish student loan: ${p4YearGBP} threshold — the highest of any plan — ${p1Rate} rate, capped interest (${cappedPct} now) and a ${p4WriteOff}-year write-off.`,
+    keywords: [
+      "what is plan 4 student loan",
+      "plan 4 student loan",
+      "scottish student loan",
+      "plan 4 student loan threshold",
+      "plan 4 student loan interest rate",
+      "plan 4 write off",
+    ],
+    heroIntro: `Plan 4 is the loan for Scottish students. It has the highest repayment threshold of any UK plan — ${p4YearGBP} a year — so you keep more of your salary before repayments start. Interest is capped at the lower of RPI or base rate + 1%, and any balance is written off after ${p4WriteOff} years.`,
+    whatItIs: [
+      `A Plan 4 student loan is repaid at ${p1Rate} of income above ${p4YearGBP} a year (${p4MonthlyGBP} a month), the highest threshold of any plan. Interest is capped at the lower of RPI or the Bank of England base rate plus 1%.`,
+      `Plan 4 replaced the old Scottish "Plan 1" arrangement in 2021, but it applies to Scottish students across all start years. Any balance is written off ${p4WriteOff} years after you became due to repay.`,
+    ],
+    whoItIsFor: [
+      "You are on Plan 4 if you took out an undergraduate student loan from the Student Awards Agency Scotland (SAAS) as a Scottish student.",
+      "Plan 4 applies regardless of when you studied — Scotland moved existing Scottish borrowers onto Plan 4 terms, including its higher repayment threshold.",
+    ],
+    interestParagraphs: [
+      `Plan 4 interest is charged at the lower of RPI (${rpiPct}) or the Bank of England base rate plus 1% (${basePlusOnePct}), currently ${cappedPct} — the same low, capped approach as Plan 1.`,
+      `Combined with the highest threshold of any plan, this makes Plan 4 one of the gentler loans to repay: you start later and the balance grows slowly.`,
+    ],
+    compareParagraph: `Plan 4's ${p4YearGBP} threshold is higher than Plan 1 (${p1YearGBP}), Plan 2 (${p2YearGBP}) or Plan 5 (${p5YearGBP}), so at the same salary you repay the least each month. Its capped interest also keeps it far cheaper over time than Plan 5's ${p5WriteOff}-year RPI-linked loan.`,
+    middleEarner: `Because Plan 4 pairs the highest threshold with capped interest, the middle-earner squeeze is milder than on Plan 2 or Plan 5. Still, borrowers who earn steadily above ${p4YearGBP} for decades can repay a large share of their loan, while lower earners reach the ${p4WriteOff}-year write-off first. See where your salary falls.`,
+    faqs: [
+      {
+        question: "What is a Plan 4 student loan?",
+        answer: `Plan 4 is the UK student loan plan for Scottish students. You repay ${p1Rate} of income above ${p4YearGBP} a year — the highest threshold of any plan — interest is capped at the lower of RPI or base rate + 1% (currently ${cappedPct}), and any balance is written off after ${p4WriteOff} years.`,
+      },
+      {
+        question: "What is the Plan 4 repayment threshold?",
+        answer: `The Plan 4 threshold is ${p4YearGBP} a year (${p4MonthlyGBP} a month), the highest of any UK student loan plan. You repay ${p1Rate} of everything you earn above it.`,
+      },
+      {
+        question: "What is the Plan 4 interest rate?",
+        answer: `Plan 4 interest is the lower of RPI (${rpiPct}) or the Bank of England base rate plus 1% (${basePlusOnePct}), currently ${cappedPct} — the same capped rate as Plan 1.`,
+      },
+      {
+        question: "Who is on Plan 4?",
+        answer: `Scottish students who borrowed through the Student Awards Agency Scotland are on Plan 4, across all start years. It replaced the previous Scottish arrangement and carries the highest repayment threshold of any plan.`,
+      },
+    ],
+  },
+  PLAN_5: {
+    key: "PLAN_5",
+    slug: "plan-5",
+    name: "Plan 5",
+    shortName: "Plan 5",
+    region: p5.region,
+    years: p5.years,
+    monthlyThreshold: PLAN_CONFIGS.PLAN_5.monthlyThreshold,
+    yearlyThreshold: p5.yearlyThreshold,
+    repaymentRate: p5.repaymentRate,
+    writeOffYears: p5.writeOffYears,
+    interestShort: "RPI only",
+    interestCurrent: rpiPct,
+    metaTitle:
+      "What Is a Plan 5 Student Loan? Threshold, Interest & Write-Off (2026)",
+    metaDescription: `Plan 5 student loans: ${p5YearGBP} threshold, ${p1Rate} rate, RPI-only interest (${rpiPct} now) and a ${p5WriteOff}-year write-off. Who's on Plan 5 and why the long term costs middle earners.`,
+    keywords: [
+      "what is plan 5 student loan",
+      "plan 5 student loan",
+      "plan 5 student loan threshold",
+      "plan 5 student loan interest rate",
+      "plan 5 repayment threshold",
+      "plan 5 write off",
+    ],
+    heroIntro: `Plan 5 is the newest UK student loan, for English students who started university from September 2023 onwards. It has the lowest threshold of the current undergraduate plans — ${p5YearGBP} a year — the simplest interest (RPI only), but the longest write-off of any plan at ${p5WriteOff} years.`,
+    whatItIs: [
+      `A Plan 5 student loan is repaid at ${p1Rate} of income above ${p5YearGBP} a year (${p5MonthlyGBP} a month). Interest is charged at RPI only — no income-based add-on — which makes the balance easier to predict than Plan 2.`,
+      `The catch is the term: Plan 5 balances are written off ${p5WriteOff} years after you become due to repay, ten years longer than Plan 2 and fifteen longer than Plan 1. That extra decade of repayments is where the real cost hides.`,
+    ],
+    whoItIsFor: [
+      "You are on Plan 5 if you are an English student who started an undergraduate course on or after 1 August 2023.",
+      "Welsh, Scottish and Northern Irish students are not on Plan 5 — Plan 5 is England-only. Students who started before August 2023 remain on Plan 2 (or Plan 1).",
+    ],
+    interestParagraphs: [
+      `Plan 5 interest is charged at RPI only — currently ${rpiPct} — with no income-based addition. That makes it the simplest interest of any plan to understand and forecast.`,
+      `Lower, simpler interest sounds cheaper, but the ${p5WriteOff}-year write-off means most borrowers keep repaying for far longer, so many end up paying more in total than they would have on the shorter Plan 2.`,
+    ],
+    compareParagraph: `Plan 5's ${p5YearGBP} threshold is lower than Plan 2 (${p2YearGBP}), so you start repaying sooner and pay more each month at the same salary. Its RPI-only interest is gentler than Plan 2's RPI + 3%, but the ${p5WriteOff}-year term (versus ${p2WriteOff} for Plan 2) is longer than any other plan.`,
+    middleEarner: `Plan 5's ${p5WriteOff}-year term turns the middle-earner trap into a marathon. Lower earners can pay for four decades and still have a balance written off; high earners clear it early. Middle earners repay steadily for most of their working life — often paying back far more than they borrowed before the write-off ever arrives.`,
+    faqs: [
+      {
+        question: "What is a Plan 5 student loan?",
+        answer: `Plan 5 is the newest UK student loan, for English students who started from September 2023. You repay ${p1Rate} of income above ${p5YearGBP} a year, interest is RPI only (currently ${rpiPct}), and any balance is written off after ${p5WriteOff} years — the longest term of any plan.`,
+      },
+      {
+        question: "What is the Plan 5 repayment threshold?",
+        answer: `The Plan 5 threshold is ${p5YearGBP} a year (${p5MonthlyGBP} a month), the lowest of the current undergraduate plans. You repay ${p1Rate} of everything you earn above it, so repayments start at a lower salary than on Plan 2.`,
+      },
+      {
+        question: "What is the Plan 5 student loan interest rate?",
+        answer: `Plan 5 interest is charged at RPI only, currently ${rpiPct}, with no income-based add-on. That is simpler and lower than Plan 2's RPI + 3% ceiling, but the ${p5WriteOff}-year write-off can make Plan 5 more expensive overall.`,
+      },
+      {
+        question: "When is a Plan 5 loan written off?",
+        answer: `A Plan 5 loan is written off ${p5WriteOff} years after the April you were first due to repay — ten years longer than Plan 2 and fifteen longer than Plan 1. That long term is the main driver of Plan 5's lifetime cost.`,
+      },
+    ],
+  },
+  POSTGRADUATE: {
+    key: "POSTGRADUATE",
+    slug: "postgraduate",
+    name: "Postgraduate Loan",
+    shortName: "Postgraduate",
+    region: pg.region,
+    years: pg.years,
+    monthlyThreshold: PLAN_CONFIGS.POSTGRADUATE.monthlyThreshold,
+    yearlyThreshold: pg.yearlyThreshold,
+    repaymentRate: pg.repaymentRate,
+    writeOffYears: pg.writeOffYears,
+    interestShort: "RPI + 3%",
+    interestCurrent: postgradPct,
+    metaTitle:
+      "What Is a Postgraduate Loan? Threshold, Interest & Write-Off (2026)",
+    metaDescription: `Postgraduate Master's & Doctoral loans: ${pgYearGBP} threshold, ${pgRatePct} rate, RPI + 3% interest (${postgradPct} now) and a ${pgWriteOff}-year write-off. How it stacks alongside your undergraduate loan.`,
+    keywords: [
+      "what is a postgraduate loan",
+      "postgraduate student loan",
+      "postgraduate loan threshold",
+      "postgraduate loan interest rate",
+      "masters loan repayment",
+      "postgraduate loan write off",
+    ],
+    heroIntro: `The Postgraduate Loan funds Master's and Doctoral study across the UK. It works differently from the undergraduate plans: you repay ${pgRatePct} (not 9%) of income above ${pgYearGBP} a year, interest is a flat RPI + 3%, and the balance is written off after ${pgWriteOff} years.`,
+    whatItIs: [
+      `A Postgraduate Loan is repaid at ${pgRatePct} of income above ${pgYearGBP} a year (${pgMonthlyGBP} a month). The threshold is the lowest of any plan, and interest is a flat RPI + 3% regardless of your salary.`,
+      `Crucially, a Postgraduate Loan is repaid alongside — not instead of — any undergraduate loan. If you hold both, the deductions stack, so a graduate on Plan 2 plus a Postgraduate Loan can face two repayments at once.`,
+    ],
+    whoItIsFor: [
+      "You are on a Postgraduate Loan if you borrowed for a Master's or Doctoral course from Student Finance anywhere in the UK from 2016 onwards.",
+      "It sits on top of any undergraduate plan you already have. Your undergraduate loan keeps its own threshold, rate and write-off — the Postgraduate Loan is calculated separately.",
+    ],
+    interestParagraphs: [
+      `Postgraduate Loan interest is a flat RPI + 3% — currently ${postgradPct} — for everyone, whatever you earn. There is no income-based sliding scale like Plan 2 and no cap like Plan 1 or Plan 4.`,
+      `That makes it one of the higher interest rates in the system, so the balance grows quickly. Combined with the ${pgWriteOff}-year term, many postgraduate borrowers repay well beyond what they originally borrowed.`,
+    ],
+    compareParagraph: `The Postgraduate Loan has the lowest threshold (${pgYearGBP}) but the lowest repayment rate (${pgRatePct} versus 9%). Its flat RPI + 3% interest matches Plan 2's ceiling, and because it stacks on top of an undergraduate loan, the combined deductions can be heavier than any single plan.`,
+    middleEarner: `Postgraduate borrowers feel the middle-earner squeeze twice over: the ${pgRatePct} postgraduate deduction stacks on top of a 9% undergraduate deduction, while RPI + 3% interest keeps both balances growing. Middle earners with two loans running at once can lose a meaningful slice of every pay rise. Model the combined effect to see it clearly.`,
+    faqs: [
+      {
+        question: "What is a Postgraduate Loan?",
+        answer: `A Postgraduate Loan funds Master's and Doctoral study in the UK. You repay ${pgRatePct} of income above ${pgYearGBP} a year, interest is a flat RPI + 3% (currently ${postgradPct}), and the balance is written off after ${pgWriteOff} years. It is repaid alongside any undergraduate loan.`,
+      },
+      {
+        question: "What is the Postgraduate Loan threshold?",
+        answer: `The Postgraduate Loan threshold is ${pgYearGBP} a year (${pgMonthlyGBP} a month), the lowest of any plan. You repay ${pgRatePct} of everything above it — a lower rate than the 9% charged on undergraduate plans.`,
+      },
+      {
+        question: "What is the Postgraduate Loan interest rate?",
+        answer: `Postgraduate Loan interest is a flat RPI + 3% for everyone, currently ${postgradPct}. Unlike Plan 2 there is no income-based sliding scale, and unlike Plan 1 and Plan 4 there is no low-rate cap.`,
+      },
+      {
+        question:
+          "Do I repay a Postgraduate Loan and an undergraduate loan at the same time?",
+        answer: `Yes. A Postgraduate Loan is repaid on top of any undergraduate plan, not instead of it. Each has its own threshold and rate, so if you hold both you make two separate deductions — ${pgRatePct} above ${pgYearGBP} for the postgraduate loan plus 9% above your undergraduate threshold.`,
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Why

Search Console shows a plan-specific query cluster worth ~1,500+ monthly impressions that the site currently has **no dedicated page** to answer, so it ranks poorly on pages that only mention plans in passing:

| Query | Impressions | Avg. position |
| --- | --- | --- |
| plan 5 student loan | 332 | 20.3 |
| student loan plans | 211 | 22.2 |
| student loan plan types | 79 | 29.9 |
| what is plan 1 student loan | 76 | 32.9 |
| what is plan 2 student loan | 55 | 23.9 |
| plan 5 student loan interest rate | 43 | 7.7 |

These are informational "what is Plan X" intents. The quiz and calculator don't satisfy them, so this adds dedicated, answer-first pages that own each phrase.

## What this gives users

- A hub at `/plans` ("UK Student Loan Plans Explained") comparing all five plans at a glance, and a page per plan (`/plans/plan-1`, `plan-2`, `plan-4`, `plan-5`, `postgraduate`).
- Each plan page answers the query directly: what it is, who's on it (start year + country), current threshold, repayment rate, interest, write-off period, and how it compares to the other plans — plus prominent links to the which-plan quiz and the home calculator.
- The site's core thesis is woven through every page: whatever the plan, **middle earners repay the most** — this stays positioned as an analysis, not a generic calculator.

## Notes for review

- Every figure (thresholds, rates, interest, write-off years) is derived from `src/lib/loans/plans.ts`, so the pages track the daily GOV.UK/BoE automation and never drift. Nothing is hardcoded. Yearly thresholds render from the monthly source of truth (e.g. Plan 5 shows £24,996), matching the existing which-plan cards and guides.
- JSON-LD (BreadcrumbList, FAQPage, ItemList) lives in `layout.tsx` files, following the established guides pattern that the eslint config expects.
- Discoverability: the which-plan "All UK Student Loan Plans" cards and a footer entry now link into the new pages; all routes added to `sitemap.xml`.
- `llms.txt` updated in both places per repo rules — the `generateLlmsTxt` template and the committed `public/llms.txt` were changed identically by hand (regeneration needs a live GOV.UK scrape, which was skipped).
- Validation: `pnpm lint && pnpm typecheck && pnpm test && pnpm build && pnpm format` all pass (486 tests; all six new routes prerender as static).