### PR TITLE
fix: stop overpay chart card overlapping the verdict card

### DIFF
--- a/src/components/overpay/OverpayPage.tsx
+++ b/src/components/overpay/OverpayPage.tsx
@@ -23,13 +23,13 @@ import { REPAYMENT_START_MONTH } from "@/lib/presets";
 import { OverpayComparisonChart } from "./OverpayComparisonChart";
 import { OverpayPrimaryInputs } from "./OverpayPrimaryInputs";
 import { OverpaySummaryCards } from "./OverpaySummaryCards";
-import { OverpayVerdict } from "./OverpayVerdict";
+import { OverpayVerdict, OverpayVerdictSkeleton } from "./OverpayVerdict";
 
 function OverpayPageSkeleton() {
   return (
     <>
       {/* Verdict skeleton */}
-      <Skeleton className="min-h-43 w-full rounded-lg xs:min-h-38 sm:min-h-29 md:min-h-0" />
+      <OverpayVerdictSkeleton />
 
       {/* Chart + cards grid skeleton */}
       <div className="grid gap-6 md:flex">

--- a/src/components/overpay/OverpayVerdict.tsx
+++ b/src/components/overpay/OverpayVerdict.tsx
@@ -5,6 +5,7 @@ import {
   InformationCircleIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { RecommendationType } from "@/lib/loans/overpayTypes";
 import { cn } from "@/lib/utils";
 
@@ -43,6 +44,90 @@ const verdictConfig: Record<
   },
 };
 
+const DISCLAIMER =
+  "This is an estimate, not financial advice. Consider speaking to a financial adviser.";
+
+/**
+ * Representative copies of the longest verdict reasons, rendered invisibly
+ * into the same grid cell as the live card so the row reserves the tallest
+ * realistic height at every viewport width. Switching verdicts (or swapping
+ * in from the skeleton) then never shifts the content below. The reasons
+ * mirror the longest templates in determineRecommendation — keep them in
+ * sync if that copy changes.
+ */
+const sizerVariants = [
+  {
+    key: "marginal",
+    reason:
+      "A lump sum of £10,000 and £250/month overpayment would only cost an extra £999. Other factors like flexibility and peace of mind may be worth considering.",
+  },
+  {
+    key: "written-off",
+    reason:
+      "Without overpaying, £123,456 would be written off. A lump sum of £10,000 and £250/month overpayment would increase total repayments by £12,345.",
+  },
+];
+
+interface VerdictBodyProps {
+  icon: typeof Alert02Icon;
+  accent: string;
+  title: string;
+  reason: string;
+  footer: string;
+}
+
+function VerdictBody({
+  icon,
+  accent,
+  title,
+  reason,
+  footer,
+}: VerdictBodyProps) {
+  return (
+    <>
+      <div className="flex items-start gap-3 pb-3">
+        <HugeiconsIcon
+          icon={icon}
+          className={cn("mt-0.5 size-5 shrink-0", accent)}
+          strokeWidth={2}
+        />
+        <div className="min-w-0 flex-1 space-y-1">
+          <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+            Verdict
+          </p>
+          <p className={cn("text-lg font-semibold", accent)}>{title}</p>
+          <p className="max-w-prose text-sm text-muted-foreground">{reason}</p>
+        </div>
+      </div>
+      <p className="mt-auto border-t border-border/60 pt-3 text-xs text-muted-foreground">
+        {footer}
+      </p>
+    </>
+  );
+}
+
+function VerdictSizers() {
+  return (
+    <>
+      {sizerVariants.map(({ key, reason }) => (
+        <div
+          key={key}
+          aria-hidden
+          className="invisible col-start-1 row-start-1 flex flex-col p-4 sm:p-5"
+        >
+          <VerdictBody
+            icon={verdictConfig.overpay.icon}
+            accent={verdictConfig.overpay.accent}
+            title={verdictConfig.overpay.title}
+            reason={reason}
+            footer={DISCLAIMER}
+          />
+        </div>
+      ))}
+    </>
+  );
+}
+
 interface OverpayVerdictProps {
   recommendation: RecommendationType;
   reason: string;
@@ -56,36 +141,37 @@ export function OverpayVerdict({
   const isIdle = recommendation === "idle";
 
   return (
-    <div className="-mb-4 min-h-43 xs:min-h-38 sm:min-h-29 md:mb-0 md:min-h-0">
+    <div className="grid">
       <div
         role="status"
         aria-live="polite"
-        className={cn("rounded-xl p-4 ring-1 sm:p-5", config.surface)}
+        className={cn(
+          "col-start-1 row-start-1 flex flex-col rounded-xl p-4 ring-1 sm:p-5",
+          config.surface,
+        )}
       >
-        <div className="flex items-start gap-3">
-          <HugeiconsIcon
-            icon={config.icon}
-            className={cn("mt-0.5 size-5 shrink-0", config.accent)}
-            strokeWidth={2}
-          />
-          <div className="min-w-0 flex-1 space-y-1">
-            <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
-              Verdict
-            </p>
-            <p className={cn("text-lg font-semibold", config.accent)}>
-              {config.title}
-            </p>
-            <p className="max-w-prose text-sm text-muted-foreground">
-              {reason}
-            </p>
-          </div>
-        </div>
-        <p className="mt-3 border-t border-border/60 pt-3 text-xs text-muted-foreground">
-          {isIdle
-            ? "Adjust the inputs below to explore different scenarios."
-            : "This is an estimate, not financial advice. Consider speaking to a financial adviser."}
-        </p>
+        <VerdictBody
+          icon={config.icon}
+          accent={config.accent}
+          title={config.title}
+          reason={reason}
+          footer={
+            isIdle
+              ? "Adjust the inputs below to explore different scenarios."
+              : DISCLAIMER
+          }
+        />
       </div>
+      <VerdictSizers />
+    </div>
+  );
+}
+
+export function OverpayVerdictSkeleton() {
+  return (
+    <div className="grid">
+      <Skeleton className="col-start-1 row-start-1 rounded-xl" />
+      <VerdictSizers />
     </div>
   );
 }


### PR DESCRIPTION
## Why

On the live `/overpay` page (reported via an iPhone screenshot), the "Fig. 1" chart card visually overlapped the bottom of the Verdict card, covering its border and disclaimer.

The verdict card's wrapper reserved vertical space with fixed min-heights (`min-h-43 xs:min-h-38 sm:min-h-29`) plus a `-mb-4` that pulled the next section up. Those magic values were tuned for the pre-"Instrument" design; after the redesign in #485 the card grew taller than the stale reservation (181px vs 172px at 390px wide, worse at 320px), so the negative margin made the chart card sit on top of it.

The min-heights weren't decorative — they existed to stop the page shifting when the verdict variant changes while the user adjusts inputs below (#198). So simply removing them would trade one bug for another.

## What changes

The reserved height is now derived from content instead of pixel values. Invisible, `aria-hidden` copies of the longest realistic verdict copy (mirroring the longest reason templates in `determineRecommendation`) share a single grid cell with the live card, so the row is always as tall as the tallest realistic variant at every viewport width — the same pattern as the readout skeleton in #510, where placeholders reuse the real classes so heights match naturally. The live card stretches to that height with the disclaimer footer pinned to the bottom.

The page skeleton reuses the same sizers via a new `OverpayVerdictSkeleton`, so the skeleton-to-content swap no longer shifts by 16px either — the old fixed-height skeleton lacked the `-mb-4` and was a latent CLS bug.

## Verified

In a real browser at 320/390/480/640/768/1024px: no overlap, a consistent 24px gap to the chart card, and toggling verdict variants (overpay / idle / dont-overpay) keeps the card height and the position of everything below pixel-identical.