### PR TITLE
fix: render visible faq on interest-rate-cap guide

### DIFF
--- a/src/app/guides/interest-rate-cap/layout.tsx
+++ b/src/app/guides/interest-rate-cap/layout.tsx
@@ -1,8 +1,5 @@
 import type { Metadata } from "next";
-import {
-  TOTAL_YEARS,
-  YEARS_ABOVE_CAP,
-} from "@/components/guides/interest-rate-cap/historical-rates";
+import { interestRateCapFaqs } from "@/components/guides/interest-rate-cap/historical-rates";
 
 export const metadata: Metadata = {
   title: "Plan 2 Interest Rate Capped at 6% — What It Means for You",
@@ -56,32 +53,14 @@ const breadcrumbSchema = {
 const faqSchema = {
   "@context": "https://schema.org",
   "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "What is the Plan 2 student loan interest rate cap?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "From 1 September 2026, the maximum interest rate on Plan 2 and Plan 3 student loans will be capped at 6% for the 2026/27 academic year, regardless of what the RPI + 3% formula produces.",
-      },
+  mainEntity: interestRateCapFaqs.map((faq) => ({
+    "@type": "Question",
+    name: faq.question,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: faq.answer,
     },
-    {
-      "@type": "Question",
-      name: "How often has the Plan 2 interest rate exceeded 6%?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: `The maximum Plan 2 interest rate has exceeded 6% in ${String(YEARS_ABOVE_CAP)} out of ${String(TOTAL_YEARS)} academic years since Plan 2 was introduced in 2012. During the 2022-2024 inflation crisis, rates reached 7.7% even after prevailing market rate interventions.`,
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Does the 6% cap change my monthly student loan repayments?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "No. Monthly repayments are based on your income (9% of earnings above the threshold), not the interest rate. The cap only affects how fast your outstanding balance grows.",
-      },
-    },
-  ],
+  })),
 };
 
 const articleSchema = {

--- a/src/components/guides/interest-rate-cap/InterestRateCapGuide.tsx
+++ b/src/components/guides/interest-rate-cap/InterestRateCapGuide.tsx
@@ -1,5 +1,6 @@
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { ChartFrame } from "@/components/instrument/ChartFrame";
+import { Panel } from "@/components/instrument/Panel";
 import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import { formatGBP, formatPercent } from "@/lib/format";
@@ -8,7 +9,11 @@ import { getCurrentTaxYearLabel } from "@/lib/taxYear";
 import { GuideArticle, KeyTakeaways } from "../guide-parts";
 import { BalanceWithCapChart } from "./BalanceWithCapChart";
 import { CurrentCapTable } from "./CurrentCapTable";
-import { TOTAL_YEARS, YEARS_ABOVE_CAP } from "./historical-rates";
+import {
+  interestRateCapFaqs,
+  TOTAL_YEARS,
+  YEARS_ABOVE_CAP,
+} from "./historical-rates";
 import { HistoricalRatesChart } from "./HistoricalRatesChart";
 import { TotalCostComparisonChart } from "./TotalCostComparisonChart";
 
@@ -278,6 +283,25 @@ export function InterestRateCapGuide() {
             extended.
           </li>
         </KeyTakeaways>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Interest Rate Cap: Frequently Asked Questions
+          </Heading>
+          <Panel
+            padding={false}
+            className="divide-y divide-border overflow-hidden"
+          >
+            {interestRateCapFaqs.map((faq) => (
+              <div key={faq.question} className="space-y-2 p-4 sm:p-5">
+                <p className="font-semibold text-foreground">{faq.question}</p>
+                <p className="text-sm text-muted-foreground sm:text-base">
+                  {faq.answer}
+                </p>
+              </div>
+            ))}
+          </Panel>
+        </section>
 
         <RelatedGuides
           current="interest-rate-cap"

--- a/src/components/guides/interest-rate-cap/historical-rates.ts
+++ b/src/components/guides/interest-rate-cap/historical-rates.ts
@@ -27,3 +27,29 @@ export const YEARS_ABOVE_CAP = HISTORICAL_RATES.filter(
 ).length;
 
 export const TOTAL_YEARS = HISTORICAL_RATES.length;
+
+export type InterestRateCapFaq = {
+  question: string;
+  answer: string;
+};
+
+// Single source of truth for the visible FAQ and the FAQPage JSON-LD in
+// layout.tsx, so the structured data can never drift from what the page shows.
+// The YEARS_ABOVE_CAP / TOTAL_YEARS interpolation stays derived from
+// HISTORICAL_RATES above.
+export const interestRateCapFaqs: InterestRateCapFaq[] = [
+  {
+    question: "What is the Plan 2 student loan interest rate cap?",
+    answer:
+      "From 1 September 2026, the maximum interest rate on Plan 2 and Plan 3 student loans will be capped at 6% for the 2026/27 academic year, regardless of what the RPI + 3% formula produces.",
+  },
+  {
+    question: "How often has the Plan 2 interest rate exceeded 6%?",
+    answer: `The maximum Plan 2 interest rate has exceeded 6% in ${String(YEARS_ABOVE_CAP)} out of ${String(TOTAL_YEARS)} academic years since Plan 2 was introduced in 2012. During the 2022-2024 inflation crisis, rates reached 7.7% even after prevailing market rate interventions.`,
+  },
+  {
+    question: "Does the 6% cap change my monthly student loan repayments?",
+    answer:
+      "No. Monthly repayments are based on your income (9% of earnings above the threshold), not the interest rate. The cap only affects how fast your outstanding balance grows.",
+  },
+];


### PR DESCRIPTION
## Why

The interest-rate-cap guide's `layout.tsx` injected a `FAQPage` JSON-LD block (3 Q&As) into the page, but the guide component rendered **none** of that Q&A visibly — the topics were only touched on in prose. Google's structured-data policy requires FAQ content in `FAQPage` markup to be **visible to users**; hidden FAQ markup risks a manual action, yields no rich result, and gives the reader nothing. This is a direct follow-up to #506, which applied the identical fix to the threshold-freeze guide, and follows the in-repo moving-abroad reference pattern.

## What changed

The Q&A text now lives in a single `interestRateCapFaqs` array in `historical-rates.ts` (already imported by both the layout and the guide, and the owner of the `YEARS_ABOVE_CAP` / `TOTAL_YEARS` figures interpolated into answer #2):

- `layout.tsx` builds the `FAQPage` `mainEntity` by mapping over that array instead of hardcoding the answer strings.
- `InterestRateCapGuide.tsx` renders a visible "Frequently Asked Questions" section from the same array (just before `RelatedGuides`), mirroring the markup MovingAbroadGuide already uses.

Because both the structured data and the on-page section read from one source, the visible text and the JSON-LD are guaranteed identical and can never drift — and the historical-rate interpolation stays derived from `HISTORICAL_RATES`.

No new copy was authored; the exact Q&A strings previously inlined in the schema were reused verbatim.