### PR TITLE
fix: make status palette colour-blind-safe

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -185,17 +185,20 @@
   --chart-5: var(--axis); /* baseline / comparison series = the axis grey */
   --chart-overpay-baseline: var(--chart-interest);
 
-  /* Status: bright semantic utility tokens — deliberately outside the two-colour thesis */
+  /* Status: bright semantic utility tokens — deliberately outside the two-colour
+     thesis. Colour-blind-safe: success is emerald (blue-shifted green, not pure
+     green) so it separates from danger red under deuteranopia/protanopia; danger
+     is deepened to red-800 so its luminance parts from warning amber. */
   --status-info-foreground: oklch(0.546 0.245 262.881); /* blue-600 */
   --status-info: oklch(0.97 0.014 254.604); /* blue-50 */
   --status-info-border: oklch(0.882 0.059 254.128); /* blue-200 */
-  --status-success-foreground: oklch(0.527 0.154 150.069); /* green-700 */
-  --status-success: oklch(0.982 0.018 155.826); /* green-50 */
-  --status-success-border: oklch(0.925 0.084 155.995); /* green-200 */
+  --status-success-foreground: oklch(0.508 0.118 165.612); /* emerald-700 */
+  --status-success: oklch(0.979 0.021 166.113); /* emerald-50 */
+  --status-success-border: oklch(0.905 0.093 164.15); /* emerald-200 */
   --status-warning-foreground: oklch(0.555 0.163 48.998); /* amber-700 */
   --status-warning: oklch(0.987 0.022 95.277); /* amber-50 */
   --status-warning-border: oklch(0.924 0.12 95.746); /* amber-200 */
-  --status-danger-foreground: oklch(0.505 0.213 27.518); /* red-700 */
+  --status-danger-foreground: oklch(0.444 0.177 26.899); /* red-800 */
   --status-danger: oklch(0.971 0.013 17.38); /* red-50 */
   --status-danger-border: oklch(0.885 0.062 18.334); /* red-200 */
 }
@@ -262,9 +265,9 @@
   --status-info-foreground: oklch(0.707 0.165 254.624); /* blue-400 */
   --status-info: oklch(0.282 0.091 267.935 / 30%); /* blue-950 */
   --status-info-border: oklch(0.424 0.199 265.638); /* blue-700 */
-  --status-success-foreground: oklch(0.792 0.209 151.711); /* green-400 */
-  --status-success: oklch(0.266 0.065 152.934 / 30%); /* green-950 */
-  --status-success-border: oklch(0.527 0.154 150.069); /* green-700 */
+  --status-success-foreground: oklch(0.765 0.177 163.223); /* emerald-400 */
+  --status-success: oklch(0.262 0.051 172.552 / 30%); /* emerald-950 */
+  --status-success-border: oklch(0.508 0.118 165.612); /* emerald-700 */
   --status-warning-foreground: oklch(0.828 0.189 84.429); /* amber-400 */
   --status-warning: oklch(0.279 0.077 45.635 / 30%); /* amber-950 */
   --status-warning-border: oklch(0.473 0.137 46.201); /* amber-800 */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -187,8 +187,11 @@
 
   /* Status: bright semantic utility tokens — deliberately outside the two-colour
      thesis. Colour-blind-safe: success is emerald (blue-shifted green, not pure
-     green) so it separates from danger red under deuteranopia/protanopia; danger
-     is deepened to red-800 so its luminance parts from warning amber. */
+     green) so it separates from danger red under deuteranopia/protanopia. Danger
+     stays a vivid red-700 rather than a deeper red — darkening would only buy a
+     little warning/danger separation while dimming the red for the red-blind
+     viewers we're helping; warning-vs-danger is disambiguated by icons + text at
+     the component layer, not by colour. */
   --status-info-foreground: oklch(0.546 0.245 262.881); /* blue-600 */
   --status-info: oklch(0.97 0.014 254.604); /* blue-50 */
   --status-info-border: oklch(0.882 0.059 254.128); /* blue-200 */
@@ -198,7 +201,7 @@
   --status-warning-foreground: oklch(0.555 0.163 48.998); /* amber-700 */
   --status-warning: oklch(0.987 0.022 95.277); /* amber-50 */
   --status-warning-border: oklch(0.924 0.12 95.746); /* amber-200 */
-  --status-danger-foreground: oklch(0.444 0.177 26.899); /* red-800 */
+  --status-danger-foreground: oklch(0.505 0.213 27.518); /* red-700 */
   --status-danger: oklch(0.971 0.013 17.38); /* red-50 */
   --status-danger-border: oklch(0.885 0.062 18.334); /* red-200 */
 }


### PR DESCRIPTION
## Why

The status colour tokens (info / success / warning / danger) paired a pure green for *success* against red for *danger* — the classic red-green colour-blindness trap that affects ~8% of men. Success and danger were only borderline distinguishable, and in dark mode they collapsed together for deuteranopes. This makes the status palette colour-blind-safe while keeping the conventional green / amber / red semantics everyone expects.

## What changes

The fix follows established CVD guidance — never rely on red vs green alone; the reliable lever is to shift green toward a blue-green. Each status pair was then checked with a Machado-2009 CVD simulation, measuring perceptual distance (ΔE) under both deuteranopia and protanopia:

- **Success** moves from pure green to **emerald** (a blue-shifted green that survives red-green CVD), in both light and dark themes. This is what actually resolves the success-vs-danger confusion (ΔE ~9–23 → ~21–43).
- **Danger** stays a vivid **red-700** — the brightest AA-safe red on the tint. Deepening it was considered and rejected: it only bought marginal warning-vs-danger separation while *dimming* the red for the very red-blind viewers this change helps (lower protanope-perceived lightness, smaller distance from neutral dark text).
- **Warning** stays amber and **Info** stays blue: testing showed orange would make warning harder to tell from both danger and success, and blue is the safe anchor colour.

Warning-vs-danger is inherently a weak colour distinction (red and amber both collapse toward yellow under deuteranopia) and is not solved by colour alone — it belongs to icons + text at the component layer.

## Result

The critical success-vs-danger pair is now clearly distinguishable under simulated deuteranopia and protanopia in both themes, and all foreground/background pairs still meet WCAG AA (≥4.5:1). `--destructive` is aliased to the danger foreground token, so all shadcn error surfaces stay consistent and above AA. Verified visually on the `/brand` guidelines page in both light and dark themes.

## Follow-up

Full CVD robustness needs status to never rely on colour alone — success/warning/danger alerts should carry distinct icons (✓ / ⚠ / ✕) and text. That is a component/usage change, out of scope for this token PR.
