### PR TITLE
fix: make modal dialogs accessible via one shared overlay primitive

### DIFF
--- a/src/components/home/ConfigOverlay.tsx
+++ b/src/components/home/ConfigOverlay.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { LoanConfigPanel } from "@/components/home/LoanConfigPanel";
+import { ModalOverlay } from "@/components/shared/ModalOverlay";
+import type { InputMode } from "@/hooks/useInputPanelMode";
+
+interface ConfigOverlayProps {
+  mode: InputMode;
+  hasPersonalized: boolean;
+  onComplete: () => void;
+  onClose: () => void;
+}
+
+/** Full-screen modal dialog wrapping the loan-config panel. */
+export function ConfigOverlay({
+  mode,
+  hasPersonalized,
+  onComplete,
+  onClose,
+}: ConfigOverlayProps) {
+  if (mode.view !== "loan-config") return null;
+
+  return (
+    <ModalOverlay
+      label="Configure your loans"
+      onClose={onClose}
+      className="flex min-h-dvh flex-col overflow-y-auto bg-background"
+    >
+      <LoanConfigPanel
+        isEditing={hasPersonalized}
+        initialPlanTypes={mode.initialPlanTypes}
+        onComplete={onComplete}
+        onClose={onClose}
+      />
+    </ModalOverlay>
+  );
+}

--- a/src/components/home/instrument/Controls.tsx
+++ b/src/components/home/instrument/Controls.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { LoanConfigPanel } from "@/components/home/LoanConfigPanel";
+import { ConfigOverlay } from "@/components/home/ConfigOverlay";
 import {
   currencyFormatter,
   MAX_SALARY,
@@ -220,57 +220,6 @@ function Presets({
           </span>
         </button>
       </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Config overlay (LoanConfigPanel dialog)
-// ---------------------------------------------------------------------------
-
-function ConfigOverlay({
-  mode,
-  hasPersonalized,
-  onComplete,
-  onClose,
-}: {
-  mode: InputMode;
-  hasPersonalized: boolean;
-  onComplete: () => void;
-  onClose: () => void;
-}) {
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const isOpen = mode.view === "loan-config";
-
-  useEffect(() => {
-    if (isOpen) {
-      dialogRef.current?.focus();
-    }
-  }, [isOpen]);
-
-  if (!isOpen) return null;
-
-  return (
-    <div
-      ref={dialogRef}
-      role="dialog"
-      aria-modal="true"
-      aria-label="Configure your loans"
-      className="fixed inset-0 z-50 flex min-h-dvh flex-col overflow-y-auto bg-background"
-      tabIndex={-1}
-      onKeyDown={(e) => {
-        if (e.key === "Escape") {
-          e.stopPropagation();
-          onClose();
-        }
-      }}
-    >
-      <LoanConfigPanel
-        isEditing={hasPersonalized}
-        initialPlanTypes={mode.initialPlanTypes}
-        onComplete={onComplete}
-        onClose={onClose}
-      />
     </div>
   );
 }

--- a/src/components/shared/ControlBar.tsx
+++ b/src/components/shared/ControlBar.tsx
@@ -2,8 +2,8 @@
 
 import { PreferenceHorizontalIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { startTransition, useEffect, useOptimistic, useRef } from "react";
-import { LoanConfigPanel } from "@/components/home/LoanConfigPanel";
+import { startTransition, useOptimistic } from "react";
+import { ConfigOverlay } from "@/components/home/ConfigOverlay";
 import { PresentValueToggle } from "@/components/home/PresentValueToggle";
 import { Slider } from "@/components/ui/slider";
 import {
@@ -228,60 +228,6 @@ function ExpandedPresets({
           </span>
         </span>
       </button>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// LoanConfigPanel overlay
-// ---------------------------------------------------------------------------
-
-function ConfigOverlay({
-  mode,
-  hasPersonalized,
-  onComplete,
-  onClose,
-}: {
-  mode: InputMode;
-  hasPersonalized: boolean;
-  onComplete: () => void;
-  onClose: () => void;
-}) {
-  const dialogRef = useRef<HTMLDivElement>(null);
-
-  const isOpen = mode.view === "loan-config";
-
-  // Auto-focus the dialog container when it opens so keyboard events work
-  // and the next Tab lands inside the dialog rather than on page content.
-  useEffect(() => {
-    if (isOpen) {
-      dialogRef.current?.focus();
-    }
-  }, [isOpen]);
-
-  if (!isOpen) return null;
-
-  return (
-    <div
-      ref={dialogRef}
-      role="dialog"
-      aria-modal="true"
-      aria-label="Configure your loans"
-      className="fixed inset-0 z-50 flex min-h-dvh flex-col overflow-y-auto bg-background"
-      tabIndex={-1}
-      onKeyDown={(e) => {
-        if (e.key === "Escape") {
-          e.stopPropagation();
-          onClose();
-        }
-      }}
-    >
-      <LoanConfigPanel
-        isEditing={hasPersonalized}
-        initialPlanTypes={mode.initialPlanTypes}
-        onComplete={onComplete}
-        onClose={onClose}
-      />
     </div>
   );
 }

--- a/src/components/shared/ModalOverlay.tsx
+++ b/src/components/shared/ModalOverlay.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib/utils";
+
+// Elements that participate in the tab order, used by the focus trap.
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+function getTabbable(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  ).filter((el) => el.offsetParent !== null || el === document.activeElement);
+}
+
+interface ModalOverlayProps {
+  /** Accessible name announced for the dialog. */
+  label: string;
+  /** Invoked when the user dismisses the dialog with Escape. */
+  onClose: () => void;
+  /** Extra classes for the full-screen dialog container. */
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * Full-screen modal dialog primitive shared by the loan-config and
+ * assumptions-wizard overlays. Owns the complete modal contract: it portals
+ * above the page, locks body scroll, marks the rest of the document
+ * inert + aria-hidden, moves focus into the dialog on open, traps Tab within
+ * it, restores focus to the trigger on close, and closes on Escape.
+ *
+ * Render it only while the dialog is open — mounting is "open" and unmounting
+ * is "close", which is what drives focus capture/restore.
+ */
+export function ModalOverlay({
+  label,
+  onClose,
+  className,
+  children,
+}: ModalOverlayProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const [container] = useState(() =>
+    typeof document === "undefined" ? null : document.createElement("div"),
+  );
+
+  useEffect(() => {
+    if (!container) return;
+    document.body.appendChild(container);
+
+    const previouslyFocused =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    // Hide everything except this dialog from assistive tech + the tab order.
+    const backdrop = Array.from(document.body.children)
+      .filter((el) => el !== container)
+      .map((el) => ({
+        el,
+        inert: el.getAttribute("inert"),
+        ariaHidden: el.getAttribute("aria-hidden"),
+      }));
+    for (const { el } of backdrop) {
+      el.setAttribute("inert", "");
+      el.setAttribute("aria-hidden", "true");
+    }
+
+    dialogRef.current?.focus();
+
+    return () => {
+      document.body.style.overflow = originalOverflow;
+      for (const { el, inert, ariaHidden } of backdrop) {
+        if (inert === null) el.removeAttribute("inert");
+        else el.setAttribute("inert", inert);
+        if (ariaHidden === null) el.removeAttribute("aria-hidden");
+        else el.setAttribute("aria-hidden", ariaHidden);
+      }
+      // Restore focus only after the background is interactive again.
+      previouslyFocused?.focus();
+      container.remove();
+    };
+  }, [container]);
+
+  if (!container) return null;
+
+  return createPortal(
+    <div
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label={label}
+      className={cn("fixed inset-0 z-50", className)}
+      tabIndex={-1}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.stopPropagation();
+          onClose();
+          return;
+        }
+        if (e.key !== "Tab") return;
+        const el = dialogRef.current;
+        if (!el) return;
+        const tabbable = getTabbable(el);
+        if (tabbable.length === 0) {
+          e.preventDefault();
+          el.focus();
+          return;
+        }
+        const first = tabbable[0];
+        const last = tabbable[tabbable.length - 1];
+        const active = document.activeElement;
+        if (e.shiftKey && (active === first || active === el)) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }}
+    >
+      {children}
+    </div>,
+    container,
+  );
+}

--- a/src/context/AssumptionsWizardContext.test.tsx
+++ b/src/context/AssumptionsWizardContext.test.tsx
@@ -162,6 +162,47 @@ describe("AssumptionsWizardContext", () => {
     expect(document.body.style.overflow).toBe("");
   });
 
+  it("restores focus to the trigger when the dialog is closed", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <AssumptionsWizardProvider>
+        <TestConsumer />
+      </AssumptionsWizardProvider>,
+    );
+
+    const trigger = screen.getByText("Open");
+    await user.click(trigger);
+    expect(screen.queryByRole("dialog")).not.toBeNull();
+
+    await user.click(screen.getByText("Close"));
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("marks background content inert + aria-hidden while open and restores on close", async () => {
+    const user = userEvent.setup();
+
+    const { container } = renderWithProviders(
+      <AssumptionsWizardProvider>
+        <TestConsumer />
+      </AssumptionsWizardProvider>,
+    );
+
+    expect(container.hasAttribute("inert")).toBe(false);
+
+    await user.click(screen.getByText("Open"));
+
+    expect(container.getAttribute("inert")).toBe("");
+    expect(container.getAttribute("aria-hidden")).toBe("true");
+
+    await user.click(screen.getByText("Close"));
+
+    expect(container.hasAttribute("inert")).toBe(false);
+    expect(container.hasAttribute("aria-hidden")).toBe(false);
+  });
+
   it("calls trackWizardStarted with 'assumptions' on open", async () => {
     const user = userEvent.setup();
 

--- a/src/context/AssumptionsWizardContext.tsx
+++ b/src/context/AssumptionsWizardContext.tsx
@@ -1,13 +1,7 @@
 "use client";
 
-import {
-  createContext,
-  use,
-  useEffect,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { createContext, use, useState, type ReactNode } from "react";
+import { ModalOverlay } from "@/components/shared/ModalOverlay";
 import { AssumptionsWizard } from "@/components/wizard/AssumptionsWizard";
 import type { AssumptionsWizardStep } from "@/components/wizard/wizardReducer";
 import { trackWizardCompleted, trackWizardStarted } from "@/lib/analytics";
@@ -38,15 +32,6 @@ export function AssumptionsWizardProvider({
     entryStep?: AssumptionsWizardStep;
   }>({ open: false });
 
-  useEffect(() => {
-    if (wizardState.open) {
-      document.body.style.overflow = "hidden";
-      return () => {
-        document.body.style.overflow = "";
-      };
-    }
-  }, [wizardState.open]);
-
   function openAssumptions(entryStep?: AssumptionsWizardStep) {
     trackWizardStarted("assumptions");
     setWizardState({ open: true, entryStep });
@@ -61,42 +46,23 @@ export function AssumptionsWizardProvider({
     setWizardState({ open: false });
   }
 
-  const dialogRef = useRef<HTMLDivElement>(null);
-
-  // Auto-focus the dialog container when it opens so keyboard events work
-  // and the next Tab lands inside the dialog rather than on page content.
-  useEffect(() => {
-    if (wizardState.open) {
-      dialogRef.current?.focus();
-    }
-  }, [wizardState.open]);
-
   const value: AssumptionsWizardValue = { openAssumptions };
 
   return (
     <AssumptionsWizardContext value={value}>
       {children}
       {wizardState.open && (
-        <div
-          ref={dialogRef}
-          role="dialog"
-          aria-modal="true"
-          aria-label="Adjust assumptions"
-          className="fixed inset-0 z-50 overflow-y-auto"
-          tabIndex={-1}
-          onKeyDown={(e) => {
-            if (e.key === "Escape") {
-              e.stopPropagation();
-              handleClose();
-            }
-          }}
+        <ModalOverlay
+          label="Adjust assumptions"
+          onClose={handleClose}
+          className="overflow-y-auto"
         >
           <AssumptionsWizard
             onComplete={handleComplete}
             onClose={handleClose}
             entryStep={wizardState.entryStep}
           />
-        </div>
+        </ModalOverlay>
       )}
     </AssumptionsWizardContext>
   );

--- a/src/hooks/useInputPanelMode.ts
+++ b/src/hooks/useInputPanelMode.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useLoanActions, useLoanConfigState } from "@/context/LoanContext";
 import {
   trackPresetApplied,
@@ -24,15 +24,6 @@ export function useInputPanelMode(options?: UseInputPanelModeOptions) {
   const { applyPreset } = useLoanActions();
   const config = useLoanConfigState();
   const hasPersonalized = !isPresetConfig(config.loans);
-
-  useEffect(() => {
-    if (mode.view !== "summary") {
-      document.body.style.overflow = "hidden";
-      return () => {
-        document.body.style.overflow = "";
-      };
-    }
-  }, [mode.view]);
 
   function handlePersonalise() {
     if (hasPersonalized) {


### PR DESCRIPTION
## Why

The app had three hand-rolled full-screen modal dialogs — the loan-config overlay (duplicated byte-for-byte in `Controls.tsx` and `ControlBar.tsx`) and the assumptions wizard host in `AssumptionsWizardContext.tsx`. Each rendered a `role="dialog" aria-modal` container, focused it on open, handled Escape, and locked body scroll — but all three shared the same three accessibility gaps:

- **No focus trap** — Tab / Shift+Tab escaped the dialog onto the background page content still sitting behind the `fixed inset-0` overlay.
- **No focus restoration** — on close, focus was dropped to `<body>` instead of returning to the control that opened the dialog. This is a WCAG 2.4.3 failure and is disorienting for keyboard and screen-reader users.
- **Background not inert** — despite `aria-modal`, the screen-reader virtual cursor and Tab order could still reach the page behind the dialog.

On top of that, the logic was duplicated: two identical `ConfigOverlay` components and body-scroll-lock implemented twice (`useInputPanelMode.ts` and `AssumptionsWizardContext.tsx`).

## What changed

Introduces one shared `ModalOverlay` primitive (`src/components/shared/ModalOverlay.tsx`) that owns the full modal contract, and routes all three call sites through it:

- Portals above the page, locks body scroll, and marks every other `<body>` child `inert` + `aria-hidden` while open (restoring prior attribute values on close).
- Captures `document.activeElement` on open and restores focus to it on unmount.
- Traps Tab / Shift+Tab within the dialog, wrapping at both ends.
- Wires `role="dialog"` / `aria-modal` / `tabIndex={-1}`, focus-on-open, and Escape-to-close.

The two byte-for-byte `ConfigOverlay` definitions collapse into a single shared `ConfigOverlay` (`src/components/home/ConfigOverlay.tsx`) that wraps `ModalOverlay`, and both duplicated scroll-locks are deleted — scroll-lock now lives solely in `ModalOverlay`. Because `InputMode` only has `summary` and `loan-config` views, the removed `mode.view !== "summary"` scroll-lock is exactly equivalent to locking when the overlay mounts, so there is no behavioural regression.

Mounting the overlay means "open" and unmounting means "close", which is what drives focus capture/restore.

```mermaid
flowchart LR
  A[Controls.tsx] --> C[ConfigOverlay]
  B[ControlBar.tsx] --> C
  C --> M[ModalOverlay]
  W[AssumptionsWizardContext.tsx] --> M
  M --> X[focus trap + restore · inert background · scroll-lock · Escape]
```

## Tests

Existing `AssumptionsWizardContext` body-overflow assertions still pass. Added coverage for focus restoration to the trigger on close, and for the background being marked inert + `aria-hidden` while open and cleared on close.
