### PR TITLE
fix: consolidate danger red onto a single token

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -126,7 +126,9 @@
   --muted-foreground: #4f5955; /* soft — secondary text */
   --accent: #e7ebe9; /* subtle hover surface (sunk), NOT the brand */
   --accent-foreground: #131b18;
-  --destructive: oklch(0.55 0.2 29);
+  --destructive: var(
+    --status-danger-foreground
+  ); /* one danger red across shadcn + status intents */
   --border: #dbe1de; /* hair */
   --input: #dbe1de;
   --ring: #0c5c44; /* focus = spruce */
@@ -187,7 +189,9 @@
   --muted-foreground: #909a95; /* soft */
   --accent: #18231f; /* subtle hover surface */
   --accent-foreground: #e7eeea;
-  --destructive: oklch(0.704 0.191 22.216);
+  --destructive: var(
+    --status-danger-foreground
+  ); /* one danger red across shadcn + status intents */
   --border: #1e2a25; /* hair */
   --input: #1e2a25;
   --ring: #50c99f;

--- a/src/components/wizard/RpiStep.tsx
+++ b/src/components/wizard/RpiStep.tsx
@@ -63,7 +63,7 @@ export function RpiStep({ direction, onNext, done }: RpiStepProps) {
             ))}
           </div>
 
-          <p className="text-xs text-status-warning-foreground">
+          <p className="text-xs text-status-info-foreground">
             RPI includes housing costs, so it typically runs higher than general
             inflation (CPI).
           </p>


### PR DESCRIPTION
## Why

Following #494 (which brightened the status intent colours), an audit surfaced that the app had **two parallel "red for bad" systems** that drifted apart:

- shadcn components (Alert, Button, Badge, Input, Switch, the dropdown-menu destructive item, and `ErrorBoundary`) express errors through the `--destructive` token.
- The design system separately defines a `--status-danger` intent family — a *different* red.

Two different reds for the same meaning is a maintenance trap and reads as inconsistent to users. This change makes there be exactly one canonical danger red.

Separately, the RPI caption in the wizard was wearing the `warning` intent, but the copy ("RPI includes housing costs, so it typically runs higher than general inflation (CPI)") is purely informational — nothing is wrong and nothing needs caution.

## What changed

- `--destructive` now points at `--status-danger-foreground`, so shadcn's error surfaces and the status-danger intent resolve to the same colour. This is done entirely at the token layer in `globals.css` — no shadcn component files are touched (AGENTS.md forbids that outside bug fixes).
  - Dark mode: the two reds were already identical (red-400), so no visible change.
  - Light mode: `--destructive` shifts from red-600 to red-700. Every consumer is text / border / low-alpha tint (there is no solid `bg-destructive` fill with white text), so this only improves contrast.
- The RPI caption switches from the `warning` intent to `info`, which better matches the copy and gives the `info` token its first real consumer.