### PR TITLE
fix: readout caption tracks live rpi and threshold config

### DIFF
--- a/src/components/home/instrument/Readout.tsx
+++ b/src/components/home/instrument/Readout.tsx
@@ -6,13 +6,14 @@ import { Figure } from "@/components/typography/Figure";
 import { percentageFormatter } from "@/constants";
 import { usePersonalisedResults } from "@/context/PersonalisedResultsContext";
 import {
+  useApplyPlan2Freeze,
   useCurrentSalary,
   useLoanConfig,
+  useRpiRate,
   useSalaryGrowthRate,
   useThresholdGrowthRate,
 } from "@/hooks/useStoreSelectors";
 import { formatGBP, percentagesSummingTo100 } from "@/lib/format";
-import { CURRENT_RATES } from "@/lib/loans/plans";
 import { primaryPlanName } from "./planInfo";
 
 const SKEL_VIZ: React.CSSProperties = { height: "2.6rem", width: "100%" };
@@ -102,11 +103,23 @@ export function Readout({
   const { loans, underGradBalance, postGradBalance } = useLoanConfig();
   const salaryGrowthRate = useSalaryGrowthRate();
   const thresholdGrowthRate = useThresholdGrowthRate();
+  const applyPlan2Freeze = useApplyPlan2Freeze();
+  const rpiRate = useRpiRate();
 
   const planName = primaryPlanName(loans);
   const borrowed = underGradBalance + postGradBalance;
   const salaryGrowthPct = Math.round(salaryGrowthRate * 100);
-  const thresholdGrowthPct = Math.round(thresholdGrowthRate * 100);
+
+  // Mirror AssumptionsCallout: only Plan 2 threshold is frozen, and RPI tracks
+  // the user's configured rate rather than the static default.
+  const hasPlan2 = loans.some((l) => l.planType === "PLAN_2");
+  const thresholdLabel =
+    applyPlan2Freeze && hasPlan2
+      ? `frozen then +${(thresholdGrowthRate * 100).toFixed(0)}%/yr`
+      : thresholdGrowthRate === 0
+        ? "frozen"
+        : `+${(thresholdGrowthRate * 100).toFixed(0)}%/yr`;
+  const rpiLabel = `${rpiRate % 1 === 0 ? rpiRate.toFixed(0) : rpiRate.toFixed(1)}%`;
 
   const interest = cards?.interest ?? null;
   const rate = cards?.effectiveRate ?? null;
@@ -311,12 +324,8 @@ export function Readout({
         Modelled on{" "}
         <b className="font-semibold text-foreground">{salaryGrowthPct}%</b>{" "}
         salary growth, thresholds{" "}
-        <b className="font-semibold text-foreground">
-          frozen then +{thresholdGrowthPct}%/yr
-        </b>
-        , and{" "}
-        <b className="font-semibold text-foreground">{CURRENT_RATES.rpi}%</b>{" "}
-        RPI.{" "}
+        <b className="font-semibold text-foreground">{thresholdLabel}</b>, and{" "}
+        <b className="font-semibold text-foreground">{rpiLabel}</b> RPI.{" "}
         <button
           type="button"
           className="m-0 cursor-pointer appearance-none [border-width:0_0_1px] border-solid border-b-[color-mix(in_oklab,var(--primary)_38%,transparent)] p-0 whitespace-nowrap text-cta no-underline [background:none] [font:inherit] hover:[border-bottom-color:var(--primary)] focus-visible:rounded-[4px] focus-visible:[outline:2px_solid_var(--ring)] focus-visible:outline-offset-2"

--- a/src/hooks/useStoreSelectors.ts
+++ b/src/hooks/useStoreSelectors.ts
@@ -57,6 +57,12 @@ export function useThresholdGrowthRate(): number {
   return thresholdGrowthRate;
 }
 
+/** Select whether the Plan 2 threshold freeze is applied */
+export function useApplyPlan2Freeze(): boolean {
+  const { applyPlan2Freeze } = useLoanConfigState();
+  return applyPlan2Freeze;
+}
+
 /** Compute Plan 2 freeze schedule from the toggle state. Returns undefined when off. */
 export function usePlan2ThresholdSchedule(): number[] | undefined {
   const { applyPlan2Freeze, loans } = useLoanConfigState();


### PR DESCRIPTION
## Why

The homepage instrument's Readout renders a "Modelled on …" caption that is meant to state the assumptions behind the headline numbers. Two of its three figures did not track the user's actual configuration, so the caption could contradict the very cards it sits beneath:

- **RPI was hardcoded** to the `CURRENT_RATES.rpi` constant (3.2%) instead of the live rate. After a user opened "Tailor to you" and changed RPI, the cards recomputed at the new rate while the caption still claimed 3.2%.
- **The threshold clause always asserted a freeze** ("thresholds frozen then +N%/yr"), but the Plan 2 threshold freeze only applies to Plan 2. Selecting the Plan 1 or Plan 5 preset — both reachable from the homepage — left the caption asserting a freeze that wasn't modelled.

The sibling `AssumptionsCallout` already derives both figures correctly from config, confirming the Readout's version was an oversight rather than a deliberate default.

## What changed

The caption now reflects the same config the cards are computed from, mirroring `AssumptionsCallout`:

- RPI reads the live `rpiRate` via the existing `useRpiRate()` selector, formatted identically (integer rates show no decimal, otherwise one).
- The threshold clause is derived from the actual simulation gate: `applyPlan2Freeze && hasPlan2` → "frozen then +N%/yr"; else zero growth → "frozen"; else "+N%/yr".
- A new `useApplyPlan2Freeze()` store selector exposes the freeze toggle.

Visual treatment (bold figures, "Tailor to you" button) is unchanged.