### PR TITLE
fix: render visible faq on rpi-vs-cpi guide

### DIFF
--- a/src/app/guides/rpi-vs-cpi/layout.tsx
+++ b/src/app/guides/rpi-vs-cpi/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { CURRENT_RATES } from "@/lib/loans/plans";
+import { rpiVsCpiFaqs } from "@/components/guides/rpi-vs-cpi/faqs";
 
 export const metadata: Metadata = {
   title: "RPI vs CPI: Why Your Student Loan Interest Outpaces Inflation",
@@ -51,32 +51,14 @@ const breadcrumbSchema = {
 const faqSchema = {
   "@context": "https://schema.org",
   "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "What is the difference between RPI and CPI for student loans?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: `RPI (Retail Prices Index) includes housing costs and uses an arithmetic mean formula, while CPI (Consumer Prices Index) excludes housing costs and uses a geometric mean. Student loan interest is tied to RPI, which currently sits at ${String(CURRENT_RATES.rpi)}%. CPI, the Bank of England's target measure, sits lower at around 2%. This means your loan interest is based on the higher measure.`,
-      },
+  mainEntity: rpiVsCpiFaqs.map((faq) => ({
+    "@type": "Question",
+    name: faq.question,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: faq.answer,
     },
-    {
-      "@type": "Question",
-      name: "Why does my student loan interest seem higher than inflation?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Your loan interest is tied to RPI, which historically runs 0.5-1 percentage points higher than CPI (the measure most people think of as 'inflation'). On top of that, some plans add up to 3% on top of RPI. So even Plan 5's 'inflation-only' rate exceeds general inflation as measured by CPI.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "What does 'adjusted for inflation' mean in the student loan calculator?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "When you toggle 'Adjust for inflation' in the calculator, it discounts future values by CPI (approximately 2%) to show amounts in today's money. This does not use RPI. Any growth that remains after toggling represents the real above-inflation cost of the loan.",
-      },
-    },
-  ],
+  })),
 };
 
 const articleSchema = {

--- a/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
+++ b/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
@@ -1,11 +1,13 @@
 import Link from "next/link";
 import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { ChartFrame } from "@/components/instrument/ChartFrame";
+import { Panel } from "@/components/instrument/Panel";
 import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import { formatPercent } from "@/lib/format";
 import { CURRENT_RATES } from "@/lib/loans/plans";
 import { GuideArticle, guideLink, KeyTakeaways } from "../guide-parts";
+import { rpiVsCpiFaqs } from "./faqs";
 import { InflationComparisonChart } from "./InflationComparisonChart";
 
 const rpi = CURRENT_RATES.rpi;
@@ -241,6 +243,25 @@ export function RpiVsCpiGuide() {
             .
           </li>
         </KeyTakeaways>
+
+        <section className="space-y-4">
+          <Heading as="h2" size="section">
+            RPI vs CPI: Frequently Asked Questions
+          </Heading>
+          <Panel
+            padding={false}
+            className="divide-y divide-border overflow-hidden"
+          >
+            {rpiVsCpiFaqs.map((faq) => (
+              <div key={faq.question} className="space-y-2 p-4 sm:p-5">
+                <p className="font-semibold text-foreground">{faq.question}</p>
+                <p className="text-sm text-muted-foreground sm:text-base">
+                  {faq.answer}
+                </p>
+              </div>
+            ))}
+          </Panel>
+        </section>
 
         <RelatedGuides
           current="rpi-vs-cpi"

--- a/src/components/guides/rpi-vs-cpi/faqs.ts
+++ b/src/components/guides/rpi-vs-cpi/faqs.ts
@@ -1,0 +1,27 @@
+import { CURRENT_RATES } from "@/lib/loans/plans";
+
+export type RpiVsCpiFaq = {
+  question: string;
+  answer: string;
+};
+
+// Single source of truth for the visible FAQ and the FAQPage JSON-LD in
+// layout.tsx, so the structured data can never drift from what the page shows.
+// Answer #1 derives the live RPI figure from CURRENT_RATES.rpi (plans.ts).
+export const rpiVsCpiFaqs: RpiVsCpiFaq[] = [
+  {
+    question: "What is the difference between RPI and CPI for student loans?",
+    answer: `RPI (Retail Prices Index) includes housing costs and uses an arithmetic mean formula, while CPI (Consumer Prices Index) excludes housing costs and uses a geometric mean. Student loan interest is tied to RPI, which currently sits at ${String(CURRENT_RATES.rpi)}%. CPI, the Bank of England's target measure, sits lower at around 2%. This means your loan interest is based on the higher measure.`,
+  },
+  {
+    question: "Why does my student loan interest seem higher than inflation?",
+    answer:
+      "Your loan interest is tied to RPI, which historically runs 0.5-1 percentage points higher than CPI (the measure most people think of as 'inflation'). On top of that, some plans add up to 3% on top of RPI. So even Plan 5's 'inflation-only' rate exceeds general inflation as measured by CPI.",
+  },
+  {
+    question:
+      "What does 'adjusted for inflation' mean in the student loan calculator?",
+    answer:
+      "When you toggle 'Adjust for inflation' in the calculator, it discounts future values by CPI (approximately 2%) to show amounts in today's money. This does not use RPI. Any growth that remains after toggling represents the real above-inflation cost of the loan.",
+  },
+];


### PR DESCRIPTION
## Why

The RPI vs CPI guide's `layout.tsx` injects a `FAQPage` JSON-LD block with three Q&As, but the page rendered none of them visibly — the guide covered the topics only in prose and ended at `RelatedGuides`. Google's structured-data policy requires FAQ content in `FAQPage` markup to be visible to users on the page; hidden FAQ markup earns no rich result and risks a manual action.

This is the next un-fixed sibling of the systemic hidden-FAQ vein, following the same fix already shipped for the threshold-freeze (#506), interest-rate-cap (#507), and self-employment (#508) guides, and mirroring the in-repo `moving-abroad` reference pattern.

## What changed

- A new single-source module `src/components/guides/rpi-vs-cpi/faqs.ts` exports `rpiVsCpiFaqs` — the three Q&As verbatim from the old schema, with answer #1 deriving the live RPI figure from `CURRENT_RATES.rpi`.
- `layout.tsx` now maps `rpiVsCpiFaqs` into `faqSchema.mainEntity` instead of hardcoding the Question/Answer objects. The emitted JSON-LD is byte-for-byte equivalent to before.
- `RpiVsCpiGuide.tsx` renders a visible "RPI vs CPI: Frequently Asked Questions" section (`Panel` with `divide-y`) immediately before `RelatedGuides`, so every question in the schema now appears on-page.

Both the JSON-LD and the visible section read from the same array, so the structured data can never drift from what the page shows. No shared FAQ component is introduced — this stays consistent with the inline per-guide pattern of the shipped siblings.
