### PR TITLE
fix: make principal/interest chart palette colour-blind-safe

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -231,7 +231,9 @@
   /* Categorical DATA colours (dark) — same roles, lifted for the dark surface.
      Validated CVD-safe by colour alone (worst-case ΔE 14). Not the brand tokens. */
   --chart-principal: #33ac75; /* Principal / good — spruce, lifted for dark */
-  --chart-interest: #ab4721; /* Interest / cost — clay, lifted for dark */
+  --chart-interest: #dd7438; /* Interest / cost — clay lifted to a readable coral
+    for dark: the dark clay was a fine bar fill but only ~3:1 as text on the dark
+    surface; this clears 4.5:1 for text and still holds CVD ΔE ~8 vs the green. */
   --chart-1: var(--chart-principal);
   --chart-2: var(--chart-interest);
   --chart-3: #5cc0a0;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,6 +41,8 @@
   --color-chart-4: var(--chart-4);
   --color-chart-5: var(--chart-5);
   --color-chart-overpay-baseline: var(--chart-overpay-baseline);
+  --color-chart-principal: var(--chart-principal);
+  --color-chart-interest: var(--chart-interest);
   --color-status-info: var(--status-info);
   --color-status-info-foreground: var(--status-info-foreground);
   --color-status-info-border: var(--status-info-border);
@@ -141,7 +143,9 @@
   /* Instrument accents */
   --cta: #094a37; /* accent-ink — links & CTA text */
   --rule: #131b18; /* ink — nameplate & footer 2px border */
-  --signal: #a8482f; /* brick — the costly peak, used sparingly */
+  --signal: var(
+    --chart-interest
+  ); /* cost accent = the Interest data clay (was brick) */
 
   --faint: #656e68; /* fine print, one step below soft */
   --axis: #6c756f; /* chart axis text */
@@ -154,12 +158,20 @@
   --elev-2:
     0 1px 0 rgba(19, 27, 24, 0.04), 0 18px 40px -28px rgba(19, 27, 24, 0.24);
 
-  --chart-1: #0c5c44; /* spruce — primary series */
-  --chart-2: #a8482f; /* brick — cost / interest */
+  /* Categorical DATA colours — colour-blind-safe. Principal is a lifted cool
+     spruce kept SEPARATE from the chrome --primary (so lifting it for data never
+     touches button/CTA/focus contrast). Interest is a dark earthy clay; --signal
+     (the brand cost accent) points at it below, so every cost surface stays one
+     colour. A wide luminance gap + distinct hue keep the pair separable under
+     deuteranopia/protanopia by colour alone (validated: worst-case CVD ΔE 16). */
+  --chart-principal: #2b9667; /* Principal / good — cool spruce, data-lifted */
+  --chart-interest: #8b3014; /* Interest / cost — dark earthy clay (drives --signal) */
+  --chart-1: var(--chart-principal); /* primary series = Principal */
+  --chart-2: var(--chart-interest); /* second series = Interest */
   --chart-3: #3f8f74; /* mid spruce */
   --chart-4: #094a37; /* deep spruce */
   --chart-5: #6c756f; /* axis grey — baseline series */
-  --chart-overpay-baseline: #a8482f;
+  --chart-overpay-baseline: var(--chart-interest);
 
   /* Status: bright semantic utility tokens — deliberately outside the two-colour thesis */
   --status-info-foreground: oklch(0.546 0.245 262.881); /* blue-600 */
@@ -203,7 +215,9 @@
 
   --cta: #50c99f; /* accent-ink, lifted */
   --rule: #e7eeea; /* ink divider reads light on dark */
-  --signal: #e0836a; /* brick, lifted */
+  --signal: var(
+    --chart-interest
+  ); /* cost accent = Interest data clay, lifted */
 
   --faint: #808983;
   --axis: #7e877f;
@@ -214,12 +228,16 @@
   --elev-1: 0 1px 0 rgba(0, 0, 0, 0.3), 0 22px 46px -34px rgba(0, 0, 0, 0.6);
   --elev-2: 0 1px 0 rgba(0, 0, 0, 0.35), 0 26px 52px -30px rgba(0, 0, 0, 0.72);
 
-  --chart-1: #34b08a;
-  --chart-2: #e0836a;
+  /* Categorical DATA colours (dark) — same roles, lifted for the dark surface.
+     Validated CVD-safe by colour alone (worst-case ΔE 14). Not the brand tokens. */
+  --chart-principal: #33ac75; /* Principal / good — spruce, lifted for dark */
+  --chart-interest: #ab4721; /* Interest / cost — clay, lifted for dark */
+  --chart-1: var(--chart-principal);
+  --chart-2: var(--chart-interest);
   --chart-3: #5cc0a0;
   --chart-4: #50c99f;
   --chart-5: #7e877f;
-  --chart-overpay-baseline: #e0836a;
+  --chart-overpay-baseline: var(--chart-interest);
 
   --status-info-foreground: oklch(0.707 0.165 254.624); /* blue-400 */
   --status-info: oklch(0.282 0.091 267.935 / 30%); /* blue-950 */

--- a/src/components/detail/InterestBreakdownChart.tsx
+++ b/src/components/detail/InterestBreakdownChart.tsx
@@ -17,7 +17,7 @@ const chartConfig = {
   },
   principalPortion: {
     label: "Principal",
-    color: "var(--primary)",
+    color: "var(--chart-principal)",
   },
 } satisfies ChartConfig;
 

--- a/src/components/detail/InterestDetailPage.tsx
+++ b/src/components/detail/InterestDetailPage.tsx
@@ -42,7 +42,7 @@ export function InterestDetailPage() {
 
   const legend: ChartLegendItem[] = result
     ? [
-        { label: "Principal", color: "var(--primary)" },
+        { label: "Principal", color: "var(--chart-principal)" },
         { label: "Interest", color: "var(--signal)" },
       ]
     : [];

--- a/src/components/detail/OutcomeBadge.tsx
+++ b/src/components/detail/OutcomeBadge.tsx
@@ -12,8 +12,9 @@ interface OutcomeBadgeProps {
 
 /**
  * A flat Instrument status chip: a hairline-ruled pill with an engraved sans
- * label and a single tonal dot — spruce for a positive outcome (paid in full),
- * brick for a caution (written off). No filled status backgrounds, no rounded
+ * label and a single tonal dot — the Principal data green for a positive outcome
+ * (paid in full), the Interest clay for a caution (written off). No filled status
+ * backgrounds, no rounded
  * Ledger badge — the meaning rides on the dot and the word.
  */
 export function OutcomeBadge({ conditions }: OutcomeBadgeProps) {
@@ -26,7 +27,9 @@ export function OutcomeBadge({ conditions }: OutcomeBadgeProps) {
         aria-hidden="true"
         className={cn(
           "size-1.5 shrink-0 rounded-full",
-          match.variant === "warning" ? "bg-signal" : "bg-primary",
+          match.variant === "warning"
+            ? "bg-chart-interest"
+            : "bg-chart-principal",
         )}
       />
       {match.label}

--- a/src/components/detail/RepaidHeroStats.tsx
+++ b/src/components/detail/RepaidHeroStats.tsx
@@ -28,7 +28,7 @@ export function RepaidHeroStats({
       <MetricCell label="Total repaid" value={totalRepaid} tone="emphasis">
         <Sparkline
           data={sparkline}
-          color="var(--primary)"
+          color="var(--chart-principal)"
           ariaLabel={`Cumulative repayments, totalling ${totalRepaid}`}
         />
       </MetricCell>

--- a/src/components/home/instrument/ChartInsight.tsx
+++ b/src/components/home/instrument/ChartInsight.tsx
@@ -37,7 +37,7 @@ export function ChartInsight() {
           dot centres on the first line of the title and stays there however the
           content below it wraps. */}
       <span className="flex h-5 flex-none items-center" aria-hidden="true">
-        <span className="size-2 rounded-full bg-primary group-data-[tone=cost]:[background:var(--signal)]" />
+        <span className="size-2 rounded-full bg-chart-principal group-data-[tone=cost]:[background:var(--chart-interest)]" />
       </span>
       <div className="flex min-w-0 flex-1 flex-wrap items-baseline justify-between gap-x-3.5 gap-y-1.5">
         <p className="m-0 font-sans text-sm font-semibold text-foreground">

--- a/src/components/home/instrument/LeversSection.tsx
+++ b/src/components/home/instrument/LeversSection.tsx
@@ -20,13 +20,13 @@ export function LeversSection() {
     >
       <div className="mt-[clamp(1.6rem,2.4vw,2.4rem)] grid grid-cols-1 gap-x-[clamp(2rem,3vw,3.5rem)] gap-y-[clamp(1.8rem,2.4vw,2.6rem)] roomy:grid-cols-3 work:mt-0">
         {levers.map((lever) => {
-          // Down (saves) reads spruce; up (costs) reads brick — the exact
-          // colours from the former `.delta.down`/`.up` and `.bar>i.down`/`.up`
-          // rules, now derived from the datum instead of a scoped class.
+          // Down (saves) reads the Principal data green; up (costs) reads the
+          // Interest clay — the CVD-safe data pair (text-signal resolves to the
+          // same clay via --signal), derived from the datum, not a scoped class.
           const deltaColor =
-            lever.direction === "down" ? "text-primary" : "text-signal";
+            lever.direction === "down" ? "text-chart-principal" : "text-signal";
           const barColor =
-            lever.direction === "down" ? "bg-primary" : "bg-signal";
+            lever.direction === "down" ? "bg-chart-principal" : "bg-signal";
           return (
             <div key={lever.name}>
               <div className="mb-[0.4rem] flex items-baseline justify-between gap-[0.8rem]">

--- a/src/components/home/instrument/LeversSection.tsx
+++ b/src/components/home/instrument/LeversSection.tsx
@@ -20,11 +20,12 @@ export function LeversSection() {
     >
       <div className="mt-[clamp(1.6rem,2.4vw,2.4rem)] grid grid-cols-1 gap-x-[clamp(2rem,3vw,3.5rem)] gap-y-[clamp(1.8rem,2.4vw,2.6rem)] roomy:grid-cols-3 work:mt-0">
         {levers.map((lever) => {
-          // Down (saves) reads the Principal data green; up (costs) reads the
-          // Interest clay — the CVD-safe data pair (text-signal resolves to the
-          // same clay via --signal), derived from the datum, not a scoped class.
+          // Down (saves) reads the brand spruce (--primary is dark enough for
+          // AA text on card); up (costs) reads the Interest clay via --signal.
+          // The 4px bar underneath uses the lifted chart-principal fill — that
+          // passes non-text 3:1 without needing to satisfy 4.5:1 text contrast.
           const deltaColor =
-            lever.direction === "down" ? "text-chart-principal" : "text-signal";
+            lever.direction === "down" ? "text-primary" : "text-signal";
           const barColor =
             lever.direction === "down" ? "bg-chart-principal" : "bg-signal";
           return (

--- a/src/components/home/instrument/Readout.tsx
+++ b/src/components/home/instrument/Readout.tsx
@@ -68,7 +68,7 @@ function InterestVizSkeleton() {
   return (
     <div aria-hidden className="mt-auto animate-[slsFade_.6s_ease_both]">
       <div className="h-3 rounded-full bg-muted [box-shadow:inset_0_0_0_1px_var(--border)]" />
-      <div className="mt-[0.55rem] hidden flex-col gap-y-2 md:flex">
+      <div className="mt-[0.55rem] flex flex-col gap-y-2">
         <div className="flex flex-wrap justify-between gap-x-4 gap-y-2">
           <LegendChipSkeleton label="Principal" />
           <LegendChipSkeleton label="Interest" />
@@ -185,7 +185,7 @@ export function Readout({ onTailor }: { onTailor: () => void }) {
             <div className="mt-auto">
               <Sparkline
                 data={cards.cumulative.data}
-                color="var(--primary)"
+                color="var(--chart-principal)"
                 ariaLabel={`Total repaid: ${cards.cumulative.stat}`}
               />
             </div>
@@ -217,7 +217,7 @@ export function Readout({ onTailor }: { onTailor: () => void }) {
             <div className="mt-auto">
               <Sparkline
                 data={cards.balance.data}
-                color="var(--primary)"
+                color="var(--chart-principal)"
                 ariaLabel={`Payoff timeline: ${cards.balance.stat}`}
               />
             </div>
@@ -253,7 +253,7 @@ export function Readout({ onTailor }: { onTailor: () => void }) {
                 aria-label={`Of ${interest.stat} repaid, ${String(interestPct)}% is interest and ${String(principalPct)}% is principal${writtenOffRatio > 0 ? `, with ${String(writtenOffPct)}% written off` : ""}.`}
               >
                 <i
-                  className="h-full bg-primary [transition:width_0.4s_cubic-bezier(0.22,1,0.36,1)]"
+                  className="h-full bg-chart-principal [transition:width_0.4s_cubic-bezier(0.22,1,0.36,1)]"
                   style={{ width: `${String(principalRatio * 100)}%` }}
                 />
                 <i
@@ -270,10 +270,10 @@ export function Readout({ onTailor }: { onTailor: () => void }) {
               {/* Two fixed rows: Principal/Interest, then Written off — always
                   shown (0% when nothing is written off) so the card keeps a
                   constant height and the equalised grid row never shifts. */}
-              <div className="mt-[0.55rem] hidden flex-col gap-y-2 md:flex">
+              <div className="mt-[0.55rem] flex flex-col gap-y-2">
                 <div className="flex flex-wrap justify-between gap-x-4 gap-y-2">
                   <span className="inline-flex items-center gap-[0.45rem] text-meta text-muted-foreground">
-                    <i className="size-[9px] flex-none rounded-[3px] bg-primary" />{" "}
+                    <i className="size-[9px] flex-none rounded-[3px] bg-chart-principal" />{" "}
                     Principal{" "}
                     <b className="min-w-[4ch] font-mono font-semibold tracking-[-0.015em] text-foreground tabular-nums">
                       {String(principalPct)}%
@@ -331,7 +331,7 @@ export function Readout({ onTailor }: { onTailor: () => void }) {
                   <span className="text-meta text-muted-foreground">Yours</span>
                   <div className="h-[7px] min-w-[26px] overflow-hidden rounded-full bg-muted">
                     <i
-                      className="block h-full rounded-full bg-primary [transition:width_0.4s_cubic-bezier(0.22,1,0.36,1)]"
+                      className="block h-full rounded-full bg-chart-principal [transition:width_0.4s_cubic-bezier(0.22,1,0.36,1)]"
                       style={{ width: `${String(yoursWidth)}%` }}
                     />
                   </div>

--- a/src/components/instrument/ChartFrame.tsx
+++ b/src/components/instrument/ChartFrame.tsx
@@ -4,14 +4,14 @@ import { Panel, PanelHeader } from "./Panel";
 export interface ChartLegendItem {
   /** Legend label (sans). */
   label: string;
-  /** Swatch colour as a CSS value, e.g. "var(--chart-1)". Defaults to spruce. */
+  /** Swatch colour as a CSS value, e.g. "var(--chart-1)". Defaults to the Principal data colour. */
   color?: string;
   /** Swatch shape: a line (default), a dot, or a dashed rule. */
   variant?: "line" | "dot" | "dash";
 }
 
 function Swatch({ color, variant = "line" }: Omit<ChartLegendItem, "label">) {
-  const c = color ?? "var(--primary)";
+  const c = color ?? "var(--chart-principal)";
   if (variant === "dot") {
     return (
       <span

--- a/src/components/shared/InsightCard.tsx
+++ b/src/components/shared/InsightCard.tsx
@@ -9,8 +9,9 @@ import type {
 
 // ---------------------------------------------------------------------------
 // Per-metric vizzes — the baseline-pinned instrument that rides inside each
-// MetricReadout cell (see InsightCards). Spruce carries the positive series and
-// principal; brick carries interest/cost; everything else is a cool neutral.
+// MetricReadout cell (see InsightCards). The Principal data colour carries the
+// positive series and principal; the Interest clay carries interest/cost;
+// everything else is a cool neutral.
 // ---------------------------------------------------------------------------
 
 /** Sparkline viz for the trend metrics (total repaid, payoff timeline). */
@@ -24,7 +25,7 @@ export function SparklineViz({
   return (
     <Sparkline
       data={cardData.data}
-      color="var(--primary)"
+      color="var(--chart-principal)"
       ariaLabel={`${label}: ${cardData.stat}`}
     />
   );
@@ -47,11 +48,11 @@ export function ProportionViz({ cardData }: { cardData: InterestCardData }) {
         aria-label={`Of ${cardData.stat} repaid, ${String(interestPct)}% is interest and ${String(principalPct)}% is principal${writtenOffPct > 0 ? `, with ${String(writtenOffPct)}% written off` : ""}.`}
       >
         <div
-          className="h-full bg-primary transition-all duration-500"
+          className="h-full bg-chart-principal transition-all duration-500"
           style={{ width: `${String(principalPct)}%` }}
         />
         <div
-          className="h-full bg-signal transition-all duration-500"
+          className="h-full bg-chart-interest transition-all duration-500"
           style={{ width: `${String(interestPct)}%` }}
         />
         {writtenOffPct > 0 && (
@@ -67,13 +68,13 @@ export function ProportionViz({ cardData }: { cardData: InterestCardData }) {
       <div className="mt-2 flex flex-col gap-y-1 text-xs text-muted-foreground">
         <div className="flex flex-wrap justify-between gap-x-4 gap-y-1">
           <span className="inline-flex items-center gap-1.5">
-            <span className="size-2 rounded-sm bg-primary" /> Principal{" "}
+            <span className="size-2 rounded-sm bg-chart-principal" /> Principal{" "}
             <b className="min-w-[4ch] font-mono font-semibold text-foreground tabular-nums">
               {String(principalPct)}%
             </b>
           </span>
           <span className="inline-flex items-center gap-1.5">
-            <span className="size-2 rounded-sm bg-signal" /> Interest{" "}
+            <span className="size-2 rounded-sm bg-chart-interest" /> Interest{" "}
             <b className="min-w-[4ch] font-mono font-semibold text-foreground tabular-nums">
               {String(interestPct)}%
             </b>
@@ -117,7 +118,7 @@ export function RateBenchmarkViz({
         </span>
         <span className="h-1.5 min-w-0 flex-1 overflow-hidden rounded-full bg-muted">
           <span
-            className="block h-full rounded-full bg-primary transition-all duration-500"
+            className="block h-full rounded-full bg-chart-principal transition-all duration-500"
             style={{ width: `${String(yoursWidth)}%` }}
           />
         </span>


### PR DESCRIPTION
## Why

The brand's two-colour thesis — spruce green + brick rust — doubles as the categorical **data** encoding for Principal vs Interest across every chart, legend, split bar, and good/bad outcome marker. That green-vs-rust pairing is the classic red-green colour-blindness trap: measured at protanopia ΔE ~3.8 (Machado-2009), it is effectively indistinguishable, and both tones are muddy at small sizes. A colour-blind user — and the person reviewing — could not tell Principal from Interest.

## What changes

A colour-blind-safe categorical data palette, **Spruce + Clay**: a lifted cool-spruce Principal and a dark earthy clay Interest, with a wide luminance gap so they separate under **both** deuteranopia and protanopia by colour alone. Validated with a data-viz validator — worst-case CVD ΔE 16 (light) / 14 (dark), passing the lightness band, chroma floor, normal-vision floor, and WCAG contrast. The spruce keeps the brand's cool hue; the clay keeps the earthy tone.

## Why this isn't a one-line token swap

`--primary` and `--signal` were shared by **both** chrome (buttons use `bg-primary text-primary-foreground`; links, focus, sliders, logo, nav) **and** data. Recolouring `--primary` directly would collapse the default button's text contrast from 7.57:1 to 3.52:1 — failing WCAG AA. So instead:

- Add dedicated data tokens `--chart-principal` / `--chart-interest`, and repoint only the **data** usages.
- Leave the chrome `--primary` (dark spruce) completely untouched — logo, slider, badges, and selection rings stay dark spruce.
- Point `--signal` (which was cost-only, never a button background) at `--chart-interest`, so every cost surface — charts, figures, guides — recolours consistently in one move.
- Alias the `--chart-1` / `--chart-2` / `--chart-overpay-baseline` ramp tokens to the new pair.

## Redundant (non-colour) encoding

On the one surface where colour was load-bearing — the homepage "Your loan breakdown" Readout hid its Principal/Interest legend below the `md` breakpoint, so on mobile colour was the only cue — the legend is now always shown.

## Verified

In the running app (light + dark tokens present): the homepage Readout at desktop and mobile, the /brand swatch page (brand marks spruce/mint unchanged; CHART 1/2 now the new pair), and the /interest recharts stacked chart — all render the new pair clearly separated, and chrome (logo, slider, badges, selection rings) stays dark spruce.

## Out of scope (intended follow-ups — not done here)

- The multi-series `chart-3/4/5` ramp (still spruce shades).
- Brand marks / social-image generator.
- Pre-existing structural collisions (**not** introduced here — ΔE ~9.2 today) between Principal-green and the reserved success-emerald intent, and between the clay and danger-red. These stem from the two-colour thesis sitting near the success/danger hue families and would require touching the reserved intent palette.

https://claude.ai/code/session_018qZZynhcju8c1nPGqBeXmH