### PR TITLE
fix: announce selected state in guide chart toggles

### DIFF
--- a/src/components/guides/interest-rate-cap/BalanceWithCapChart.tsx
+++ b/src/components/guides/interest-rate-cap/BalanceWithCapChart.tsx
@@ -123,6 +123,7 @@ export function BalanceWithCapChart() {
             <button
               key={option.value}
               type="button"
+              aria-pressed={rpi === option.value}
               onClick={() => {
                 setRpi(option.value);
               }}

--- a/src/components/guides/plan-2-vs-plan-5/BalanceComparisonChart.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/BalanceComparisonChart.tsx
@@ -95,14 +95,18 @@ export function BalanceComparisonChart() {
   return (
     <div className="flex h-full flex-col gap-3">
       <div className="flex items-center gap-2">
-        <span className="text-sm font-medium text-muted-foreground">
+        <span
+          id="salary-label"
+          className="text-sm font-medium text-muted-foreground"
+        >
           Salary:
         </span>
-        <div className="flex gap-1">
+        <div className="flex gap-1" role="group" aria-labelledby="salary-label">
           {SALARY_OPTIONS.map((option) => (
             <button
               key={option}
               type="button"
+              aria-pressed={salary === option}
               onClick={() => {
                 setSalary(option);
               }}

--- a/src/components/guides/rpi-vs-cpi/InflationComparisonChart.tsx
+++ b/src/components/guides/rpi-vs-cpi/InflationComparisonChart.tsx
@@ -79,14 +79,18 @@ export function InflationComparisonChart() {
   return (
     <div className="flex h-full flex-col gap-3">
       <div className="flex items-center gap-2">
-        <span className="text-sm font-medium text-muted-foreground">
+        <span
+          id="salary-label"
+          className="text-sm font-medium text-muted-foreground"
+        >
           Salary:
         </span>
-        <div className="flex gap-1">
+        <div className="flex gap-1" role="group" aria-labelledby="salary-label">
           {SALARY_OPTIONS.map((option) => (
             <button
               key={option}
               type="button"
+              aria-pressed={salary === option}
               onClick={() => {
                 setSalary(option);
               }}


### PR DESCRIPTION
## Why

Three interactive guide charts render a segmented Salary/RPI selector as a row of `<button>` elements where the active option was conveyed **only visually** (`bg-foreground text-background`). None set `aria-pressed`, so a screen-reader user heard "£30k button / £50k button / £70k button" with no indication which one was selected. Two of the three groups also had no `role="group"` or accessible name — the "Salary:" label was a bare sibling `<span>`, not programmatically associated.

This was inconsistent with the rest of the app, whose segmented controls (`Controls.tsx`, `LoanConfigPanel.tsx`, `ControlBar.tsx`) already set `aria-pressed`.

## What changed

- Each toggle button in the plan-2-vs-plan-5 balance chart, the rpi-vs-cpi inflation chart, and the interest-rate-cap balance chart now sets `aria-pressed` reflecting whether that option is currently selected, so assistive tech announces the pressed state.
- The two previously-unlabelled salary selectors are wrapped in `role="group"` with `aria-labelledby` pointing at the "Salary:" label — mirroring the `role="group"` + `aria-labelledby` pattern already used in the interest-rate-cap chart.

Visual styling is unchanged: this adds ARIA attributes and a label id only.