### PR TITLE
fix: announce copied link to screen readers in share button

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -48,7 +48,9 @@ test.describe("Accessibility", () => {
   test("overpay page has no WCAG 2.1 AA violations", async ({ page }) => {
     await page.goto("/overpay");
     // Wait for verdict to load
-    const verdict = page.locator("[role='status'][aria-live='polite']").first();
+    const verdict = page.getByRole("status", {
+      name: "Overpay recommendation",
+    });
     await expect(verdict).toBeVisible({ timeout: 15_000 });
 
     const results = await axeScan(page).analyze();

--- a/e2e/overpay-flow.spec.ts
+++ b/e2e/overpay-flow.spec.ts
@@ -5,7 +5,9 @@ test.describe("Overpay page", () => {
     await page.goto("/overpay");
 
     // Wait for the verdict to appear (shows recommendation)
-    const verdict = page.locator("[role='status'][aria-live='polite']").first();
+    const verdict = page.getByRole("status", {
+      name: "Overpay recommendation",
+    });
     await expect(verdict).toBeVisible({ timeout: 15_000 });
 
     // Heading should be visible
@@ -22,7 +24,9 @@ test.describe("Overpay page", () => {
     await page.goto("/overpay?loans=PLAN_2:45000&sal=50000");
 
     // Wait for initial verdict
-    const verdict = page.locator("[role='status'][aria-live='polite']").first();
+    const verdict = page.getByRole("status", {
+      name: "Overpay recommendation",
+    });
     await expect(verdict).toBeVisible({ timeout: 15_000 });
 
     // Focus the overpayment slider thumb and use keyboard to change value
@@ -46,7 +50,9 @@ test.describe("Overpay page", () => {
     await page.goto("/overpay?loans=PLAN_2:45000&sal=50000");
 
     // Wait for page to load
-    const verdict = page.locator("[role='status'][aria-live='polite']").first();
+    const verdict = page.getByRole("status", {
+      name: "Overpay recommendation",
+    });
     await expect(verdict).toBeVisible({ timeout: 15_000 });
     const initialText = await verdict.textContent();
 
@@ -65,7 +71,9 @@ test.describe("Overpay page", () => {
     await page.goto("/overpay");
 
     // Wait for initial load
-    const verdict = page.locator("[role='status'][aria-live='polite']").first();
+    const verdict = page.getByRole("status", {
+      name: "Overpay recommendation",
+    });
     await expect(verdict).toBeVisible({ timeout: 15_000 });
     const initialText = await verdict.textContent();
 

--- a/e2e/share-url.spec.ts
+++ b/e2e/share-url.spec.ts
@@ -35,7 +35,9 @@ test.describe("Share URL round-trip", () => {
     await page.goto("/overpay?loans=PLAN_2:45000&sal=50000&ovp=200&lsp=5000");
 
     // Wait for the overpay verdict to appear
-    const verdict = page.locator("[role='status'][aria-live='polite']").first();
+    const verdict = page.getByRole("status", {
+      name: "Overpay recommendation",
+    });
     await expect(verdict).toBeVisible({ timeout: 15_000 });
   });
 

--- a/src/components/layout/ShareButton.test.tsx
+++ b/src/components/layout/ShareButton.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { LoanProvider } from "@/context/LoanContext";
+import { ShareButton } from "./ShareButton";
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <LoanProvider>{children}</LoanProvider>;
+}
+
+describe("ShareButton", () => {
+  beforeEach(() => {
+    // Force the clipboard fallback path (no native share sheet).
+    Object.defineProperty(navigator, "share", {
+      value: undefined,
+      configurable: true,
+    });
+  });
+
+  it("announces copy success to screen readers via a live region", async () => {
+    // Define the clipboard mock after setup(): userEvent installs its own
+    // clipboard stub during setup(), which would otherwise shadow this one.
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(<ShareButton />, { wrapper: Wrapper });
+
+    // The live region exists up front but is empty, so a repeat copy re-announces.
+    const status = screen.getByRole("status");
+    expect(status.textContent).toBe("");
+
+    await user.click(screen.getByRole("button", { name: "Share results" }));
+
+    await waitFor(() => {
+      expect(status.textContent).toBe("Link copied to clipboard");
+    });
+    expect(writeText).toHaveBeenCalledOnce();
+    // Existing icon/label feedback is preserved alongside the announcement.
+    expect(screen.getByRole("button", { name: "Link copied" })).not.toBeNull();
+  });
+
+  it("keeps the live region empty when the clipboard copy fails", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockRejectedValue(new Error("blocked"));
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(<ShareButton />, { wrapper: Wrapper });
+
+    await user.click(screen.getByRole("button", { name: "Share results" }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledOnce();
+    });
+    expect(screen.getByRole("status").textContent).toBe("");
+  });
+});

--- a/src/components/layout/ShareButton.tsx
+++ b/src/components/layout/ShareButton.tsx
@@ -61,18 +61,27 @@ export function ShareButton({ repaymentYear }: ShareButtonProps) {
   };
 
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      onClick={handleShare}
-      aria-label={copied ? "Link copied" : "Share results"}
-      className="shrink-0"
-    >
-      <HugeiconsIcon
-        icon={copied ? Tick02Icon : Share01Icon}
-        className="size-4"
-        strokeWidth={2}
-      />
-    </Button>
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={handleShare}
+        aria-label={copied ? "Link copied" : "Share results"}
+        className="shrink-0"
+      >
+        <HugeiconsIcon
+          icon={copied ? Tick02Icon : Share01Icon}
+          className="size-4"
+          strokeWidth={2}
+        />
+      </Button>
+      {/* Announce copy success to screen readers: an aria-label change on the
+          already-focused button is not reliably re-read, so a live region is
+          needed. The message clears when `copied` resets, so a repeat copy
+          re-announces. */}
+      <span role="status" aria-live="polite" className="sr-only">
+        {copied ? "Link copied to clipboard" : ""}
+      </span>
+    </>
   );
 }

--- a/src/components/overpay/OverpayVerdict.tsx
+++ b/src/components/overpay/OverpayVerdict.tsx
@@ -268,6 +268,7 @@ export function OverpayVerdict({
         <div
           role="status"
           aria-live="polite"
+          aria-label="Overpay recommendation"
           className="col-start-1 row-start-1 self-start"
         >
           <VerdictBody


### PR DESCRIPTION
## Why

The header share button confirmed a successful clipboard copy only by swapping its icon (Share → Tick) and flipping the button's `aria-label` from "Share results" to "Link copied" for 2 seconds. Changing the accessible name of an element that is **already focused** is not reliably re-announced by screen readers — NVDA and VoiceOver generally do not re-read a focused control's label when only its `aria-label` changes. So a screen-reader user who activated Share on a desktop / clipboard-fallback browser got **no confirmation** the link was copied. The copy itself always worked; only the feedback was inaccessible.

## What changed

A visually-hidden (`sr-only`) live region — `role="status"` / `aria-live="polite"` — now sits alongside the button. It is always present in the DOM and renders "Link copied to clipboard" only while the existing `copied` state is true, and is empty otherwise. Because `copied` is set only in the clipboard-success branch and auto-clears after the existing 2s timeout:

- success is announced exactly once per copy,
- a repeat copy re-announces (the region empties in between, so the change is observed),
- the native-share path stays silent (the OS provides its own feedback),
- the silent clipboard-failure path stays silent.

There is no visual or layout change. All prior behaviour — icon swap, `aria-label` toggle, `trackShareClicked` analytics, and native-share-vs-clipboard branching — is untouched.

A new test file covers the two cases that matter for this fix: the live region announces on a successful copy, and stays empty when the clipboard write rejects.