### PR TITLE
fix: surface threshold freeze guide faq to match its schema

### DIFF
--- a/src/app/guides/threshold-freeze/layout.tsx
+++ b/src/app/guides/threshold-freeze/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { thresholdFreezeFaqs } from "@/components/guides/threshold-freeze/faqs";
 
 export const metadata: Metadata = {
   title: "Student Loan Threshold Freeze Explained — What It Costs You",
@@ -51,40 +52,14 @@ const breadcrumbSchema = {
 const faqSchema = {
   "@context": "https://schema.org",
   "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "What is the student loan threshold freeze?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "The Chancellor announced the Plan 2 repayment threshold will freeze at £29,385 from April 2027 to April 2030. Normally thresholds rise with inflation, so freezing means graduates start repaying at a lower real salary and pay more each month.",
-      },
+  mainEntity: thresholdFreezeFaqs.map((faq) => ({
+    "@type": "Question",
+    name: faq.question,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: faq.answer,
     },
-    {
-      "@type": "Question",
-      name: "Which student loan plans are affected by the threshold freeze?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Plan 2 (2012-2023 borrowers) is directly affected with a 3-year freeze from 2027-28 to 2029-30. Plan 5 (2023+ borrowers) is not frozen — its £25,000 threshold starts rising with RPI from April 2027. Plan 1 and Plan 4 continue annual adjustments.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "How much more will I pay because of the threshold freeze?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Depends on salary. At £35,000, the freeze costs roughly £80-100 more per year compared to an inflation-linked threshold. Over the 3-year freeze, that adds up to several hundred pounds in extra repayments.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "What is the 2026 parliamentary inquiry into student loans?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "The Treasury Select Committee launched an inquiry on 12 March 2026 examining whether student loan repayment terms are fair, with particular focus on the threshold freeze and its impact on Plan 2 borrowers.",
-      },
-    },
-  ],
+  })),
 };
 
 const articleSchema = {

--- a/src/components/guides/threshold-freeze/ThresholdFreezeGuide.tsx
+++ b/src/components/guides/threshold-freeze/ThresholdFreezeGuide.tsx
@@ -3,6 +3,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { ChartFrame } from "@/components/instrument/ChartFrame";
+import { Panel } from "@/components/instrument/Panel";
 import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -11,6 +12,7 @@ import { PLAN_CONFIGS } from "@/lib/loans/plans";
 import { getCurrentTaxYearLabel } from "@/lib/taxYear";
 import { GuideArticle, guideLink } from "../guide-parts";
 import { CurrentThresholdsTable } from "./CurrentThresholdsTable";
+import { thresholdFreezeFaqs } from "./faqs";
 import { ThresholdComparisonChart } from "./ThresholdComparisonChart";
 
 // Historical thresholds — hardcoded because these are facts about specific
@@ -280,6 +282,25 @@ export function ThresholdFreezeGuide() {
               shape future threshold policy.
             </p>
           </div>
+        </section>
+
+        <section className="space-y-3">
+          <Heading as="h2" size="section">
+            Threshold Freeze: Frequently Asked Questions
+          </Heading>
+          <Panel
+            padding={false}
+            className="divide-y divide-border overflow-hidden"
+          >
+            {thresholdFreezeFaqs.map((faq) => (
+              <div key={faq.question} className="space-y-2 p-4 sm:p-5">
+                <p className="font-semibold text-foreground">{faq.question}</p>
+                <p className="text-sm text-muted-foreground sm:text-base">
+                  {faq.answer}
+                </p>
+              </div>
+            ))}
+          </Panel>
         </section>
 
         <section className="space-y-3">

--- a/src/components/guides/threshold-freeze/faqs.ts
+++ b/src/components/guides/threshold-freeze/faqs.ts
@@ -1,0 +1,32 @@
+export type ThresholdFreezeFaq = {
+  question: string;
+  answer: string;
+};
+
+// Single source of truth for the visible FAQ section in ThresholdFreezeGuide and
+// the FAQPage JSON-LD in layout.tsx, so the structured data can never drift from
+// what the page shows — Google requires FAQPage Q&A to be visible on the page.
+// Figures match the historical, hardcoded thresholds the guide narrates and are
+// not derived from the live config, which tracks the current tax year.
+export const thresholdFreezeFaqs: ThresholdFreezeFaq[] = [
+  {
+    question: "What is the student loan threshold freeze?",
+    answer:
+      "The Chancellor announced the Plan 2 repayment threshold will freeze at £29,385 from April 2027 to April 2030. Normally thresholds rise with inflation, so freezing means graduates start repaying at a lower real salary and pay more each month.",
+  },
+  {
+    question: "Which student loan plans are affected by the threshold freeze?",
+    answer:
+      "Plan 2 (2012-2023 borrowers) is directly affected with a 3-year freeze from 2027-28 to 2029-30. Plan 5 (2023+ borrowers) is not frozen — its £25,000 threshold starts rising with RPI from April 2027. Plan 1 and Plan 4 continue annual adjustments.",
+  },
+  {
+    question: "How much more will I pay because of the threshold freeze?",
+    answer:
+      "Depends on salary. At £35,000, the freeze costs roughly £80-100 more per year compared to an inflation-linked threshold. Over the 3-year freeze, that adds up to several hundred pounds in extra repayments.",
+  },
+  {
+    question: "What is the 2026 parliamentary inquiry into student loans?",
+    answer:
+      "The Treasury Select Committee launched an inquiry on 12 March 2026 examining whether student loan repayment terms are fair, with particular focus on the threshold freeze and its impact on Plan 2 borrowers.",
+  },
+];


### PR DESCRIPTION
## Why

The Threshold Freeze guide's `layout.tsx` injected a `FAQPage` JSON-LD block with 4 questions and answers, but `ThresholdFreezeGuide` rendered none of that Q&A visibly — the page was prose-only. Google's structured-data policy explicitly requires `FAQPage` questions and answers to be **visible to users on the page**. Emitting them only in invisible markup risks a manual action and, at best, produces no rich result.

The codebase already had the correct reference pattern: `MovingAbroadGuide` (with `overseas-data.ts`) and `PlanDetailPage` render a visible FAQ from a single-source array that also feeds the schema, so the structured data can't drift from what the page shows. This change mirrors that pattern for this one guide (kept contained — the ~sibling layouts with the same anti-pattern can follow later).

## What changed

- The 4 Q&As now live in a framework-agnostic data module (`src/components/guides/threshold-freeze/faqs.ts`, no `"use client"`).
- `ThresholdFreezeGuide` renders them as a visible, accessible FAQ section (a `<Heading>` section over `Panel` question/answer pairs, light/dark aware), following the moving-abroad markup.
- `layout.tsx` now builds `faqSchema.mainEntity` by mapping that same array, so the visible text and the JSON-LD are guaranteed identical.

The exact Q&A strings already present in the schema are reused verbatim — no new content invented. The answers are kept as literal copy rather than derived from live config on purpose: figures like the £25,000 Plan 5 threshold in the prose don't equal the rounded config-derived value, and they describe historical/announced facts. The single-source array (consumed by both the component and the layout) is what guarantees schema/visible parity, not the figures' provenance.