### PR TITLE
feat: apply instrument layout to guides index

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -76,6 +76,11 @@
   --text-section--line-height: 1.1;
   --text-lead: 1.0625rem;
   --text-lead--line-height: 1.45;
+  /* Index-title size: the compact list-item title (matches text-lead) that
+     grows a step on large screens so a single-column index reads with presence
+     without competing with a section heading. */
+  --text-index: clamp(1.0625rem, 1.15vw, 1.375rem);
+  --text-index--line-height: 1.25;
   /* Instrument body + label scale (sans) — promoted from raw vars so the
      homepage uses on-system text-* utilities, not [font-size:var(--t-*)]. */
   --text-micro: 0.6875rem;

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
-import { LinkIndex, LinkIndexRow } from "@/components/instrument/LinkIndex";
-import { PageLayout } from "@/components/layout/PageLayout";
+import { WideLayout } from "@/components/layout/WideLayout";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { Heading } from "@/components/typography/Heading";
 import {
@@ -12,6 +11,25 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import { GUIDES } from "@/lib/guides";
+import { SHELL_GUTTER } from "@/lib/layout";
+import { LAST_UPDATED } from "@/lib/loans/plans";
+
+// "Updated May 2026" — derived from the automation's LAST_UPDATED so the guides
+// masthead carries the same freshness signal as the homepage hero.
+const UPDATED_LABEL = new Intl.DateTimeFormat("en-GB", {
+  month: "long",
+  year: "numeric",
+}).format(new Date(LAST_UPDATED));
+
+// Aggregate the honest topic taxonomy into counts for the orientation rail's
+// "by topic" ledger — derived from the data (unique topics in first-appearance
+// order) so it self-maintains as guides are added and never drifts from GUIDES.
+const TOPIC_SUMMARY = [...new Set(GUIDES.map((guide) => guide.topic))].map(
+  (label) => ({
+    label,
+    count: GUIDES.filter((guide) => guide.topic === label).length,
+  }),
+);
 
 const itemListSchema = {
   "@context": "https://schema.org",
@@ -49,49 +67,161 @@ const breadcrumbSchema = {
 
 export default function GuidesPage() {
   return (
-    <PageLayout>
+    <WideLayout>
       <JsonLd data={itemListSchema} />
       <JsonLd data={breadcrumbSchema} />
-      <header className="space-y-4">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>Guides</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
+      {/* Three-zone workspace (the same grammar the homepage Fold uses:
+          36ch masthead + content + a right-anchored companion): masthead rail,
+          a bounded single-column index, and a right-anchored orientation rail.
+          index is capped so it never over-stretches, and the leftover width
+          becomes a ruled central aisle between two anchored blocks — mass at
+          both edges instead of a one-sided void on wide screens. */}
+      <section
+        className={`${SHELL_GUTTER} pt-[clamp(1.8rem,3.2vw,3rem)] pb-[clamp(2.6rem,5vw,5.5rem)] work:grid work:grid-cols-[34ch_minmax(0,1fr)_minmax(0,68ch)_minmax(0,44ch)] work:items-stretch work:gap-x-[clamp(2.4rem,3vw,4rem)] ultra:max-w-[2160px] ultra:grid-cols-[38ch_minmax(0,1fr)_minmax(0,74ch)_minmax(0,48ch)]`}
+        aria-labelledby="guides-h"
+      >
+        <div className="work:col-start-1 work:flex work:flex-col">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>Guides</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
 
-        <div className="space-y-3">
-          <Heading as="h1" size="page-hero">
+          <Heading
+            as="h1"
+            size="page-hero"
+            id="guides-h"
+            className="mt-5 mb-4 max-w-[18ch]"
+          >
             Student loan guides
           </Heading>
-          <p className="max-w-2xl text-lead text-pretty text-muted-foreground">
-            In-depth guides to help you understand UK student loan repayment,
-            interest, and how it fits into your wider finances — every figure
-            sourced from the same GOV.UK data as the calculator.
+          <p className="mb-[1.1rem] max-w-[46ch] text-lead text-pretty text-muted-foreground">
+            In-depth guides to the questions graduates actually ask — how
+            repayment, interest, and write-off work, and how the loan fits into
+            your wider finances.
+          </p>
+          <p className="flex flex-wrap items-center gap-x-[0.65rem] gap-y-[0.4rem] pt-6 font-sans text-meta text-muted-foreground work:mt-auto">
+            <span className="font-bold text-primary">✓</span> Independent{" "}
+            <span className="text-faint">·</span> GOV.UK sourced{" "}
+            <span className="text-faint">·</span> Updated {UPDATED_LABEL}
           </p>
         </div>
-      </header>
 
-      <LinkIndex>
-        {GUIDES.map((guide) => {
-          const isNew =
-            guide.newUntil != null && new Date() < new Date(guide.newUntil);
-          return (
-            <LinkIndexRow
-              key={guide.slug}
-              href={`/guides/${guide.slug}`}
-              title={guide.title}
-              description={guide.description}
-              badge={isNew ? "New" : undefined}
-            />
-          );
-        })}
-      </LinkIndex>
-    </PageLayout>
+        {/* Index ledger: one column, scanned top to bottom, at every width —
+            never split into parallel columns. On large screens it is bounded
+            and given a full-height hairline right wall (work:border-r) so its
+            arrows square to the dek and the wall defines the central aisle. */}
+        <div className="mt-[clamp(1.8rem,3.2vw,2.8rem)] work:col-start-3 work:mt-0 work:border-r work:border-border work:pr-[clamp(1.5rem,2vw,2.25rem)]">
+          {GUIDES.map((guide) => {
+            const isNew =
+              guide.newUntil != null && new Date() < new Date(guide.newUntil);
+            return (
+              <Link
+                className="group grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-[clamp(1.25rem,3vw,3.5rem)] border-b border-border py-[clamp(1.1rem,1.9vw,1.9rem)] no-underline"
+                href={`/guides/${guide.slug}`}
+                key={guide.slug}
+              >
+                <span className="min-w-0">
+                  <span className="flex flex-wrap items-baseline gap-x-2.5 gap-y-1">
+                    <span className="text-index font-semibold tracking-[-0.011em] transition-colors duration-150 ease-[ease] group-hover:text-primary">
+                      {guide.title}
+                    </span>
+                    {isNew && (
+                      <span className="rounded-full bg-accent-wash px-2 py-0.5 text-xs font-semibold tracking-wide text-cta uppercase">
+                        New
+                      </span>
+                    )}
+                  </span>
+                  <span className="mt-[0.45rem] block max-w-[64ch] text-body text-pretty text-muted-foreground">
+                    {guide.description}
+                  </span>
+                </span>
+                <span
+                  className="text-lead text-primary transition-transform duration-150 ease-[ease] group-hover:translate-x-[3px]"
+                  aria-hidden="true"
+                >
+                  →
+                </span>
+              </Link>
+            );
+          })}
+        </div>
+
+        {/* Orientation rail (third zone): a right-anchored companion —
+            the anchor the homepage gets from its Readout, which this page
+            lacked. Wayfinding into the calculator plus a mono "by topic" ledger
+            give the far-right edge real, quiet mass. Below `work` it collapses
+            to a full-width closing strip. It holds no guides — the index stays
+            one column — so removing it leaves the list unchanged. */}
+        <aside className="mt-[clamp(2rem,4vw,3rem)] border-t border-border pt-[clamp(1.5rem,3vw,2rem)] work:col-start-4 work:mt-0 work:border-t-0 work:pt-0">
+          {/* Bracketed like the masthead — wayfinding at the top, the "by topic"
+              reference at the foot — so on large screens both outer columns
+              frame the index top-and-bottom instead of emptying out below a
+              short top-anchored block. */}
+          <div className="work:ml-auto work:flex work:h-full work:max-w-[42ch] work:flex-col work:justify-between ultra:max-w-[46ch]">
+            <div>
+              <p className="font-sans text-xs font-semibold tracking-label text-muted-foreground uppercase">
+                Where to start
+              </p>
+              <p className="mt-3 text-body text-pretty text-muted-foreground">
+                These guides unpack the figures the calculator produces — the
+                interest, the frozen thresholds, and the 2026 rule changes that
+                set what you actually repay.
+              </p>
+              <Link
+                href="/"
+                className="group mt-4 inline-flex items-baseline gap-1.5 text-cta no-underline"
+              >
+                <span className="text-body font-medium">
+                  Open the calculator
+                </span>
+                <span
+                  aria-hidden="true"
+                  className="transition-transform duration-150 ease-[ease] group-hover:translate-x-[3px]"
+                >
+                  →
+                </span>
+              </Link>
+            </div>
+
+            <div className="mt-[clamp(1.8rem,3vw,2.5rem)] work:mt-0">
+              <div className="border-t border-border pt-[clamp(1.1rem,1.8vw,1.5rem)]">
+                <p className="font-sans text-xs font-semibold tracking-label text-muted-foreground uppercase">
+                  By topic
+                </p>
+                <dl className="mt-3 space-y-2">
+                  {TOPIC_SUMMARY.map(({ label, count }) => (
+                    <div
+                      key={label}
+                      className="flex items-baseline justify-between gap-4 border-b border-border pb-2 last:border-b-0 last:pb-0"
+                    >
+                      <dt className="text-meta text-muted-foreground">
+                        {label}
+                      </dt>
+                      <dd className="font-mono text-fig-sm text-foreground tabular-nums">
+                        {count}
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+
+              <p className="mt-[clamp(1.1rem,1.8vw,1.5rem)] flex items-baseline gap-x-2 border-t border-border pt-3 text-meta text-faint">
+                <span className="font-mono text-fig-sm text-foreground tabular-nums">
+                  {GUIDES.length}
+                </span>{" "}
+                guides · GOV.UK sourced
+              </p>
+            </div>
+          </div>
+        </aside>
+      </section>
+    </WideLayout>
   );
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,11 +5,9 @@ import { Fold } from "@/components/home/instrument/Fold";
 import { LeversSection } from "@/components/home/instrument/LeversSection";
 import { RulesSection } from "@/components/home/instrument/RulesSection";
 import { ToolsSection } from "@/components/home/instrument/ToolsSection";
-import { Footer } from "@/components/layout/Footer";
-import { Header } from "@/components/layout/Header";
+import { WideLayout } from "@/components/layout/WideLayout";
 import { useLoanActions, useLoanConfigState } from "@/context/LoanContext";
 import type { InputMode } from "@/hooks/useInputPanelMode";
-import { SHELL_MAX } from "@/lib/layout";
 import { PlanFromQuery } from "./shared/PlanFromQuery";
 
 export function App() {
@@ -28,19 +26,12 @@ export function App() {
   }, [pendingQuizPlanTypes, updateField]);
 
   return (
-    <div className="flex min-h-dvh flex-col">
+    <WideLayout>
       <PlanFromQuery />
-      <Header wide />
-      <main
-        id="main-content"
-        className={`mx-auto w-full ${SHELL_MAX} flex-auto`}
-      >
-        <Fold initialMode={initialMode} />
-        <RulesSection />
-        <LeversSection />
-        <ToolsSection />
-      </main>
-      <Footer wide />
-    </div>
+      <Fold initialMode={initialMode} />
+      <RulesSection />
+      <LeversSection />
+      <ToolsSection />
+    </WideLayout>
   );
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -3,20 +3,16 @@ import { BrandLogo } from "@/components/brand/BrandLogo";
 import { Eyebrow } from "@/components/typography/Eyebrow";
 import { GUIDES } from "@/lib/guides";
 import { SHELL_WIDE } from "@/lib/layout";
-import { cn } from "@/lib/utils";
 
 const NAV_LINK_CLASS =
   "text-muted-foreground transition-colors hover:text-foreground";
 
-export function Footer({ wide = false }: { wide?: boolean }) {
+// Global chrome — always the full-bleed shell so the footer aligns with the
+// header and never shifts between page types (see Header for the rationale).
+export function Footer() {
   return (
     <footer className="border-t-2 border-rule bg-background">
-      <div
-        className={cn(
-          "mx-auto py-10 sm:py-12",
-          wide ? SHELL_WIDE : "max-w-4xl px-3",
-        )}
-      >
+      <div className={`mx-auto py-10 sm:py-12 ${SHELL_WIDE}`}>
         <div className="mb-10 flex flex-col gap-4 border-b pb-8 sm:flex-row sm:items-end sm:justify-between">
           <div className="space-y-3">
             <BrandLogo size="sm" />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,19 +1,20 @@
 import Link from "next/link";
 import { BrandLogo } from "@/components/brand/BrandLogo";
 import { SHELL_WIDE } from "@/lib/layout";
-import { cn } from "@/lib/utils";
 import { GovUkBadge } from "./GovUkBadge";
 import { ShareButton } from "./ShareButton";
 import { ThemeToggle } from "./ThemeToggle";
 
 interface HeaderProps {
   repaymentYear?: number;
-  /** Full-bleed shell (homepage): 3440px cap + fold gutter instead of the
-   *  default max-w-4xl reading column. */
-  wide?: boolean;
 }
 
-export function Header({ repaymentYear, wide = false }: HeaderProps) {
+// The header is global chrome: it is always the full-bleed shell (3440px cap +
+// fluid gutter) so the logo and controls sit in the exact same place on every
+// route. Page bodies vary their own width (PageLayout's reading column vs the
+// full-bleed WideLayout) — the header must not, or navigating between page
+// types would shift it.
+export function Header({ repaymentYear }: HeaderProps) {
   return (
     <div className="sticky top-0 z-50 border-b-2 border-rule bg-background/85 backdrop-blur-sm">
       <a
@@ -22,7 +23,7 @@ export function Header({ repaymentYear, wide = false }: HeaderProps) {
       >
         Skip to main content
       </a>
-      <div className={cn("mx-auto", wide ? SHELL_WIDE : "max-w-4xl px-3")}>
+      <div className={`mx-auto ${SHELL_WIDE}`}>
         <header className="flex items-center justify-between gap-3 py-3">
           <Link href="/" aria-label="Go to home page">
             <BrandLogo size="sm" />

--- a/src/components/layout/WideLayout.tsx
+++ b/src/components/layout/WideLayout.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+import { Footer } from "@/components/layout/Footer";
+import { Header } from "@/components/layout/Header";
+import { SHELL_MAX } from "@/lib/layout";
+
+/**
+ * The full-bleed Instrument shell: the wide sticky header, an ultra-wide-capped
+ * `<main>` that lets its section children own their fluid gutters and hairline
+ * seams, and the wide footer.
+ *
+ * This is the landing/index-page counterpart to {@link PageLayout} — where that
+ * is the narrow `max-w-4xl` reading column for prose and detail pages, this is
+ * the edge-to-edge shell the homepage uses. Index pages (the homepage `App`,
+ * the guides index) share it so the wide shell lives in exactly one place
+ * instead of being re-typed per page.
+ */
+export function WideLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-dvh flex-col">
+      <Header />
+      <main
+        id="main-content"
+        className={`mx-auto w-full ${SHELL_MAX} flex-auto`}
+      >
+        {children}
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/lib/guides.ts
+++ b/src/lib/guides.ts
@@ -9,10 +9,15 @@ export type GuideSlug =
   | "self-employment"
   | "interest-rate-cap";
 
+// A small, honest taxonomy derived only from the nine guide topics — it powers
+// the guides-index "by topic" summary rail, never per-row labels or grouping.
+export type GuideTopic = "Interest" | "Repayment" | "Life & money" | "Rules";
+
 export interface GuideEntry {
   slug: GuideSlug;
   title: string;
   description: string;
+  topic: GuideTopic;
   newUntil?: string;
 }
 
@@ -22,6 +27,7 @@ export const GUIDES: GuideEntry[] = [
     title: "Plan 2 Interest Rate Cap",
     description:
       "The government is capping Plan 2 interest at 6% from September 2026. What it means for your loan.",
+    topic: "Interest",
     newUntil: "2026-07-08",
   },
   {
@@ -29,6 +35,7 @@ export const GUIDES: GuideEntry[] = [
     title: "Threshold Freeze Explained",
     description:
       "How frozen repayment thresholds cost you more each month, and what the 2026 parliamentary inquiry means.",
+    topic: "Repayment",
     newUntil: "2026-06-01",
   },
   {
@@ -36,41 +43,48 @@ export const GUIDES: GuideEntry[] = [
     title: "Plan 2 vs Plan 5",
     description:
       "Compare lifetime repayment costs for pre- and post-2023 loans side by side.",
+    topic: "Repayment",
   },
   {
     slug: "student-loan-vs-mortgage",
     title: "Student Loans & Mortgages",
     description:
       "Does a student loan affect your mortgage? Affordability, income, your credit file, and whether to clear it first.",
+    topic: "Life & money",
   },
   {
     slug: "how-interest-works",
     title: "How Interest Works",
     description:
       "RPI, sliding scales, and why your balance can grow despite repayments.",
+    topic: "Interest",
   },
   {
     slug: "rpi-vs-cpi",
     title: "RPI vs CPI",
     description:
-      "Why your loan interest outpaces inflation and what \u2018adjusted for inflation\u2019 really means.",
+      "Why your loan interest outpaces inflation and what ‘adjusted for inflation’ really means.",
+    topic: "Interest",
   },
   {
     slug: "pay-upfront-or-take-loan",
     title: "Pay Upfront or Take the Loan?",
     description:
-      "When paying tuition upfront beats taking the loan, and when it doesn\u2019t.",
+      "When paying tuition upfront beats taking the loan, and when it doesn’t.",
+    topic: "Life & money",
   },
   {
     slug: "moving-abroad",
     title: "Moving Abroad",
     description:
-      "Country-specific thresholds, SLC obligations, and what happens if you don\u2019t comply.",
+      "Country-specific thresholds, SLC obligations, and what happens if you don’t comply.",
+    topic: "Rules",
   },
   {
     slug: "self-employment",
     title: "Self-Employment",
     description:
       "How Self Assessment changes your repayments and common mistakes to avoid.",
+    topic: "Rules",
   },
 ];


### PR DESCRIPTION
## Why

The recent "Instrument" redesign (#485) rebuilt the home page onto a full-bleed shell — left-rail masthead, fluid `clamp()` gutters, multi-column link rails — but stopped there. The `/guides` index was still on the old narrow, centered `PageLayout` (`max-w-4xl` reading column), so it looked nothing like the page it links back to. This brings the guides index onto the same shell, and pulls the wide shell out into one shared place while doing it.

## What changes

**Guides index rebuilt onto the Instrument shell.** It now renders as a full-bleed workspace section: a left-rail hero masthead (breadcrumb, page-hero heading, lead, and an "Independent · GOV.UK sourced · Updated <month year>" trust line mirroring the home hero) with a two-column link rail for the guides that intentionally matches the home page's "Go deeper" rail — the reference point for the redesign. JSON-LD schemas, breadcrumb, and the "New" badge are preserved.

**Shared `WideLayout` component.** The full-bleed landing/index-page counterpart to the narrow `PageLayout`. The home `App` was hand-rolling this shell inline; now both the home `App` and the guides index route through `WideLayout`, so the wide shell lives in one place instead of being duplicated per page.

**Header and Footer are now full-bleed unconditionally** (the per-page `wide` prop is gone). A header/footer that changes width between page types causes a jarring layout shift on navigation. As global chrome, they must be pixel-stable across every route — the logo and controls now sit in the exact same place on every page, and only each page's *content column* varies (narrow reading column via `PageLayout`, full-bleed via `WideLayout`). This benefits every consumer for free (the ~15 `PageLayout` pages, `which-plan`, the 404, plus home and guides).

```mermaid
graph TD
    Header["Header (full-bleed, always)"]
    Footer["Footer (full-bleed, always)"]
    Wide["WideLayout (full-bleed body)"]
    Narrow["PageLayout (narrow reading column)"]
    Header --- Wide
    Footer --- Wide
    Header --- Narrow
    Footer --- Narrow
    Wide --> Home["home (App)"]
    Wide --> Guides["/guides index"]
    Narrow --> Rest["~15 detail/prose pages, which-plan, 404"]
```

## Note

Not-yet-migrated narrow-body pages (guide articles, plans, overpay, etc.) now show full-bleed chrome above a narrow body — the standard full-width-nav pattern. This is a deliberate, intended tradeoff pending a future change that migrates those bodies to the wide shell, not a regression.