### PR TITLE
fix: render visible faq on self-employment guide

### DIFF
--- a/src/app/guides/self-employment/layout.tsx
+++ b/src/app/guides/self-employment/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { PLAN_CONFIGS } from "@/lib/loans/plans";
+import { selfEmploymentFaqs } from "@/components/guides/self-employment/faqs";
 
 export const metadata: Metadata = {
   title: "Self-Employed? Your Student Loan Repayments Work Differently",
@@ -53,32 +53,14 @@ const breadcrumbSchema = {
 const faqSchema = {
   "@context": "https://schema.org",
   "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "How do I repay my student loan if I'm self-employed?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "If you're self-employed, you repay your student loan through your annual Self Assessment tax return rather than automatic PAYE deductions. HMRC calculates what you owe based on your net profit, and you pay it as part of your tax bill — typically in two lump-sum payments in January and July.",
-      },
+  mainEntity: selfEmploymentFaqs.map((faq) => ({
+    "@type": "Question",
+    name: faq.question,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: faq.answer,
     },
-    {
-      "@type": "Question",
-      name: "Do I pay student loan through Self Assessment?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: `Yes. Self-employed borrowers repay their student loan through Self Assessment. Your repayment is calculated at ${String(PLAN_CONFIGS.PLAN_2.repaymentRate * 100)}% (Plan 2 and Plan 5) of your profit above the repayment threshold and is included in your tax bill alongside income tax and National Insurance.`,
-      },
-    },
-    {
-      "@type": "Question",
-      name: "What happens if I have both PAYE and self-employment income?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "If you have mixed income, HMRC collects student loan repayments through both mechanisms. Your employer deducts repayments from your salary via PAYE, and your Self Assessment tops up the difference based on your combined total income.",
-      },
-    },
-  ],
+  })),
 };
 
 const articleSchema = {

--- a/src/components/guides/self-employment/SelfEmploymentGuide.tsx
+++ b/src/components/guides/self-employment/SelfEmploymentGuide.tsx
@@ -8,6 +8,8 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
+import { selfEmploymentFaqs } from "@/components/guides/self-employment/faqs";
+import { Panel } from "@/components/instrument/Panel";
 import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
@@ -313,6 +315,25 @@ export function SelfEmploymentGuide() {
             .
           </li>
         </KeyTakeaways>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            Self-Employment: Frequently Asked Questions
+          </Heading>
+          <Panel
+            padding={false}
+            className="divide-y divide-border overflow-hidden"
+          >
+            {selfEmploymentFaqs.map((faq) => (
+              <div key={faq.question} className="space-y-2 p-4 sm:p-5">
+                <p className="font-semibold text-foreground">{faq.question}</p>
+                <p className="text-sm text-muted-foreground sm:text-base">
+                  {faq.answer}
+                </p>
+              </div>
+            ))}
+          </Panel>
+        </section>
 
         <RelatedGuides
           current="self-employment"

--- a/src/components/guides/self-employment/faqs.ts
+++ b/src/components/guides/self-employment/faqs.ts
@@ -1,0 +1,25 @@
+import { PLAN_CONFIGS } from "@/lib/loans/plans";
+
+export type SelfEmploymentFaq = {
+  question: string;
+  answer: string;
+};
+
+// Single source of truth for the visible FAQ and the FAQPage JSON-LD in
+// layout.tsx, so the structured data can never drift from what the page shows.
+export const selfEmploymentFaqs: SelfEmploymentFaq[] = [
+  {
+    question: "How do I repay my student loan if I'm self-employed?",
+    answer:
+      "If you're self-employed, you repay your student loan through your annual Self Assessment tax return rather than automatic PAYE deductions. HMRC calculates what you owe based on your net profit, and you pay it as part of your tax bill — typically in two lump-sum payments in January and July.",
+  },
+  {
+    question: "Do I pay student loan through Self Assessment?",
+    answer: `Yes. Self-employed borrowers repay their student loan through Self Assessment. Your repayment is calculated at ${String(PLAN_CONFIGS.PLAN_2.repaymentRate * 100)}% (Plan 2 and Plan 5) of your profit above the repayment threshold and is included in your tax bill alongside income tax and National Insurance.`,
+  },
+  {
+    question: "What happens if I have both PAYE and self-employment income?",
+    answer:
+      "If you have mixed income, HMRC collects student loan repayments through both mechanisms. Your employer deducts repayments from your salary via PAYE, and your Self Assessment tops up the difference based on your combined total income.",
+  },
+];


### PR DESCRIPTION
## Why

`src/app/guides/self-employment/layout.tsx` injects a `FAQPage` JSON-LD block with three Q&As, but the guide page rendered none of them as a visible on-page Q&A block — the topics only appeared scattered through the prose. Google's structured-data policy requires FAQ content in `FAQPage` markup to be visible to users on the page. Hidden FAQ markup risks a manual action, produces no rich result, and gives readers no benefit.

This is the same systemic issue already fixed for the moving-abroad guide (reference implementation), `PlanDetailPage`, and the two preceding auto-improve fixes — threshold-freeze (#506) and interest-rate-cap (#507). Self-employment was the next un-fixed sibling.

## What changed

The three exact question/answer strings that already lived in the schema are now the shipped copy — no new copy was authored. They move into a single-source module, `src/components/guides/self-employment/faqs.ts`, exporting `selfEmploymentFaqs`. Both consumers read from it:

- **`layout.tsx`** builds `faqSchema.mainEntity` by mapping over the array, so the emitted JSON-LD is byte-for-byte equivalent to before.
- **`SelfEmploymentGuide.tsx`** renders a visible "Self-Employment: Frequently Asked Questions" section from the same array, placed after Key Takeaways and before Related Guides.

The second answer still derives its repayment rate from `PLAN_CONFIGS.PLAN_2.repaymentRate`, matching the previous schema behaviour. A single source of truth means the structured data and the visible page can never drift.

Consistent with the just-shipped inline per-guide pattern, no shared FAQ component was introduced, and the section matches sibling guides' light/dark styling.

```mermaid
flowchart LR
  F["faqs.ts<br/>selfEmploymentFaqs"] --> S["layout.tsx<br/>FAQPage JSON-LD"]
  F --> V["SelfEmploymentGuide.tsx<br/>visible FAQ section"]
```