### PR TITLE
fix: remove double divider below last guide when stacked

### DIFF
--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -123,7 +123,7 @@ export default function GuidesPage() {
               guide.newUntil != null && new Date() < new Date(guide.newUntil);
             return (
               <Link
-                className="group grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-[clamp(1.25rem,3vw,3.5rem)] border-b border-border py-[clamp(1.1rem,1.9vw,1.9rem)] no-underline"
+                className="group grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-[clamp(1.25rem,3vw,3.5rem)] border-b border-border py-[clamp(1.1rem,1.9vw,1.9rem)] no-underline max-work:last:border-b-0"
                 href={`/guides/${guide.slug}`}
                 key={guide.slug}
               >


### PR DESCRIPTION
## Why

On the all-guides page, screens narrower than 1500px showed **two divider lines** stacked on top of each other between the last guide article and the "Where to start" section — an obvious visual seam.

Below the `work` breakpoint (`--breakpoint-work: 93.75rem` = 1500px) the three-zone grid collapses into a single stacked column. In that layout the last guide link's bottom rule and the "Where to start" aside's top rule land directly adjacent, rendering as two hairlines instead of one.

## What changed

The last guide link now drops its bottom rule only when the layout is stacked (below 1500px), so the aside's top border becomes the single section divider.

At ≥1500px the aside sits in a side column rather than below the guide list, so the guide ledger still needs to close with its own bottom rule — that layout is unaffected and keeps both borders as intended.