### PR TITLE
fix: cue external references in link index open a new tab

### DIFF
--- a/src/components/instrument/LinkIndex.tsx
+++ b/src/components/instrument/LinkIndex.tsx
@@ -1,4 +1,7 @@
-import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import {
+  ArrowRight01Icon,
+  ArrowUpRight01Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
@@ -33,10 +36,12 @@ function RowInner({
   title,
   description,
   badge,
+  external,
 }: {
   title: React.ReactNode;
   description?: React.ReactNode;
   badge?: React.ReactNode;
+  external?: boolean;
 }) {
   return (
     <>
@@ -50,9 +55,14 @@ function RowInner({
           </span>
         )}
         <HugeiconsIcon
-          icon={ArrowRight01Icon}
-          className="ml-auto size-4 shrink-0 text-faint transition-[color,transform] group-hover:translate-x-0.5 group-hover:text-primary group-focus-visible:translate-x-0.5 group-focus-visible:text-primary"
+          icon={external ? ArrowUpRight01Icon : ArrowRight01Icon}
+          className={cn(
+            "ml-auto size-4 shrink-0 text-faint transition-[color,transform] group-hover:translate-x-0.5 group-hover:text-primary group-focus-visible:translate-x-0.5 group-focus-visible:text-primary",
+            external &&
+              "group-hover:-translate-y-0.5 group-focus-visible:-translate-y-0.5",
+          )}
         />
+        {external && <span className="sr-only"> (opens in a new tab)</span>}
       </div>
       {description != null && (
         <p className="text-sm text-muted-foreground">{description}</p>
@@ -83,7 +93,12 @@ export function LinkIndexRow({
         rel="noopener noreferrer"
         className={ROW_CLASS}
       >
-        <RowInner title={title} description={description} badge={badge} />
+        <RowInner
+          title={title}
+          description={description}
+          badge={badge}
+          external
+        />
       </a>
     );
   }


### PR DESCRIPTION
## Why

`LinkIndexRow`'s `external` branch renders `<a target="_blank" rel="noopener noreferrer">` but gave the reader no signal that the link leaves the site and opens in a new tab:

- **No accessible cue (WCAG 3.2.5).** Screen-reader users got no warning, so when focus landed in a new tab and Back stopped working they were left disoriented.
- **Visually indistinguishable from internal links.** The external branch reused the exact same right-pointing `ArrowRight01Icon` as internal Next.js `<Link>` rows, so an external gov.uk / parliament.uk reference looked identical to an in-site link.

This is live on 4 published guide pages — threshold-freeze, self-employment, moving-abroad, and student-loan-vs-mortgage — whose RelatedGuides "References" sections pass external `extraLinks`. The app already solves this correctly in `OurDataPage` ("Cross-check it yourself" uses an up-right `ArrowUpRight01Icon` plus a visually-hidden "(opens in a new tab)" span), confirming the missing treatment here was an oversight.

## What changed

External rows now follow the same `OurDataPage` convention:

- render `ArrowUpRight01Icon` (with a diagonal hover/focus translate) instead of the internal right arrow, so external links are visually distinct;
- append a visually-hidden " (opens in a new tab)" hint to the accessible name.

Internal-link rows and the `external` API surface consumed by RelatedGuides are unchanged; the whole change is contained to `LinkIndex.tsx` via an `external` flag threaded to the shared `RowInner`.