### PR TITLE
fix: correct chart insight cta wrapping and balance legend colour

### DIFF
--- a/src/components/detail/BalanceDetailPage.tsx
+++ b/src/components/detail/BalanceDetailPage.tsx
@@ -45,7 +45,7 @@ export function BalanceDetailPage() {
 
   const legend: ChartLegendItem[] = result
     ? [
-        { label: "Outstanding balance", color: "var(--chart-2)" },
+        { label: "Outstanding balance", color: "var(--chart-1)" },
         ...(result.stats.peakBalanceMonth > 0
           ? [
               {

--- a/src/components/home/instrument/ChartInsight.tsx
+++ b/src/components/home/instrument/ChartInsight.tsx
@@ -13,6 +13,11 @@ const COST_ZONES = new Set<Insight["type"]>(["middle-earner"]);
  * under the chart with a deep-link into the overpayment calculator. Driven live
  * by the same simulation as the readout (generateInsight), so it updates as the
  * salary slider moves.
+ *
+ * Layout: the status dot sits in a fixed marker column so the title and CTA
+ * share one left edge. When they fit, the CTA rides inline to the right
+ * (justify-between); when the panel is too narrow it drops onto its own line
+ * and stays aligned under the title instead of orphaning against the right edge.
  */
 export function ChartInsight() {
   const { insight } = usePersonalizedResults();
@@ -23,32 +28,36 @@ export function ChartInsight() {
 
   return (
     <div
-      className="group mt-[0.85rem] flex flex-wrap items-baseline gap-x-[0.9rem] gap-y-[0.35rem] border-t border-border pt-[0.85rem]"
+      className="group mt-3.5 flex items-start gap-3.5 border-t border-border pt-3.5"
       data-tone={tone}
       role="status"
       aria-live="polite"
     >
-      <span
-        className="size-2 flex-none self-center rounded-full bg-primary group-data-[tone=cost]:[background:var(--signal)]"
-        aria-hidden="true"
-      />
-      <p className="m-0 font-sans text-sm font-semibold tracking-[-0.01em] text-foreground">
-        {insight.title}
-      </p>
-      {insight.cta && (
-        <Link
-          className="group/cta ml-auto inline-flex items-baseline gap-[0.3rem] font-sans text-sm font-semibold whitespace-nowrap text-cta no-underline [transition:color_0.15s]"
-          href={insight.cta.href}
-        >
-          {insight.cta.text}
-          <span
-            className="text-primary [transition:transform_0.15s] group-hover/cta:translate-x-[3px]"
-            aria-hidden="true"
+      {/* Marker column is exactly one line tall (h-5 = text-sm leading), so the
+          dot centres on the first line of the title and stays there however the
+          content below it wraps. */}
+      <span className="flex h-5 flex-none items-center" aria-hidden="true">
+        <span className="size-2 rounded-full bg-primary group-data-[tone=cost]:[background:var(--signal)]" />
+      </span>
+      <div className="flex min-w-0 flex-1 flex-wrap items-baseline justify-between gap-x-3.5 gap-y-1.5">
+        <p className="m-0 font-sans text-sm font-semibold text-foreground">
+          {insight.title}
+        </p>
+        {insight.cta && (
+          <Link
+            className="group/cta inline-flex items-baseline gap-1 font-sans text-sm font-semibold whitespace-nowrap text-cta no-underline transition-colors"
+            href={insight.cta.href}
           >
-            →
-          </span>
-        </Link>
-      )}
+            {insight.cta.text}
+            <span
+              className="text-primary transition-transform group-hover/cta:translate-x-0.5 motion-reduce:transition-none"
+              aria-hidden="true"
+            >
+              →
+            </span>
+          </Link>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Two small, self-contained chart UI correctness fixes.

## Homepage chart-insight callout wrapping

The insight callout shows a status title on the left (e.g. "You're in the peak repayment zone") and a CTA link on the right (e.g. "Calculate your overpayment savings →"). At narrow widths where both couldn't fit on one line, the CTA wrapped to its own line but stayed pinned to the right edge (`ml-auto`), leaving an awkward orphaned, right-aligned link.

Now the status dot + title are grouped into a single flex child and the container uses `justify-between` instead of `ml-auto`. On one line it still spreads title-left / CTA-right; when it wraps, the lone CTA falls back to flex-start and left-aligns into a clean stack under the title. Verified visually in the browser at 520px width.

## Balance-detail legend swatch colour

Surfaced by code review: the "Outstanding balance" legend swatch used `var(--chart-2)` (brick), but the plotted balance line is deliberately `var(--chart-1)` (spruce) — the chart component documents that brick was intentionally dropped. The legend colour therefore contradicted the line it labelled and instead matched the brick "Peak balance" marker. The swatch now uses `var(--chart-1)` so it matches the line it describes.