### PR TITLE
fix: vitest worktree crawl, share-url float noise, £ formatting

### DIFF
--- a/src/components/guides/plan-2-vs-plan-5/ComparisonTable.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/ComparisonTable.tsx
@@ -7,6 +7,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { formatGBP } from "@/lib/format";
 import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
 import { surfaceCard } from "@/lib/surfaces";
 import { specHead } from "../guide-parts";
@@ -14,8 +15,8 @@ import { specHead } from "../guide-parts";
 const plan2 = PLAN_DISPLAY_INFO.PLAN_2;
 const plan5 = PLAN_DISPLAY_INFO.PLAN_5;
 
-const plan2Threshold = String(PLAN_CONFIGS.PLAN_2.monthlyThreshold * 12);
-const plan5Threshold = String(PLAN_CONFIGS.PLAN_5.monthlyThreshold * 12);
+const plan2Threshold = formatGBP(PLAN_CONFIGS.PLAN_2.monthlyThreshold * 12);
+const plan5Threshold = formatGBP(PLAN_CONFIGS.PLAN_5.monthlyThreshold * 12);
 const repaymentRate = String(plan2.repaymentRate * 100);
 
 const rows = [
@@ -26,8 +27,8 @@ const rows = [
   },
   {
     label: "Repayment threshold",
-    plan2: `\u00a3${plan2Threshold}/yr`,
-    plan5: `\u00a3${plan5Threshold}/yr`,
+    plan2: `${plan2Threshold}/yr`,
+    plan5: `${plan5Threshold}/yr`,
   },
   {
     label: "Repayment rate",

--- a/src/lib/shareUrl.test.ts
+++ b/src/lib/shareUrl.test.ts
@@ -66,6 +66,13 @@ describe("encodeStateToParams", () => {
     },
   );
 
+  it("trims floating-point noise from assumption values", () => {
+    const state: LoanState = { ...mockState, discountRate: 2.8 / 100 };
+    const params = encodeStateToParams(state);
+
+    expect(params.get("dr")).toBe("0.028");
+  });
+
   it("excludes overpay fields by default", () => {
     const params = encodeStateToParams(mockState);
 

--- a/src/lib/shareUrl.ts
+++ b/src/lib/shareUrl.ts
@@ -107,6 +107,14 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 /**
+ * Stringifies an assumption rate for the URL, trimming IEEE-754 noise
+ * (e.g. 2.8 / 100 → 0.027999999999999997 → "0.028").
+ */
+function encodeAssumptionValue(value: number): string {
+  return String(Number(value.toFixed(6)));
+}
+
+/**
  * Encodes a loans array to the URL-safe format: "PLAN_2:45000,POSTGRADUATE:12000"
  */
 function encodeLoans(loans: Loan[]): string {
@@ -154,7 +162,7 @@ export function encodeStateToParams(
   // Assumption fields — always included
   for (const field of ASSUMPTION_PARAMS) {
     const value = state[field.stateKey];
-    params.set(field.urlParam, String(value));
+    params.set(field.urlParam, encodeAssumptionValue(value));
   }
 
   // Boolean flags

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import { dirname } from "node:path";
 import babel from "@rolldown/plugin-babel";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 // Resolve setup files to absolute paths so Vite doesn't misresolve bare
 // specifiers through the main repo's node_modules when running in a git
@@ -35,7 +35,14 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: [resolvedWebWorker, "./src/test/setup.ts"],
-    exclude: ["e2e/**", "scripts/**", "node_modules/**"],
+    // Extend (don't replace) the defaults: losing **/node_modules/** made
+    // vitest crawl dependency test suites inside .claude/worktrees/*/node_modules.
+    exclude: [
+      ...configDefaults.exclude,
+      "e2e/**",
+      "scripts/**",
+      "**/.claude/**",
+    ],
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "lcov"],


### PR DESCRIPTION
## Why

`pnpm test` was taking 15+ minutes locally and running zod's own test suites. The custom `exclude` in `vitest.config.ts` **replaced** vitest 4's defaults (`**/node_modules/**`, `**/.git/**`) with a root-relative `node_modules/**`, so vitest crawled `.claude/worktrees/*/node_modules` — those worktrees are full repo copies with their own installed dependencies — and picked up dependency test suites.

The fix extends `configDefaults.exclude` instead of replacing it, and additionally excludes `**/.claude/**`: even with the defaults restored, worktrees contain duplicate copies of the repo's own `src/**/*.test.ts` that would still run. After the change, vitest discovers only `src/` tests — 507 tests in ~2s.

## Also in this PR

Two small correctness fixes:

- **Share URLs no longer carry floating-point noise.** Assumption rates like 2.8% were encoded via `String(2.8 / 100)`, producing `dr=0.027999999999999997` in shared URLs. Values are now trimmed of IEEE-754 noise before encoding, so the URL reads `dr=0.028`.
- **Plan 2 vs Plan 5 comparison table uses the shared GBP formatter.** Repayment thresholds were hand-prefixed with `£` and rendered without thousands separators (e.g. `£28470/yr`); they now go through `formatGBP`, matching currency formatting everywhere else (`£28,470/yr`).