### PR TITLE
feat: redesign guide pages into a full-width workspace

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,7 +49,11 @@ export default defineConfig(
       "better-tailwindcss/enforce-consistent-line-wrapping": "off",
       "better-tailwindcss/no-unknown-classes": [
         "error",
-        { ignore: ["dark", "light"] },
+        // `guide-body` / `guide-breakout` drive the guide reading-column grid in
+        // globals.css `@layer components` (`guide-breakout` exists only as the
+        // `.guide-body > .guide-breakout` target), not as Tailwind utilities, so
+        // the resolver can't see them.
+        { ignore: ["dark", "light", "guide-body", "guide-breakout"] },
       ],
     },
   },
@@ -72,6 +76,17 @@ export default defineConfig(
     files: ["src/app/global-error.tsx"],
     rules: {
       "@next/next/no-html-link-for-pages": "off",
+    },
+  },
+  {
+    // guide-parts.tsx deliberately walks the guide body with Children.map +
+    // cloneElement to inject server-rendered section anchor ids (the standard
+    // heading-anchor transform, à la rehype-slug), so the "uncommon React API"
+    // nudges don't apply here.
+    files: ["src/components/guides/guide-parts.tsx"],
+    rules: {
+      "@eslint-react/no-children-map": "off",
+      "@eslint-react/no-clone-element": "off",
     },
   },
   {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -289,6 +289,56 @@
   }
 }
 
+/* ==========================================================================
+   GUIDE READING WORKSPACE — the long-form article body. A centred prose measure
+   (~66ch) with a wider breakout track: charts and data tables opt into
+   `.guide-breakout` to read wider than the prose that frames them, while the
+   sentences stay at a comfortable measure. Works at every width — below the
+   `work` workspace breakpoint the tracks collapse so the body is just a centred
+   column with full-width figures, matching the pre-redesign reading experience.
+   ========================================================================== */
+@layer components {
+  .guide-body {
+    display: grid;
+    grid-template-columns:
+      [full-start] minmax(0, 1fr)
+      [content-start] min(66ch, 100%)
+      [content-end] minmax(0, 1fr)
+      [full-end];
+    row-gap: clamp(2.25rem, 3.4vw, 3.25rem);
+    /* Fluid reading size: 16px through laptop widths, easing up to 18px only on
+       very wide viewports (~2000px+). Because the `content` track is measured in
+       `ch`, the prose column grows in pixels while characters-per-line stays
+       ~66 — spending ultrawide space on legibility, not a longer line. Headings
+       and the mono readouts keep their own scales. */
+    font-size: clamp(1rem, 0.75rem + 0.2vw, 1.125rem);
+  }
+  /* Prose sits in the reading measure; every child gets min-width:0 so a wide
+     table or chart can shrink instead of forcing horizontal overflow. */
+  .guide-body > * {
+    grid-column: content;
+    min-width: 0;
+  }
+  /* Figures span the full column — wider than the prose, still column-relative
+     so they never collide with the sticky rails on the workspace grid. */
+  .guide-body > .guide-breakout {
+    grid-column: full;
+  }
+  /* Anchor targets (section headings the contents rail links to) clear the
+     sticky header when jumped to. */
+  .guide-body :is(h2, h3)[id] {
+    scroll-margin-top: 5.5rem;
+  }
+}
+
+/* The guide lead paragraph — a step above body, sized in `em` so it rides the
+   fluid reading base (`.guide-body`'s font-size) instead of a fixed rem. Body
+   copy just inherits that base; only the lead needs a ratio of its own. */
+@utility guide-lead {
+  font-size: 1.0625em;
+  line-height: 1.45;
+}
+
 /* Theme transition */
 body {
   transition:

--- a/src/components/guides/GuideContents.tsx
+++ b/src/components/guides/GuideContents.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Eyebrow } from "@/components/typography/Eyebrow";
+import { cn } from "@/lib/utils";
+
+export interface GuideSection {
+  id: string;
+  label: string;
+}
+
+/**
+ * The guide "On this page" contents rail. Sections (id + label) are derived
+ * server-side from the article's `<Heading>` elements (see `processGuideBody` in
+ * guide-parts), so the nav and its anchor links render in the initial HTML —
+ * shareable `#section` URLs and crawlers work without JS. This client component
+ * only adds the scroll-spy highlight and smooth-scroll enhancement on top.
+ * Wide-screen wayfinding only — the parent hides it below the workspace
+ * breakpoint, where the article is a single column.
+ */
+export function GuideContents({ sections }: { sections: GuideSection[] }) {
+  const [activeId, setActiveId] = useState("");
+
+  // Scroll-spy: the current section is the last heading whose top has crossed a
+  // line just below the sticky header. Reading "last crossed" (rather than a
+  // narrow intersection band) keeps the final section highlightable at the
+  // bottom of the page, and lets the highlight track a click-driven scroll to
+  // its target instead of needing a separate suppression timer.
+  useEffect(() => {
+    if (sections.length === 0) return;
+    const headings = sections
+      .map((s) => document.getElementById(s.id))
+      .filter((el): el is HTMLElement => el !== null);
+    if (headings.length === 0) return;
+
+    let frame = 0;
+    const sync = () => {
+      frame = 0;
+      const line = 100;
+      let current = headings[0].id;
+      for (const el of headings) {
+        if (el.getBoundingClientRect().top - line <= 0) current = el.id;
+        else break;
+      }
+      setActiveId(current);
+    };
+    const onScroll = () => {
+      if (frame === 0) frame = requestAnimationFrame(sync);
+    };
+
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+      if (frame !== 0) cancelAnimationFrame(frame);
+    };
+  }, [sections]);
+
+  function handleClick(event: React.MouseEvent<HTMLAnchorElement>, id: string) {
+    const target = document.getElementById(id);
+    if (!target) return;
+    event.preventDefault();
+    const reduce = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    target.scrollIntoView({ behavior: reduce ? "auto" : "smooth" });
+    history.replaceState(null, "", `#${id}`);
+  }
+
+  if (sections.length < 2) return null;
+
+  return (
+    <nav aria-label="On this page">
+      <Eyebrow as="p" marker={false}>
+        On this page
+      </Eyebrow>
+      <ul className="mt-3 space-y-0.5 border-l border-border">
+        {sections.map((section) => {
+          const isActive = section.id === activeId;
+          return (
+            <li key={section.id}>
+              <a
+                href={`#${section.id}`}
+                onClick={(event) => {
+                  handleClick(event, section.id);
+                }}
+                aria-current={isActive ? "true" : undefined}
+                className={cn(
+                  "-ml-px block border-l py-1 pl-3.5 text-meta text-pretty no-underline transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-inset",
+                  isActive
+                    ? "border-primary font-medium text-foreground"
+                    : "border-transparent text-muted-foreground hover:border-border hover:text-foreground",
+                )}
+              >
+                {section.label}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/guides/RelatedGuides.tsx
+++ b/src/components/guides/RelatedGuides.tsx
@@ -1,5 +1,8 @@
+import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
 import { LinkIndex, LinkIndexRow } from "@/components/instrument/LinkIndex";
-import { Heading } from "@/components/typography/Heading";
+import { Eyebrow } from "@/components/typography/Eyebrow";
 import type { GuideEntry, GuideSlug } from "@/lib/guides";
 import { GUIDES } from "@/lib/guides";
 
@@ -60,6 +63,26 @@ const TOOLS: Partial<Record<string, ToolLink>> = {
 
 const DEFAULT_TOOLS = ["/", "/overpay"];
 
+/** A quiet grouped block in the companion rail: engraved label + a link index. */
+function RailGroup({
+  label,
+  children,
+  labelId,
+}: {
+  label: string;
+  labelId: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section aria-labelledby={labelId}>
+      <Eyebrow as="h2" marker={false} id={labelId}>
+        {label}
+      </Eyebrow>
+      <div className="mt-2.5">{children}</div>
+    </section>
+  );
+}
+
 interface RelatedGuidesProps {
   current: GuideSlug;
   order: GuideSlug[];
@@ -68,6 +91,14 @@ interface RelatedGuidesProps {
   tools?: string[];
 }
 
+/**
+ * The guide companion — the content of a guide's right-anchored rail (and, below
+ * the workspace breakpoint, the closing block beneath the article). It opens
+ * with a standing wayfinding link into the calculator, then a compact index of
+ * related guides, optional references, and the guide's other tools. Set quietly
+ * (engraved labels + hairline-separated rows) so it frames the reading column
+ * without competing with it.
+ */
 export function RelatedGuides({
   current,
   order,
@@ -79,35 +110,55 @@ export function RelatedGuides({
     .filter((slug) => slug !== current)
     .map((slug) => guidesBySlug.get(slug))
     .filter((g): g is GuideEntry => g !== undefined)
-    .slice(0, 2);
+    .slice(0, 3);
 
+  // The main calculator is the standing call-to-action, so drop it from the
+  // "More tools" index to avoid listing the same destination twice.
   const toolLinks = tools
+    .filter((href) => href !== "/")
     .map((href) => TOOLS[href])
     .filter((t): t is ToolLink => t !== undefined);
 
   return (
-    <div className="space-y-10 border-t border-border pt-10">
-      <section className="space-y-4" aria-labelledby="related-guides-h">
-        <Heading as="h2" size="section" id="related-guides-h">
-          Related guides
-        </Heading>
-        <LinkIndex>
-          {orderedGuides.map((guide) => (
-            <LinkIndexRow
-              key={guide.slug}
-              href={`/guides/${guide.slug}`}
-              title={guide.title}
-              description={guide.description}
-            />
-          ))}
-        </LinkIndex>
-      </section>
+    <div className="space-y-8">
+      <Link
+        href="/"
+        className="group block no-underline"
+        aria-labelledby="companion-cta-h"
+      >
+        <Eyebrow marker={false}>Try it yourself</Eyebrow>
+        <span
+          id="companion-cta-h"
+          className="mt-2 flex items-center gap-1.5 font-semibold text-foreground transition-colors group-hover:text-cta"
+        >
+          Open the calculator
+          <HugeiconsIcon
+            icon={ArrowRight01Icon}
+            className="size-4 shrink-0 text-primary transition-transform group-hover:translate-x-[3px]"
+          />
+        </span>
+        <span className="mt-1 block text-sm text-muted-foreground">
+          See what you will actually repay at your salary.
+        </span>
+      </Link>
+
+      {orderedGuides.length > 0 && (
+        <RailGroup label="Related guides" labelId="related-guides-h">
+          <LinkIndex>
+            {orderedGuides.map((guide) => (
+              <LinkIndexRow
+                key={guide.slug}
+                href={`/guides/${guide.slug}`}
+                title={guide.title}
+                description={guide.description}
+              />
+            ))}
+          </LinkIndex>
+        </RailGroup>
+      )}
 
       {extraLinks && extraLinks.length > 0 && (
-        <section className="space-y-4" aria-labelledby="references-h">
-          <Heading as="h2" size="section" id="references-h">
-            References
-          </Heading>
+        <RailGroup label="References" labelId="references-h">
           <LinkIndex>
             {extraLinks.map((link) => (
               <LinkIndexRow
@@ -118,14 +169,11 @@ export function RelatedGuides({
               />
             ))}
           </LinkIndex>
-        </section>
+        </RailGroup>
       )}
 
       {toolLinks.length > 0 && (
-        <section className="space-y-4" aria-labelledby="more-tools-h">
-          <Heading as="h2" size="section" id="more-tools-h">
-            More tools
-          </Heading>
+        <RailGroup label="More tools" labelId="more-tools-h">
           <LinkIndex>
             {toolLinks.map((tool) => (
               <LinkIndexRow
@@ -136,7 +184,7 @@ export function RelatedGuides({
               />
             ))}
           </LinkIndex>
-        </section>
+        </RailGroup>
       )}
     </div>
   );

--- a/src/components/guides/guide-parts.tsx
+++ b/src/components/guides/guide-parts.tsx
@@ -1,5 +1,18 @@
 import Link from "next/link";
+import {
+  Children,
+  cloneElement,
+  Fragment,
+  isValidElement,
+  type ReactNode,
+} from "react";
+import {
+  GuideContents,
+  type GuideSection,
+} from "@/components/guides/GuideContents";
+import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { Panel } from "@/components/instrument/Panel";
+import { WideLayout } from "@/components/layout/WideLayout";
 import { Eyebrow } from "@/components/typography/Eyebrow";
 import { Heading } from "@/components/typography/Heading";
 import {
@@ -10,7 +23,93 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+import { SHELL_GUTTER } from "@/lib/layout";
+import { LAST_UPDATED } from "@/lib/loans/plans";
 import { cn } from "@/lib/utils";
+
+// "Updated May 2026" — the same freshness signal the guides index and homepage
+// hero carry, derived from the figure automation's LAST_UPDATED.
+const UPDATED_LABEL = new Intl.DateTimeFormat("en-GB", {
+  month: "long",
+  year: "numeric",
+}).format(new Date(LAST_UPDATED));
+
+/** Slugify a heading's text into a stable, URL-safe anchor id. */
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+/** Flatten a heading's children (strings, numbers, interpolations) to text. */
+function nodeText(node: ReactNode): string {
+  if (typeof node === "string") return node;
+  if (typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(nodeText).join("");
+  if (isValidElement(node)) {
+    return nodeText((node.props as { children?: ReactNode }).children);
+  }
+  return "";
+}
+
+type SectionHeadingElement = React.ReactElement<{
+  children?: ReactNode;
+  id?: string;
+  size?: string;
+}>;
+
+const isSectionHeading = (
+  el: React.ReactElement,
+): el is SectionHeadingElement =>
+  el.type === Heading && (el.props as { size?: string }).size === "section";
+
+/**
+ * Walk the guide body, give each section `<Heading size="section">` a stable
+ * slug id (server-side, so the anchor targets and the contents rail exist in the
+ * initial HTML — shareable `#section` URLs and crawlers work without JS), and
+ * return the collected sections for the rail. Only real section headings are
+ * picked up; the `Eyebrow`-based labels inside panels (e.g. "Key takeaways") are
+ * not `<Heading>`s, so they never leak into the table of contents.
+ */
+function processGuideBody(children: ReactNode): {
+  processed: ReactNode;
+  sections: GuideSection[];
+} {
+  const sections: GuideSection[] = [];
+  const seen = new Set<string>();
+
+  const withId = (heading: SectionHeadingElement): React.ReactElement => {
+    const label = nodeText(heading.props.children).trim();
+    if (!label) return heading;
+    let id = heading.props.id ?? slugify(label);
+    let n = 2;
+    while (seen.has(id)) {
+      id = `${slugify(label)}-${String(n)}`;
+      n++;
+    }
+    seen.add(id);
+    sections.push({ id, label });
+    return cloneElement(heading, { id });
+  };
+
+  // Recurse through structural wrappers (`<section>` and fragments) so a heading
+  // nested one or more levels down is still found; feature components (charts,
+  // tables, panels) hold no section headings and pass through untouched rather
+  // than being cloned.
+  const walk = (nodes: ReactNode): ReactNode =>
+    Children.map(nodes, (child) => {
+      if (!isValidElement(child)) return child;
+      if (isSectionHeading(child)) return withId(child);
+      const kids = (child.props as { children?: ReactNode }).children;
+      if (child.type === Fragment) return walk(kids);
+      if (child.type === "section")
+        return cloneElement(child, undefined, walk(kids));
+      return child;
+    });
+
+  return { processed: walk(children), sections };
+}
 
 /**
  * Shared building blocks for the guide (article) archetype. Every piece speaks
@@ -19,56 +118,114 @@ import { cn } from "@/lib/utils";
  * calibrated system rather than a stack of recolored Ledger cards.
  */
 
-/** Reading column for an editorial guide — a single centred ~70ch measure. */
-export const readingColumn = "mx-auto max-w-2xl";
-
 /**
- * The shared guide masthead + reading column. Renders the centred reading
- * measure, the Home › Guides › [current] breadcrumb, the page-hero heading and
- * its lead paragraph, then the guide body — so every long-form guide opens with
- * the same calibrated header instead of re-inlining ~25 lines of markup.
+ * The full-bleed guide workspace — the long-form counterpart to the wide
+ * homepage and guides-index shells. Below the `work` breakpoint it is a single
+ * centred reading column (the pre-redesign guide experience). At `work` and up
+ * it opens into three zones, mirroring the guides-index "mass at both edges"
+ * grammar:
+ *
+ *   - a sticky **contents** rail (an auto-built "On this page" table of contents
+ *     plus the freshness meta) anchoring the left edge;
+ *   - the **reading column** in the middle — prose held at a ~66ch measure while
+ *     charts and data tables (`.guide-breakout`) read wider;
+ *   - a sticky **companion** rail (calculator CTA, related guides, tools)
+ *     anchoring the right edge — the same block that stacks beneath the article
+ *     on narrow screens.
+ *
+ * Guides pass their cross-links as `related`; the companion renders them, so a
+ * guide's body no longer ends with a full-width related-guides section.
  */
 export function GuideArticle({
   breadcrumbLabel,
   title,
   intro,
+  related,
   children,
 }: {
   breadcrumbLabel: React.ReactNode;
   title: React.ReactNode;
   intro: React.ReactNode;
+  related?: React.ComponentProps<typeof RelatedGuides>;
   children: React.ReactNode;
 }) {
+  const { processed, sections } = processGuideBody(children);
   return (
-    <article className={cn(readingColumn, "space-y-12")}>
-      <header className="space-y-4">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbLink render={<Link href="/guides" />}>
-                Guides
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>{breadcrumbLabel}</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
+    <WideLayout>
+      <div
+        className={cn(
+          SHELL_GUTTER,
+          "w-full py-[clamp(1.8rem,3.2vw,3rem)]",
+          "work:grid work:grid-cols-[minmax(0,15rem)_minmax(0,50rem)_minmax(0,17rem)] work:content-start work:justify-center work:gap-x-[clamp(2.5rem,3.5vw,4.5rem)]",
+          "ultra:grid-cols-[minmax(0,17rem)_minmax(0,62rem)_minmax(0,19rem)] ultra:gap-x-[clamp(3.5rem,4vw,6rem)]",
+        )}
+      >
+        {/* Contents rail — sticky wayfinding, wide screens only. Capped to the
+            viewport so a long list stays reachable on a short window. */}
+        <aside className="hidden work:sticky work:top-22 work:block work:max-h-[calc(100dvh-7rem)] work:self-start work:overflow-y-auto">
+          <GuideContents sections={sections} />
+          <dl className="mt-8 space-y-1.5 border-t border-border pt-5 text-meta text-muted-foreground">
+            <div className="flex items-baseline gap-1.5">
+              <dt className="sr-only">Last updated</dt>
+              <dd>Updated {UPDATED_LABEL}</dd>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <dt className="sr-only">Source</dt>
+              <dd className="flex items-center gap-1.5">
+                <span aria-hidden="true" className="font-bold text-primary">
+                  ✓
+                </span>
+                GOV.UK sourced
+              </dd>
+            </div>
+          </dl>
+        </aside>
 
-        <div className="space-y-3">
-          <Heading as="h1" size="page-hero">
-            {title}
-          </Heading>
-          <p className="text-lead text-pretty text-muted-foreground">{intro}</p>
-        </div>
-      </header>
-      {children}
-    </article>
+        {/* Reading column — header + body share the ~66ch content track; figures
+            marked `guide-breakout` span wider. */}
+        <article className="guide-body mx-auto max-w-200 min-w-0 work:mx-0 work:max-w-none">
+          <header className="space-y-4">
+            <Breadcrumb>
+              <BreadcrumbList>
+                <BreadcrumbItem>
+                  <BreadcrumbLink render={<Link href="/" />}>
+                    Home
+                  </BreadcrumbLink>
+                </BreadcrumbItem>
+                <BreadcrumbSeparator />
+                <BreadcrumbItem>
+                  <BreadcrumbLink render={<Link href="/guides" />}>
+                    Guides
+                  </BreadcrumbLink>
+                </BreadcrumbItem>
+                <BreadcrumbSeparator />
+                <BreadcrumbItem>
+                  <BreadcrumbPage>{breadcrumbLabel}</BreadcrumbPage>
+                </BreadcrumbItem>
+              </BreadcrumbList>
+            </Breadcrumb>
+
+            <div className="space-y-3">
+              <Heading as="h1" size="page-hero">
+                {title}
+              </Heading>
+              <p className="guide-lead text-pretty text-muted-foreground">
+                {intro}
+              </p>
+            </div>
+          </header>
+          {processed}
+        </article>
+
+        {/* Companion rail — sticky beside the article on wide, the closing block
+            beneath it on narrow. */}
+        {related && (
+          <aside className="mx-auto mt-12 w-full max-w-200 border-t border-border pt-8 work:sticky work:top-22 work:mx-0 work:mt-0 work:block work:max-h-[calc(100dvh-7rem)] work:max-w-none work:self-start work:overflow-y-auto work:border-t-0 work:pt-0">
+            <RelatedGuides {...related} />
+          </aside>
+        )}
+      </div>
+    </WideLayout>
   );
 }
 
@@ -95,7 +252,7 @@ export function KeyTakeaways({ children }: { children: React.ReactNode }) {
       <Eyebrow as="h2" marker={false}>
         Key takeaways
       </Eyebrow>
-      <ul className="list-disc space-y-2.5 pl-5 text-sm text-muted-foreground marker:text-primary sm:text-base">
+      <ul className="list-disc space-y-2.5 pl-5 text-muted-foreground marker:text-primary">
         {children}
       </ul>
     </Panel>

--- a/src/components/guides/how-interest-works/InterestGuide.tsx
+++ b/src/components/guides/how-interest-works/InterestGuide.tsx
@@ -1,7 +1,5 @@
 import Link from "next/link";
-import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { ChartFrame } from "@/components/instrument/ChartFrame";
-import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import { formatGBP, formatPercent } from "@/lib/format";
 import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
@@ -22,182 +20,182 @@ const currentTaxYear = getCurrentTaxYearLabel();
 
 export function InterestGuide() {
   return (
-    <PageLayout>
-      <GuideArticle
-        breadcrumbLabel="How Interest Works"
-        title="How interest works on UK student loans"
-        intro={
-          <>
-            Interest is one of the most confusing parts of student loans. Each
-            plan type calculates it differently, which means the amount your
-            balance grows varies depending on when you started university and
-            how much you earn.
-          </>
-        }
+    <GuideArticle
+      breadcrumbLabel="How Interest Works"
+      title="How interest works on UK student loans"
+      intro={
+        <>
+          Interest is one of the most confusing parts of student loans. Each
+          plan type calculates it differently, which means the amount your
+          balance grows varies depending on when you started university and how
+          much you earn.
+        </>
+      }
+      related={{
+        current: "how-interest-works",
+        order: ["rpi-vs-cpi", "plan-2-vs-plan-5"],
+        tools: ["/interest", "/effective-rate"],
+      }}
+    >
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Plan 2: The Sliding Scale
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            Plan 2 has the most complex interest calculation. It uses a sliding
+            scale tied to your income, ranging from RPI (currently{" "}
+            {formatPercent(rpi)}) up to RPI + 3% (currently{" "}
+            {formatPercent(maxRate)}).
+          </p>
+          <ul className="list-disc space-y-1 pl-6">
+            <li>
+              Earning below the lower threshold of{" "}
+              <strong className="text-foreground">
+                {formatGBP(PLAN_CONFIGS.PLAN_2.interestLowerThreshold)}
+              </strong>
+              : you pay RPI only ({formatPercent(rpi)})
+            </li>
+            <li>
+              Earning above the upper threshold of{" "}
+              <strong className="text-foreground">
+                {formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}
+              </strong>
+              : you pay the maximum of RPI + 3% ({formatPercent(maxRate)})
+            </li>
+            <li>
+              Earning between the two: the rate scales linearly from{" "}
+              {formatPercent(rpi)} up to {formatPercent(maxRate)}
+            </li>
+          </ul>
+          <p>
+            While studying, Plan 2 borrowers are charged the maximum rate of RPI
+            + 3%. This means your balance starts growing before you even
+            graduate.
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Plan 5: RPI Only
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            Plan 5, introduced for students starting from September 2023, has a
+            much simpler formula. Regardless of how much you earn, the interest
+            rate is just RPI &mdash; currently {formatPercent(rpi)}.
+          </p>
+          <p>
+            This is a significant change from Plan 2. A high earner on Plan 2
+            could be paying {formatPercent(maxRate)} interest, while the same
+            earner on Plan 5 would pay only {formatPercent(rpi)}. The chart
+            below illustrates this difference clearly.
+          </p>
+        </div>
+      </section>
+
+      <ChartFrame
+        className="guide-breakout"
+        caption="Fig. 1 — Annual interest rate by salary · Plan 2 vs Plan 5"
+        figure={`${formatPercent(maxRate)} max`}
+        figureTone="cost"
       >
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Plan 2: The Sliding Scale
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              Plan 2 has the most complex interest calculation. It uses a
-              sliding scale tied to your income, ranging from RPI (currently{" "}
-              {formatPercent(rpi)}) up to RPI + 3% (currently{" "}
-              {formatPercent(maxRate)}).
-            </p>
-            <ul className="list-disc space-y-1 pl-6">
-              <li>
-                Earning below the lower threshold of{" "}
-                <strong className="text-foreground">
-                  {formatGBP(PLAN_CONFIGS.PLAN_2.interestLowerThreshold)}
-                </strong>
-                : you pay RPI only ({formatPercent(rpi)})
-              </li>
-              <li>
-                Earning above the upper threshold of{" "}
-                <strong className="text-foreground">
-                  {formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}
-                </strong>
-                : you pay the maximum of RPI + 3% ({formatPercent(maxRate)})
-              </li>
-              <li>
-                Earning between the two: the rate scales linearly from{" "}
-                {formatPercent(rpi)} up to {formatPercent(maxRate)}
-              </li>
-            </ul>
-            <p>
-              While studying, Plan 2 borrowers are charged the maximum rate of
-              RPI + 3%. This means your balance starts growing before you even
-              graduate.
-            </p>
-          </div>
-        </section>
+        <InterestRateChart />
+      </ChartFrame>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Plan 5: RPI Only
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              Plan 5, introduced for students starting from September 2023, has
-              a much simpler formula. Regardless of how much you earn, the
-              interest rate is just RPI &mdash; currently {formatPercent(rpi)}.
-            </p>
-            <p>
-              This is a significant change from Plan 2. A high earner on Plan 2
-              could be paying {formatPercent(maxRate)} interest, while the same
-              earner on Plan 5 would pay only {formatPercent(rpi)}. The chart
-              below illustrates this difference clearly.
-            </p>
-          </div>
-        </section>
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Plan 1 and Plan 4
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            Plan 1 (England, Wales &amp; Northern Ireland pre-2012) and Plan 4
+            (Scotland) use the same interest formula: the lesser of RPI or the
+            Bank of England base rate plus 1%.
+          </p>
+          <p>
+            With RPI at {formatPercent(rpi)} and the base rate at{" "}
+            {formatPercent(CURRENT_RATES.boeBaseRate)}, the current interest
+            rate for these plans is{" "}
+            <strong className="text-foreground">
+              {formatPercent(plan1Rate)}
+            </strong>{" "}
+            (the lower of {formatPercent(rpi)} and {formatPercent(boeRatePlus1)}
+            ).
+          </p>
+        </div>
+      </section>
 
-        <ChartFrame
-          caption="Fig. 1 — Annual interest rate by salary · Plan 2 vs Plan 5"
-          figure={`${formatPercent(maxRate)} max`}
-          figureTone="cost"
-        >
-          <InterestRateChart />
-        </ChartFrame>
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Postgraduate Loans
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            Postgraduate (Master&apos;s and Doctoral) loans always charge RPI +
+            3%, regardless of your income. At current rates, that means{" "}
+            <strong className="text-foreground">
+              {formatPercent(maxRate)}
+            </strong>{" "}
+            interest per year &mdash; the highest rate of any UK student loan
+            plan.
+          </p>
+        </div>
+      </section>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Plan 1 and Plan 4
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              Plan 1 (England, Wales &amp; Northern Ireland pre-2012) and Plan 4
-              (Scotland) use the same interest formula: the lesser of RPI or the
-              Bank of England base rate plus 1%.
-            </p>
-            <p>
-              With RPI at {formatPercent(rpi)} and the base rate at{" "}
-              {formatPercent(CURRENT_RATES.boeBaseRate)}, the current interest
-              rate for these plans is{" "}
-              <strong className="text-foreground">
-                {formatPercent(plan1Rate)}
-              </strong>{" "}
-              (the lower of {formatPercent(rpi)} and{" "}
-              {formatPercent(boeRatePlus1)}).
-            </p>
-          </div>
-        </section>
+      <section className="space-y-3">
+        <Heading as="h2" size="section" id="current-interest-rates-by-plan">
+          Current Interest Rates by Plan ({currentTaxYear})
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            Here are the interest rates in force across every plan for the{" "}
+            {currentTaxYear} tax year, based on RPI of {formatPercent(rpi)}.
+            Middle earners on Plan 2 feel this most: they sit on the sliding
+            scale, charged above RPI without earning enough to clear the balance
+            before interest compounds.
+          </p>
+        </div>
+      </section>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Postgraduate Loans
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              Postgraduate (Master&apos;s and Doctoral) loans always charge RPI
-              + 3%, regardless of your income. At current rates, that means{" "}
-              <strong className="text-foreground">
-                {formatPercent(maxRate)}
-              </strong>{" "}
-              interest per year &mdash; the highest rate of any UK student loan
-              plan.
-            </p>
-          </div>
-        </section>
+      <div className="guide-breakout">
+        <CurrentRatesTable />
+      </div>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Current Interest Rates by Plan ({currentTaxYear})
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              Here are the interest rates in force across every plan for the{" "}
-              {currentTaxYear} tax year, based on RPI of {formatPercent(rpi)}.
-              Middle earners on Plan 2 feel this most: they sit on the sliding
-              scale, charged above RPI without earning enough to clear the
-              balance before interest compounds.
-            </p>
-          </div>
-          <CurrentRatesTable />
-        </section>
-
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Why Your Balance Grows
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              Many graduates are surprised to see their loan balance increase
-              despite making repayments. This happens when the interest added
-              each month exceeds what you repay.
-            </p>
-            <p>
-              For example, on a {formatGBP(EXAMPLE_BALANCE)} balance at{" "}
-              {formatPercent(maxRate)} interest, you would accrue roughly{" "}
-              {formatGBP(monthlyInterest)} per month in interest alone. If your
-              monthly repayment is less than that, the balance will keep
-              growing.
-            </p>
-            <p>
-              This is most common early in your career when salaries are lower
-              and balances are at their highest. Over time, salary growth
-              increases your repayments while the balance (hopefully) shrinks,
-              eventually tipping the scales. Use the{" "}
-              <Link href="/" className={guideLink}>
-                repayment calculator
-              </Link>{" "}
-              to see when this tipping point occurs at your salary, or explore
-              whether{" "}
-              <Link href="/overpay" className={guideLink}>
-                overpaying your loan
-              </Link>{" "}
-              could reduce the total cost.
-            </p>
-          </div>
-        </section>
-
-        <RelatedGuides
-          current="how-interest-works"
-          order={["rpi-vs-cpi", "plan-2-vs-plan-5"]}
-          tools={["/interest", "/effective-rate"]}
-        />
-      </GuideArticle>
-    </PageLayout>
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Why Your Balance Grows
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            Many graduates are surprised to see their loan balance increase
+            despite making repayments. This happens when the interest added each
+            month exceeds what you repay.
+          </p>
+          <p>
+            For example, on a {formatGBP(EXAMPLE_BALANCE)} balance at{" "}
+            {formatPercent(maxRate)} interest, you would accrue roughly{" "}
+            {formatGBP(monthlyInterest)} per month in interest alone. If your
+            monthly repayment is less than that, the balance will keep growing.
+          </p>
+          <p>
+            This is most common early in your career when salaries are lower and
+            balances are at their highest. Over time, salary growth increases
+            your repayments while the balance (hopefully) shrinks, eventually
+            tipping the scales. Use the{" "}
+            <Link href="/" className={guideLink}>
+              repayment calculator
+            </Link>{" "}
+            to see when this tipping point occurs at your salary, or explore
+            whether{" "}
+            <Link href="/overpay" className={guideLink}>
+              overpaying your loan
+            </Link>{" "}
+            could reduce the total cost.
+          </p>
+        </div>
+      </section>
+    </GuideArticle>
   );
 }

--- a/src/components/guides/interest-rate-cap/InterestRateCapGuide.tsx
+++ b/src/components/guides/interest-rate-cap/InterestRateCapGuide.tsx
@@ -1,6 +1,4 @@
-import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { ChartFrame } from "@/components/instrument/ChartFrame";
-import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import { formatGBP, formatPercent } from "@/lib/format";
 import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
@@ -20,271 +18,277 @@ const currentTaxYear = getCurrentTaxYearLabel();
 
 export function InterestRateCapGuide() {
   return (
-    <PageLayout>
-      <GuideArticle
-        breadcrumbLabel="Interest Rate Cap"
-        title="Plan 2 interest rate capped at 6%: what it means for you"
-        intro={
-          <>
-            On 7 April 2026, the government announced a 6% cap on Plan 2 and
-            Plan 3 student loan interest rates from September 2026. Here is what
-            that means in practice and how much it could save you.
-          </>
-        }
-      >
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            What Changed
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              Plan 2 loans charge interest on a sliding scale: from RPI
-              (currently {formatPercent(rpi)}) for lower earners up to RPI + 3%
-              (currently {formatPercent(currentMaxRate)}) for those earning
-              above{" "}
-              <strong className="text-foreground">
-                {formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}
-              </strong>
-              . While studying, borrowers are charged the full RPI + 3%.
-            </p>
-            <p>
-              From 1 September 2026, the maximum interest rate on Plan 2 and
-              Plan 3 loans will be capped at{" "}
-              <strong className="text-foreground">6%</strong>, regardless of
-              what the RPI + 3% formula produces. This cap applies for the
-              2026/27 academic year.
-            </p>
-            <p>
-              At current rates, this barely bites &mdash; the maximum is{" "}
-              {formatPercent(currentMaxRate)}, only{" "}
-              {formatPercent(Math.round((currentMaxRate - 6) * 100) / 100)}{" "}
-              above the cap. But the cap is designed as insurance: if inflation
-              surges again, your interest rate will not follow it above 6%.
-            </p>
-          </div>
-        </section>
-
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Plan 2 Interest Rates at a Glance ({currentTaxYear})
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              The key Plan 2 interest figures for the {currentTaxYear} tax year,
-              alongside the 6% cap that applies from September 2026.
-            </p>
-          </div>
-          <CurrentCapTable />
-        </section>
-
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Why the Government Acted
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              Skills Minister Jacqui Smith cited the risk of inflation pressures
-              from Middle East conflicts and global instability. When RPI
-              spikes, the RPI + 3% formula can push interest rates well into
-              double digits &mdash; exactly what happened in 2022&ndash;2024.
-            </p>
-            <p>
-              The government had previously used the &ldquo;prevailing market
-              rate&rdquo; (PMR) mechanism to intervene when rates became
-              unreasonable. The 6% cap formalises this protection with a clear,
-              predictable ceiling instead of ad-hoc adjustments.
-            </p>
-          </div>
-        </section>
-
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            How Often Has the Rate Exceeded 6%?
-          </Heading>
-          <p className="text-muted-foreground">
-            The maximum Plan 2 interest rate has exceeded 6% in{" "}
+    <GuideArticle
+      breadcrumbLabel="Interest Rate Cap"
+      title="Plan 2 interest rate capped at 6%: what it means for you"
+      intro={
+        <>
+          On 7 April 2026, the government announced a 6% cap on Plan 2 and Plan
+          3 student loan interest rates from September 2026. Here is what that
+          means in practice and how much it could save you.
+        </>
+      }
+      related={{
+        current: "interest-rate-cap",
+        order: ["how-interest-works", "rpi-vs-cpi", "plan-2-vs-plan-5"],
+        tools: ["/interest", "/repaid"],
+      }}
+    >
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          What Changed
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            Plan 2 loans charge interest on a sliding scale: from RPI (currently{" "}
+            {formatPercent(rpi)}) for lower earners up to RPI + 3% (currently{" "}
+            {formatPercent(currentMaxRate)}) for those earning above{" "}
             <strong className="text-foreground">
-              {String(YEARS_ABOVE_CAP)} out of {String(TOTAL_YEARS)} academic
-              years
-            </strong>{" "}
-            since Plan 2 was introduced in 2012. During the inflation crisis of
-            2022&ndash;2024, rates hit 7.7% even after the PMR cap was applied
-            &mdash; without that intervention, the formula rate would have
-            reached 16.5%.
+              {formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}
+            </strong>
+            . While studying, borrowers are charged the full RPI + 3%.
           </p>
-          <ChartFrame
-            caption="Fig. 1 — Maximum Plan 2 rate charged by year"
-            figure="Cap 6%"
-            figureTone="cost"
-          >
-            <HistoricalRatesChart />
-          </ChartFrame>
-          <p className="text-sm text-muted-foreground">
-            The bars show the maximum rate actually charged each year (after any
-            PMR intervention). The dashed line marks the new 6% cap.
+          <p>
+            From 1 September 2026, the maximum interest rate on Plan 2 and Plan
+            3 loans will be capped at{" "}
+            <strong className="text-foreground">6%</strong>, regardless of what
+            the RPI + 3% formula produces. This cap applies for the 2026/27
+            academic year.
           </p>
-        </section>
-
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            Impact on Your Balance
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              The real impact of the cap depends on future inflation. At current
-              RPI ({formatPercent(rpi)}), the difference is small. But if
-              inflation returns to levels seen in 2022&ndash;2023, the cap
-              prevents your balance from compounding at extreme rates.
-            </p>
-            <p>
-              The chart below starts at today&apos;s RPI ({formatPercent(rpi)}),
-              where the two lines nearly overlap. Try selecting 7% or 9% to see
-              why the cap was introduced &mdash; at those levels the gap between
-              capped and uncapped balances becomes dramatic. The scenario
-              assumes a {formatGBP(45_000)} loan, a {formatGBP(35_000)} starting
-              salary, and 3% annual growth.
-            </p>
-          </div>
-          <ChartFrame
-            caption="Fig. 2 — Balance with and without the 6% cap"
-            figure="Cap 6%"
-            figureTone="cost"
-            bodyClassName="h-80 sm:h-100"
-          >
-            <BalanceWithCapChart />
-          </ChartFrame>
-          <p className="text-sm text-muted-foreground">
-            At higher RPI values, the gap between the capped and uncapped
-            balance widens significantly. At 7% RPI, the uncapped rate would be
-            10% &mdash; the cap saves borrowers from this compounding effect.
+          <p>
+            At current rates, this barely bites &mdash; the maximum is{" "}
+            {formatPercent(currentMaxRate)}, only{" "}
+            {formatPercent(Math.round((currentMaxRate - 6) * 100) / 100)} above
+            the cap. But the cap is designed as insurance: if inflation surges
+            again, your interest rate will not follow it above 6%.
           </p>
-        </section>
+        </div>
+      </section>
 
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            How Much Less Could You Repay?
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              Because Plan 2 loans are written off after 30 years regardless of
-              the remaining balance, most borrowers will not repay in full. The
-              cap matters most for middle-to-high earners who do repay
-              everything &mdash; they accumulate less interest, so their total
-              bill is lower.
-            </p>
-            <p>
-              The chart below compares total repayment across salary levels,
-              assuming a sustained 7% RPI scenario. Lower earners see little
-              difference because their loans are written off either way. Higher
-              earners see meaningful savings.
-            </p>
-          </div>
-          <ChartFrame caption="Fig. 3 — Total repaid by salary · sustained 7% RPI">
-            <TotalCostComparisonChart />
-          </ChartFrame>
-        </section>
+      <section className="space-y-3">
+        <Heading as="h2" size="section" id="plan-2-interest-rates-at-a-glance">
+          Plan 2 Interest Rates at a Glance ({currentTaxYear})
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            The key Plan 2 interest figures for the {currentTaxYear} tax year,
+            alongside the 6% cap that applies from September 2026.
+          </p>
+        </div>
+      </section>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Who Benefits Most?
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <ul className="list-disc space-y-2 pl-6">
-              <li>
-                <strong className="text-foreground">
-                  Current students on Plan 2 or Plan 3
-                </strong>{" "}
-                &mdash; while studying, you are charged the maximum rate (RPI +
-                3%). The cap means this will not exceed 6%, slowing the growth
-                of your balance before you even start repaying.
-              </li>
-              <li>
-                <strong className="text-foreground">
-                  Higher earners with large balances
-                </strong>{" "}
-                &mdash; if you earn above{" "}
-                {formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}, you are
-                on the maximum rate. The cap gives you the biggest absolute
-                reduction in interest.
-              </li>
-              <li>
-                <strong className="text-foreground">
-                  Graduates who will repay in full
-                </strong>{" "}
-                &mdash; if your salary is high enough to clear the loan before
-                the 30-year write-off, lower interest means a lower total cost.
-              </li>
-            </ul>
-            <p>
-              Lower earners who will never repay in full are less directly
-              affected &mdash; the cap reduces the balance that eventually gets
-              written off, but does not change their monthly repayments (which
-              are based purely on income).
-            </p>
-          </div>
-        </section>
+      <div className="guide-breakout">
+        <CurrentCapTable />
+      </div>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            What This Does Not Change
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <ul className="list-disc space-y-2 pl-6">
-              <li>
-                <strong className="text-foreground">
-                  Monthly repayments are unchanged
-                </strong>{" "}
-                &mdash; you still repay 9% of income above the threshold (
-                {formatGBP(PLAN_CONFIGS.PLAN_2.monthlyThreshold * 12)}/year).
-                The cap only affects how fast your balance grows.
-              </li>
-              <li>
-                <strong className="text-foreground">
-                  Plan 1, 4, and 5 are not affected
-                </strong>{" "}
-                &mdash; Plan 1 and 4 rates are already capped at the lower of
-                RPI or Bank of England base rate + 1%. Plan 5 charges RPI only,
-                with no +3% component.
-              </li>
-              <li>
-                <strong className="text-foreground">
-                  The cap is for 2026/27 only
-                </strong>{" "}
-                &mdash; it has been announced for one academic year. Whether it
-                becomes permanent depends on future policy decisions.
-              </li>
-            </ul>
-          </div>
-        </section>
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Why the Government Acted
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            Skills Minister Jacqui Smith cited the risk of inflation pressures
+            from Middle East conflicts and global instability. When RPI spikes,
+            the RPI + 3% formula can push interest rates well into double digits
+            &mdash; exactly what happened in 2022&ndash;2024.
+          </p>
+          <p>
+            The government had previously used the &ldquo;prevailing market
+            rate&rdquo; (PMR) mechanism to intervene when rates became
+            unreasonable. The 6% cap formalises this protection with a clear,
+            predictable ceiling instead of ad-hoc adjustments.
+          </p>
+        </div>
+      </section>
 
-        <KeyTakeaways>
-          <li>
-            Plan 2 and Plan 3 interest will be capped at 6% from September 2026.
-          </li>
-          <li>
-            The maximum rate has exceeded 6% in {String(YEARS_ABOVE_CAP)} of the{" "}
-            {String(TOTAL_YEARS)} years since Plan 2 was introduced.
-          </li>
-          <li>
-            The biggest beneficiaries are higher earners and current students,
-            especially if inflation rises again.
-          </li>
-          <li>
-            Monthly repayments do not change &mdash; the cap only slows balance
-            growth.
-          </li>
-          <li>
-            The cap is announced for one year only (2026/27), though it may be
-            extended.
-          </li>
-        </KeyTakeaways>
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          How Often Has the Rate Exceeded 6%?
+        </Heading>
+        <p className="text-muted-foreground">
+          The maximum Plan 2 interest rate has exceeded 6% in{" "}
+          <strong className="text-foreground">
+            {String(YEARS_ABOVE_CAP)} out of {String(TOTAL_YEARS)} academic
+            years
+          </strong>{" "}
+          since Plan 2 was introduced in 2012. During the inflation crisis of
+          2022&ndash;2024, rates hit 7.7% even after the PMR cap was applied
+          &mdash; without that intervention, the formula rate would have reached
+          16.5%.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          The bars show the maximum rate actually charged each year (after any
+          PMR intervention). The dashed line marks the new 6% cap.
+        </p>
+      </section>
 
-        <RelatedGuides
-          current="interest-rate-cap"
-          order={["how-interest-works", "rpi-vs-cpi", "plan-2-vs-plan-5"]}
-          tools={["/interest", "/repaid"]}
-        />
-      </GuideArticle>
-    </PageLayout>
+      <ChartFrame
+        className="guide-breakout"
+        caption="Fig. 1 — Maximum Plan 2 rate charged by year"
+        figure="Cap 6%"
+        figureTone="cost"
+      >
+        <HistoricalRatesChart />
+      </ChartFrame>
+
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          Impact on Your Balance
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            The real impact of the cap depends on future inflation. At current
+            RPI ({formatPercent(rpi)}), the difference is small. But if
+            inflation returns to levels seen in 2022&ndash;2023, the cap
+            prevents your balance from compounding at extreme rates.
+          </p>
+          <p>
+            The chart below starts at today&apos;s RPI ({formatPercent(rpi)}),
+            where the two lines nearly overlap. Try selecting 7% or 9% to see
+            why the cap was introduced &mdash; at those levels the gap between
+            capped and uncapped balances becomes dramatic. The scenario assumes
+            a {formatGBP(45_000)} loan, a {formatGBP(35_000)} starting salary,
+            and 3% annual growth.
+          </p>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          At higher RPI values, the gap between the capped and uncapped balance
+          widens significantly. At 7% RPI, the uncapped rate would be 10%
+          &mdash; the cap saves borrowers from this compounding effect.
+        </p>
+      </section>
+
+      <ChartFrame
+        className="guide-breakout"
+        caption="Fig. 2 — Balance with and without the 6% cap"
+        figure="Cap 6%"
+        figureTone="cost"
+        bodyClassName="h-80 sm:h-100"
+      >
+        <BalanceWithCapChart />
+      </ChartFrame>
+
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          How Much Less Could You Repay?
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            Because Plan 2 loans are written off after 30 years regardless of
+            the remaining balance, most borrowers will not repay in full. The
+            cap matters most for middle-to-high earners who do repay everything
+            &mdash; they accumulate less interest, so their total bill is lower.
+          </p>
+          <p>
+            The chart below compares total repayment across salary levels,
+            assuming a sustained 7% RPI scenario. Lower earners see little
+            difference because their loans are written off either way. Higher
+            earners see meaningful savings.
+          </p>
+        </div>
+      </section>
+
+      <ChartFrame
+        className="guide-breakout"
+        caption="Fig. 3 — Total repaid by salary · sustained 7% RPI"
+      >
+        <TotalCostComparisonChart />
+      </ChartFrame>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Who Benefits Most?
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              <strong className="text-foreground">
+                Current students on Plan 2 or Plan 3
+              </strong>{" "}
+              &mdash; while studying, you are charged the maximum rate (RPI +
+              3%). The cap means this will not exceed 6%, slowing the growth of
+              your balance before you even start repaying.
+            </li>
+            <li>
+              <strong className="text-foreground">
+                Higher earners with large balances
+              </strong>{" "}
+              &mdash; if you earn above{" "}
+              {formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}, you are
+              on the maximum rate. The cap gives you the biggest absolute
+              reduction in interest.
+            </li>
+            <li>
+              <strong className="text-foreground">
+                Graduates who will repay in full
+              </strong>{" "}
+              &mdash; if your salary is high enough to clear the loan before the
+              30-year write-off, lower interest means a lower total cost.
+            </li>
+          </ul>
+          <p>
+            Lower earners who will never repay in full are less directly
+            affected &mdash; the cap reduces the balance that eventually gets
+            written off, but does not change their monthly repayments (which are
+            based purely on income).
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          What This Does Not Change
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              <strong className="text-foreground">
+                Monthly repayments are unchanged
+              </strong>{" "}
+              &mdash; you still repay 9% of income above the threshold (
+              {formatGBP(PLAN_CONFIGS.PLAN_2.monthlyThreshold * 12)}/year). The
+              cap only affects how fast your balance grows.
+            </li>
+            <li>
+              <strong className="text-foreground">
+                Plan 1, 4, and 5 are not affected
+              </strong>{" "}
+              &mdash; Plan 1 and 4 rates are already capped at the lower of RPI
+              or Bank of England base rate + 1%. Plan 5 charges RPI only, with
+              no +3% component.
+            </li>
+            <li>
+              <strong className="text-foreground">
+                The cap is for 2026/27 only
+              </strong>{" "}
+              &mdash; it has been announced for one academic year. Whether it
+              becomes permanent depends on future policy decisions.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <KeyTakeaways>
+        <li>
+          Plan 2 and Plan 3 interest will be capped at 6% from September 2026.
+        </li>
+        <li>
+          The maximum rate has exceeded 6% in {String(YEARS_ABOVE_CAP)} of the{" "}
+          {String(TOTAL_YEARS)} years since Plan 2 was introduced.
+        </li>
+        <li>
+          The biggest beneficiaries are higher earners and current students,
+          especially if inflation rises again.
+        </li>
+        <li>
+          Monthly repayments do not change &mdash; the cap only slows balance
+          growth.
+        </li>
+        <li>
+          The cap is announced for one year only (2026/27), though it may be
+          extended.
+        </li>
+      </KeyTakeaways>
+    </GuideArticle>
   );
 }

--- a/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
+++ b/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
@@ -6,9 +6,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
-import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { Panel } from "@/components/instrument/Panel";
-import { PageLayout } from "@/components/layout/PageLayout";
 import { ScrollFadeWrapper } from "@/components/shared/ScrollFadeWrapper";
 import { Heading } from "@/components/typography/Heading";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -53,381 +51,381 @@ const linkClasses = guideLink;
 
 export function MovingAbroadGuide() {
   return (
-    <PageLayout>
-      <GuideArticle
-        breadcrumbLabel="Moving Abroad"
-        title="What happens to your student loan if you move abroad?"
-        intro={
-          <>
-            Moving overseas doesn&rsquo;t make your student loan disappear. The
-            Student Loans Company (SLC) continues to collect repayments
-            regardless of where you live, and the rules for how much you pay
-            change when you leave the UK.
-          </>
-        }
-      >
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            You Must Notify SLC
-          </Heading>
-          <p className="text-sm text-muted-foreground sm:text-base">
-            If you&rsquo;re planning to leave the UK for more than three months,
-            you are legally required to inform SLC. This applies whether
-            you&rsquo;re moving for work, travel, or any other reason.
-          </p>
-          <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
-            <li>
-              Notify SLC <strong>within three months</strong> of moving abroad
-            </li>
-            <li>Provide your new overseas address and contact details</li>
-            <li>
-              Submit evidence of your income through the{" "}
-              <a
-                href={govUkAbroadLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={linkClasses}
-              >
-                overseas income assessment form
-              </a>
-            </li>
-            <li>
-              Continue providing income evidence annually to keep your
-              repayments accurate
-            </li>
-          </ul>
-        </section>
-
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            How Repayments Work Abroad
-          </Heading>
-          <p className="text-sm text-muted-foreground sm:text-base">
-            When you live in the UK, repayments are automatically deducted from
-            your salary through PAYE. Abroad, the system works differently.
-          </p>
-          <SeamGrid columns={3}>
-            <SeamCell
-              icon={
-                <HugeiconsIcon
-                  icon={Globe02Icon}
-                  className="size-5 text-primary"
-                />
-              }
-              title="Country thresholds"
-            >
-              SLC sets{" "}
-              <a
-                href={govUkAbroadLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={linkClasses}
-              >
-                country-specific repayment thresholds
-              </a>{" "}
-              based on local cost of living — they may be higher or lower than
-              the UK threshold.
-            </SeamCell>
-            <SeamCell
-              icon={
-                <HugeiconsIcon
-                  icon={CoinsPoundIcon}
-                  className="size-5 text-primary"
-                />
-              }
-              title="Repayment rates"
-            >
-              You still repay {undergradRate} of income above the threshold for
-              undergraduate loans ({postgradRate} for Postgraduate Loans).
-            </SeamCell>
-            <SeamCell
-              icon={
-                <HugeiconsIcon
-                  icon={CreditCardIcon}
-                  className="size-5 text-primary"
-                />
-              }
-              title="Direct payments to SLC"
-            >
-              Repayments are made directly to SLC rather than through your
-              employer.
-            </SeamCell>
-          </SeamGrid>
-        </section>
-
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            Country-by-Country: How Your Threshold Changes
-          </Heading>
-          <p className="text-sm text-muted-foreground sm:text-base">
-            SLC doesn&rsquo;t use a single overseas threshold for everyone.
-            Every country is placed into a price-level band that multiplies the
-            UK threshold up or down based on local living costs, so the salary
-            at which you start repaying can sit below or above the UK&rsquo;s{" "}
-            {formatGBP(UK_PLAN2_THRESHOLD)}. This is where{" "}
-            <strong>middle earners abroad feel it most</strong> &mdash; in a
-            lower-threshold country, a mid-range salary that would barely
-            trigger repayments at home can pull a much bigger slice into the{" "}
-            {undergradRate} repayment band.
-          </p>
-          <p className="text-sm text-muted-foreground sm:text-base">
-            The process is the same wherever you go: notify SLC within three
-            months, complete the overseas income assessment on your worldwide
-            income (converted into pounds), and re-submit evidence every year.
-            Only the threshold changes by country. Skip the assessment and SLC
-            falls back to fixed repayment amounts that are usually higher than
-            income-based ones.
-          </p>
-          <ScrollFadeWrapper className={surfaceCard}>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead scope="col" className={specHead}>
-                    Destination
-                  </TableHead>
-                  <TableHead scope="col" className={specHeadNum}>
-                    Plan 2 threshold (2026/27)
-                  </TableHead>
-                  <TableHead scope="col" className={specHead}>
-                    Compared to the UK
-                  </TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {overseasThresholds.map((row) => (
-                  <TableRow key={row.country}>
-                    <TableHead
-                      scope="row"
-                      className="font-semibold text-foreground"
-                    >
-                      {row.country}
-                    </TableHead>
-                    <TableCell className={specNum}>
-                      {formatGBP(row.threshold)}
-                    </TableCell>
-                    <TableCell className="text-muted-foreground">
-                      {overseasComparisonLabel(row.threshold)}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </ScrollFadeWrapper>
-          <p className="text-xs text-muted-foreground sm:text-sm">
-            Figures are SLC&rsquo;s Plan 2 (undergraduate) overseas thresholds
-            for 2026/27, set against the UK threshold of{" "}
-            {formatGBP(UK_PLAN2_THRESHOLD)}. Other plans use a different base
-            figure, and SLC revises every country each April &mdash; always{" "}
+    <GuideArticle
+      breadcrumbLabel="Moving Abroad"
+      title="What happens to your student loan if you move abroad?"
+      intro={
+        <>
+          Moving overseas doesn&rsquo;t make your student loan disappear. The
+          Student Loans Company (SLC) continues to collect repayments regardless
+          of where you live, and the rules for how much you pay change when you
+          leave the UK.
+        </>
+      }
+      related={{
+        current: "moving-abroad",
+        order: ["self-employment", "plan-2-vs-plan-5"],
+        tools: ["/repaid", "/"],
+        extraLinks: [
+          {
+            href: "https://www.gov.uk/repaying-your-student-loan/repaying-from-abroad",
+            label: "GOV.UK: Repaying from Abroad",
+          },
+        ],
+      }}
+    >
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          You Must Notify SLC
+        </Heading>
+        <p className="text-muted-foreground">
+          If you&rsquo;re planning to leave the UK for more than three months,
+          you are legally required to inform SLC. This applies whether
+          you&rsquo;re moving for work, travel, or any other reason.
+        </p>
+        <ul className="list-inside list-disc space-y-2 text-muted-foreground">
+          <li>
+            Notify SLC <strong>within three months</strong> of moving abroad
+          </li>
+          <li>Provide your new overseas address and contact details</li>
+          <li>
+            Submit evidence of your income through the{" "}
             <a
-              href={govUkOverseasThresholdsLink}
+              href={govUkAbroadLink}
               target="_blank"
               rel="noopener noreferrer"
               className={linkClasses}
             >
-              check the latest figures on GOV.UK
+              overseas income assessment form
             </a>
-            .
-          </p>
-          <ul className="list-inside list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
-            <li>
-              <strong className="text-foreground">
-                Australia, Canada &amp; New Zealand:
-              </strong>{" "}
-              currently sit in the same band as the UK, so your threshold
-              matches the home figure and repayments feel much like they did in
-              the UK.
-            </li>
-            <li>
-              <strong className="text-foreground">Spain:</strong> a lower band
-              pulls the threshold below the UK&rsquo;s, so repayments start
-              earlier &mdash; a classic squeeze on middle earners.
-            </li>
-            <li>
-              <strong className="text-foreground">UAE (Dubai):</strong> there is
-              no local income tax, but your UK student loan is separate from
-              that &mdash; the SLC threshold is still lower than the UK&rsquo;s,
-              so a tax-free salary is caught sooner, not exempted.
-            </li>
-            <li>
-              <strong className="text-foreground">United States:</strong> a
-              higher band lifts the threshold above the UK&rsquo;s, so you keep
-              more of your salary before repayments begin.
-            </li>
-          </ul>
-        </section>
+          </li>
+          <li>
+            Continue providing income evidence annually to keep your repayments
+            accurate
+          </li>
+        </ul>
+      </section>
 
-        <section className="space-y-4">
-          <Alert className="border-signal/30 bg-signal-wash text-signal">
-            <HugeiconsIcon icon={AlertCircleIcon} className="size-4" />
-            <AlertTitle>
-              What If You Don&rsquo;t Provide Income Evidence?
-            </AlertTitle>
-            <AlertDescription className="text-signal">
-              <p>
-                If you fail to complete the overseas income assessment, SLC
-                doesn&rsquo;t simply stop collecting. Instead, they apply{" "}
-                <strong>fixed repayment amounts</strong> that are not based on
-                your actual earnings.
-              </p>
-              <ul className="mt-2 list-inside list-disc space-y-1 marker:text-signal">
-                <li>
-                  Fixed amounts can be <strong>significantly higher</strong>{" "}
-                  than what you would pay based on your real income
-                </li>
-                <li>
-                  This effectively acts as a penalty for not engaging with the
-                  process
-                </li>
-                <li>
-                  You can avoid this by submitting your income evidence on time
-                  each year
-                </li>
-              </ul>
-            </AlertDescription>
-          </Alert>
-        </section>
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          How Repayments Work Abroad
+        </Heading>
+        <p className="text-muted-foreground">
+          When you live in the UK, repayments are automatically deducted from
+          your salary through PAYE. Abroad, the system works differently.
+        </p>
+        <SeamGrid columns={3}>
+          <SeamCell
+            icon={
+              <HugeiconsIcon
+                icon={Globe02Icon}
+                className="size-5 text-primary"
+              />
+            }
+            title="Country thresholds"
+          >
+            SLC sets{" "}
+            <a
+              href={govUkAbroadLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={linkClasses}
+            >
+              country-specific repayment thresholds
+            </a>{" "}
+            based on local cost of living — they may be higher or lower than the
+            UK threshold.
+          </SeamCell>
+          <SeamCell
+            icon={
+              <HugeiconsIcon
+                icon={CoinsPoundIcon}
+                className="size-5 text-primary"
+              />
+            }
+            title="Repayment rates"
+          >
+            You still repay {undergradRate} of income above the threshold for
+            undergraduate loans ({postgradRate} for Postgraduate Loans).
+          </SeamCell>
+          <SeamCell
+            icon={
+              <HugeiconsIcon
+                icon={CreditCardIcon}
+                className="size-5 text-primary"
+              />
+            }
+            title="Direct payments to SLC"
+          >
+            Repayments are made directly to SLC rather than through your
+            employer.
+          </SeamCell>
+        </SeamGrid>
+      </section>
 
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            Consequences of Non-Compliance
-          </Heading>
-          <p className="text-pretty text-muted-foreground">
-            Ignoring your student loan obligations while abroad can have serious
-            consequences. SLC has several enforcement mechanisms available.
-          </p>
-          <Panel>
-            <ul className="list-disc space-y-2 pl-5 text-muted-foreground marker:text-signal">
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          Country-by-Country: How Your Threshold Changes
+        </Heading>
+        <p className="text-muted-foreground">
+          SLC doesn&rsquo;t use a single overseas threshold for everyone. Every
+          country is placed into a price-level band that multiplies the UK
+          threshold up or down based on local living costs, so the salary at
+          which you start repaying can sit below or above the UK&rsquo;s{" "}
+          {formatGBP(UK_PLAN2_THRESHOLD)}. This is where{" "}
+          <strong>middle earners abroad feel it most</strong> &mdash; in a
+          lower-threshold country, a mid-range salary that would barely trigger
+          repayments at home can pull a much bigger slice into the{" "}
+          {undergradRate} repayment band.
+        </p>
+        <p className="text-muted-foreground">
+          The process is the same wherever you go: notify SLC within three
+          months, complete the overseas income assessment on your worldwide
+          income (converted into pounds), and re-submit evidence every year.
+          Only the threshold changes by country. Skip the assessment and SLC
+          falls back to fixed repayment amounts that are usually higher than
+          income-based ones.
+        </p>
+      </section>
+
+      <div className="guide-breakout">
+        <ScrollFadeWrapper className={surfaceCard}>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead scope="col" className={specHead}>
+                  Destination
+                </TableHead>
+                <TableHead scope="col" className={specHeadNum}>
+                  Plan 2 threshold (2026/27)
+                </TableHead>
+                <TableHead scope="col" className={specHead}>
+                  Compared to the UK
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {overseasThresholds.map((row) => (
+                <TableRow key={row.country}>
+                  <TableHead
+                    scope="row"
+                    className="font-semibold text-foreground"
+                  >
+                    {row.country}
+                  </TableHead>
+                  <TableCell className={specNum}>
+                    {formatGBP(row.threshold)}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {overseasComparisonLabel(row.threshold)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </ScrollFadeWrapper>
+      </div>
+
+      <div className="space-y-4">
+        <p className="text-xs text-muted-foreground sm:text-sm">
+          Figures are SLC&rsquo;s Plan 2 (undergraduate) overseas thresholds for
+          2026/27, set against the UK threshold of{" "}
+          {formatGBP(UK_PLAN2_THRESHOLD)}. Other plans use a different base
+          figure, and SLC revises every country each April &mdash; always{" "}
+          <a
+            href={govUkOverseasThresholdsLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={linkClasses}
+          >
+            check the latest figures on GOV.UK
+          </a>
+          .
+        </p>
+        <ul className="list-inside list-disc space-y-2 text-muted-foreground">
+          <li>
+            <strong className="text-foreground">
+              Australia, Canada &amp; New Zealand:
+            </strong>{" "}
+            currently sit in the same band as the UK, so your threshold matches
+            the home figure and repayments feel much like they did in the UK.
+          </li>
+          <li>
+            <strong className="text-foreground">Spain:</strong> a lower band
+            pulls the threshold below the UK&rsquo;s, so repayments start
+            earlier &mdash; a classic squeeze on middle earners.
+          </li>
+          <li>
+            <strong className="text-foreground">UAE (Dubai):</strong> there is
+            no local income tax, but your UK student loan is separate from that
+            &mdash; the SLC threshold is still lower than the UK&rsquo;s, so a
+            tax-free salary is caught sooner, not exempted.
+          </li>
+          <li>
+            <strong className="text-foreground">United States:</strong> a higher
+            band lifts the threshold above the UK&rsquo;s, so you keep more of
+            your salary before repayments begin.
+          </li>
+        </ul>
+      </div>
+
+      <section className="space-y-4">
+        <Alert className="border-signal/30 bg-signal-wash text-signal">
+          <HugeiconsIcon icon={AlertCircleIcon} className="size-4" />
+          <AlertTitle>
+            What If You Don&rsquo;t Provide Income Evidence?
+          </AlertTitle>
+          <AlertDescription className="text-signal">
+            <p>
+              If you fail to complete the overseas income assessment, SLC
+              doesn&rsquo;t simply stop collecting. Instead, they apply{" "}
+              <strong>fixed repayment amounts</strong> that are not based on
+              your actual earnings.
+            </p>
+            <ul className="mt-2 list-inside list-disc space-y-1 marker:text-signal">
               <li>
-                SLC can take <strong>legal action</strong> to recover the debt.
+                Fixed amounts can be <strong>significantly higher</strong> than
+                what you would pay based on your real income
               </li>
               <li>
-                Your debt may be passed to <strong>collection agencies</strong>.
+                This effectively acts as a penalty for not engaging with the
+                process
               </li>
               <li>
-                If you return to the UK, missed payments could{" "}
-                <strong>affect your credit record</strong>.
-              </li>
-              <li>
-                Additional <strong>penalties and interest</strong> may be
-                applied to your balance.
-              </li>
-              <li>
-                HMRC can resume automatic deductions from your salary if you
-                return to UK employment.
+                You can avoid this by submitting your income evidence on time
+                each year
               </li>
             </ul>
-          </Panel>
-        </section>
+          </AlertDescription>
+        </Alert>
+      </section>
 
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            Practical Steps Before You Move
-          </Heading>
-          <p className="text-sm text-muted-foreground sm:text-base">
-            If you&rsquo;re planning to move abroad, take these steps to stay on
-            top of your loan.
-          </p>
-          <StepList>
-            {[
-              {
-                title: "Notify SLC",
-                description:
-                  "Inform SLC of your move and new address as early as possible.",
-              },
-              {
-                title: "Complete the overseas income assessment",
-                description:
-                  "Submit the form to ensure your repayments are based on your actual income.",
-              },
-              {
-                title: "Check your country\u2019s threshold",
-                description:
-                  "Look up the SLC website so you know what to expect for your destination.",
-              },
-              {
-                title: "Set up a payment method",
-                description:
-                  "Arrange a way to make direct repayments to SLC from abroad.",
-              },
-              {
-                title: "Keep records",
-                description:
-                  "Save all correspondence and payment confirmations with SLC.",
-              },
-              {
-                title: "Set annual reminders",
-                description:
-                  "Resubmit income evidence before the deadline each year.",
-              },
-            ].map((step, i) => (
-              <Step key={step.title} index={i + 1} title={step.title}>
-                {step.description}
-              </Step>
-            ))}
-          </StepList>
-        </section>
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          Consequences of Non-Compliance
+        </Heading>
+        <p className="text-pretty text-muted-foreground">
+          Ignoring your student loan obligations while abroad can have serious
+          consequences. SLC has several enforcement mechanisms available.
+        </p>
+        <Panel>
+          <ul className="list-disc space-y-2 pl-5 text-muted-foreground marker:text-signal">
+            <li>
+              SLC can take <strong>legal action</strong> to recover the debt.
+            </li>
+            <li>
+              Your debt may be passed to <strong>collection agencies</strong>.
+            </li>
+            <li>
+              If you return to the UK, missed payments could{" "}
+              <strong>affect your credit record</strong>.
+            </li>
+            <li>
+              Additional <strong>penalties and interest</strong> may be applied
+              to your balance.
+            </li>
+            <li>
+              HMRC can resume automatic deductions from your salary if you
+              return to UK employment.
+            </li>
+          </ul>
+        </Panel>
+      </section>
 
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            Moving Abroad: Frequently Asked Questions
-          </Heading>
-          <Panel
-            padding={false}
-            className="divide-y divide-border overflow-hidden"
-          >
-            {movingAbroadFaqs.map((faq) => (
-              <div key={faq.question} className="space-y-2 p-4 sm:p-5">
-                <p className="font-semibold text-foreground">{faq.question}</p>
-                <p className="text-sm text-muted-foreground sm:text-base">
-                  {faq.answer}
-                </p>
-              </div>
-            ))}
-          </Panel>
-        </section>
-
-        <KeyTakeaways>
-          <li>
-            Moving abroad does <strong>not</strong> cancel or pause your student
-            loan repayments.
-          </li>
-          <li>
-            You must notify SLC within three months and provide annual income
-            evidence.
-          </li>
-          <li>
-            Repayment thresholds vary by country based on local cost of living.
-          </li>
-          <li>
-            Failing to engage with SLC results in fixed repayment amounts that
-            are typically higher than income-based payments.
-          </li>
-          <li>
-            Non-compliance can lead to legal action, collection agencies, and
-            credit impacts if you return to the UK.
-          </li>
-          <li>
-            Before you move, check your remaining balance and repayment timeline
-            with the{" "}
-            <Link href="/" className={guideLink}>
-              repayment calculator
-            </Link>
-            .
-          </li>
-        </KeyTakeaways>
-
-        <RelatedGuides
-          current="moving-abroad"
-          order={["self-employment", "plan-2-vs-plan-5"]}
-          tools={["/repaid", "/"]}
-          extraLinks={[
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          Practical Steps Before You Move
+        </Heading>
+        <p className="text-muted-foreground">
+          If you&rsquo;re planning to move abroad, take these steps to stay on
+          top of your loan.
+        </p>
+        <StepList>
+          {[
             {
-              href: "https://www.gov.uk/repaying-your-student-loan/repaying-from-abroad",
-              label: "GOV.UK: Repaying from Abroad",
+              title: "Notify SLC",
+              description:
+                "Inform SLC of your move and new address as early as possible.",
             },
-          ]}
-        />
-      </GuideArticle>
-    </PageLayout>
+            {
+              title: "Complete the overseas income assessment",
+              description:
+                "Submit the form to ensure your repayments are based on your actual income.",
+            },
+            {
+              title: "Check your country\u2019s threshold",
+              description:
+                "Look up the SLC website so you know what to expect for your destination.",
+            },
+            {
+              title: "Set up a payment method",
+              description:
+                "Arrange a way to make direct repayments to SLC from abroad.",
+            },
+            {
+              title: "Keep records",
+              description:
+                "Save all correspondence and payment confirmations with SLC.",
+            },
+            {
+              title: "Set annual reminders",
+              description:
+                "Resubmit income evidence before the deadline each year.",
+            },
+          ].map((step, i) => (
+            <Step key={step.title} index={i + 1} title={step.title}>
+              {step.description}
+            </Step>
+          ))}
+        </StepList>
+      </section>
+
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          Moving Abroad: Frequently Asked Questions
+        </Heading>
+        <Panel
+          padding={false}
+          className="divide-y divide-border overflow-hidden"
+        >
+          {movingAbroadFaqs.map((faq) => (
+            <div key={faq.question} className="space-y-2 p-4 sm:p-5">
+              <p className="font-semibold text-foreground">{faq.question}</p>
+              <p className="text-muted-foreground">{faq.answer}</p>
+            </div>
+          ))}
+        </Panel>
+      </section>
+
+      <KeyTakeaways>
+        <li>
+          Moving abroad does <strong>not</strong> cancel or pause your student
+          loan repayments.
+        </li>
+        <li>
+          You must notify SLC within three months and provide annual income
+          evidence.
+        </li>
+        <li>
+          Repayment thresholds vary by country based on local cost of living.
+        </li>
+        <li>
+          Failing to engage with SLC results in fixed repayment amounts that are
+          typically higher than income-based payments.
+        </li>
+        <li>
+          Non-compliance can lead to legal action, collection agencies, and
+          credit impacts if you return to the UK.
+        </li>
+        <li>
+          Before you move, check your remaining balance and repayment timeline
+          with the{" "}
+          <Link href="/" className={guideLink}>
+            repayment calculator
+          </Link>
+          .
+        </li>
+      </KeyTakeaways>
+    </GuideArticle>
   );
 }

--- a/src/components/guides/pay-upfront-or-take-loan/PayUpfrontGuide.tsx
+++ b/src/components/guides/pay-upfront-or-take-loan/PayUpfrontGuide.tsx
@@ -1,7 +1,5 @@
 import Link from "next/link";
-import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { ChartFrame } from "@/components/instrument/ChartFrame";
-import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import { formatGBP } from "@/lib/format";
 import {
@@ -20,207 +18,203 @@ const feeCapFormatted = formatGBP(TUITION_FEE_CAP);
 
 export function PayUpfrontGuide() {
   return (
-    <PageLayout>
-      <GuideArticle
-        breadcrumbLabel="Pay Upfront or Take the Loan?"
-        title="Should you pay tuition upfront or take the loan?"
-        intro={
-          <>
-            The answer depends on how much the graduate will earn over their
-            career &mdash; and starting salary alone doesn&rsquo;t tell the
-            whole story.
-          </>
-        }
+    <GuideArticle
+      breadcrumbLabel="Pay Upfront or Take the Loan?"
+      title="Should you pay tuition upfront or take the loan?"
+      intro={
+        <>
+          The answer depends on how much the graduate will earn over their
+          career &mdash; and starting salary alone doesn&rsquo;t tell the whole
+          story.
+        </>
+      }
+      related={{
+        current: "pay-upfront-or-take-loan",
+        order: ["how-interest-works", "plan-2-vs-plan-5"],
+        tools: ["/overpay", "/repaid"],
+      }}
+    >
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          The Cost of Paying Upfront
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            At the current maximum tuition fee of {feeCapFormatted} per year, a
+            standard three-year undergraduate degree costs{" "}
+            <strong className="text-foreground">{tuitionFormatted}</strong> in
+            tuition fees alone. Paying this upfront means handing over that sum
+            before the student even starts, with no possibility of getting any
+            of it back.
+          </p>
+          <p>
+            That money is gone regardless of what happens next &mdash; whether
+            the graduate earns &pound;25,000 or &pound;100,000 a year, the cost
+            is fixed at {tuitionFormatted}.
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          What Happens If You Take the Loan Instead
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            Under Plan 5, tuition fee loans are written off{" "}
+            <strong className="text-foreground">{writeOffYears} years</strong>{" "}
+            after the graduate becomes eligible to repay. Repayments are 9% of
+            earnings above the {threshold} threshold, and interest is charged at
+            RPI only.
+          </p>
+          <p>
+            The total you end up paying depends on your earning trajectory over
+            those {writeOffYears} years, and graduates broadly fall into three
+            groups:
+          </p>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              <strong className="text-foreground">Low earners</strong> &mdash;
+              repayments stay small and the loan is partially written off. Total
+              cost ends up well below {tuitionFormatted}. The loan is clearly
+              cheaper than paying upfront.
+            </li>
+            <li>
+              <strong className="text-foreground">Middle earners</strong>{" "}
+              &mdash; this is the trap. You earn enough to keep repaying for
+              decades but not enough to clear the balance before interest
+              compounds. Total repayments can exceed the upfront cost, sometimes
+              significantly. This is the group that ends up paying the most.
+            </li>
+            <li>
+              <strong className="text-foreground">High earners</strong> &mdash;
+              clear the loan relatively quickly, so interest doesn&rsquo;t
+              compound much. Total cost is close to or slightly above the
+              upfront price, and you kept your capital in the meantime.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          The Salary Growth Trap
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            A graduate starting on &pound;30,000 might think &ldquo;at this
+            salary I&rsquo;ll barely repay anything.&rdquo; But salaries grow.
+            At 4% annual growth &mdash; a typical career progression &mdash; a
+            &pound;30k starting salary reaches roughly &pound;65k after 20
+            years.
+          </p>
+          <p>
+            As salary grows, repayments increase, and many graduates who
+            expected to be in the &ldquo;low earner&rdquo; category end up
+            firmly in the middle-earner zone, paying more than the upfront cost
+            over the life of the loan.
+          </p>
+          <p>
+            The chart below shows how this plays out. Notice the gap between the
+            flat-salary line and the growing-salary line &mdash; that gap is the
+            hidden cost of salary growth that a snapshot of your starting salary
+            won&rsquo;t reveal.
+          </p>
+        </div>
+      </section>
+
+      <ChartFrame
+        className="guide-breakout"
+        caption="Fig. 1 — Total cost: loan vs upfront by salary · Plan 5"
+        figure={`Upfront ${tuitionFormatted}`}
+        figureTone="cost"
+        bodyClassName="h-75 sm:h-90"
       >
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            The Cost of Paying Upfront
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              At the current maximum tuition fee of {feeCapFormatted} per year,
-              a standard three-year undergraduate degree costs{" "}
-              <strong className="text-foreground">{tuitionFormatted}</strong> in
-              tuition fees alone. Paying this upfront means handing over that
-              sum before the student even starts, with no possibility of getting
-              any of it back.
-            </p>
-            <p>
-              That money is gone regardless of what happens next &mdash; whether
-              the graduate earns &pound;25,000 or &pound;100,000 a year, the
-              cost is fixed at {tuitionFormatted}.
-            </p>
-          </div>
-        </section>
+        <CostComparisonChart />
+      </ChartFrame>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            What Happens If You Take the Loan Instead
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              Under Plan 5, tuition fee loans are written off{" "}
-              <strong className="text-foreground">{writeOffYears} years</strong>{" "}
-              after the graduate becomes eligible to repay. Repayments are 9% of
-              earnings above the {threshold} threshold, and interest is charged
-              at RPI only.
-            </p>
-            <p>
-              The total you end up paying depends on your earning trajectory
-              over those {writeOffYears} years, and graduates broadly fall into
-              three groups:
-            </p>
-            <ul className="list-disc space-y-2 pl-6">
-              <li>
-                <strong className="text-foreground">Low earners</strong> &mdash;
-                repayments stay small and the loan is partially written off.
-                Total cost ends up well below {tuitionFormatted}. The loan is
-                clearly cheaper than paying upfront.
-              </li>
-              <li>
-                <strong className="text-foreground">Middle earners</strong>{" "}
-                &mdash; this is the trap. You earn enough to keep repaying for
-                decades but not enough to clear the balance before interest
-                compounds. Total repayments can exceed the upfront cost,
-                sometimes significantly. This is the group that ends up paying
-                the most.
-              </li>
-              <li>
-                <strong className="text-foreground">High earners</strong>{" "}
-                &mdash; clear the loan relatively quickly, so interest
-                doesn&rsquo;t compound much. Total cost is close to or slightly
-                above the upfront price, and you kept your capital in the
-                meantime.
-              </li>
-            </ul>
-          </div>
-        </section>
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          When Paying Upfront Makes Sense
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            Paying upfront can save money for graduates who will land in the
+            middle-earner zone &mdash; not just the highest earners.
+          </p>
+          <ul className="list-disc space-y-1 pl-6">
+            <li>
+              The graduate expects moderate-to-high earnings over their career
+              (the middle-earner zone where total repayments exceed the upfront
+              cost)
+            </li>
+            <li>
+              The family has the funds available without impacting their own
+              financial security
+            </li>
+            <li>
+              The graduate wants to avoid decades of repayments that end up
+              exceeding the original tuition cost
+            </li>
+          </ul>
+        </div>
+      </section>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            The Salary Growth Trap
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              A graduate starting on &pound;30,000 might think &ldquo;at this
-              salary I&rsquo;ll barely repay anything.&rdquo; But salaries grow.
-              At 4% annual growth &mdash; a typical career progression &mdash; a
-              &pound;30k starting salary reaches roughly &pound;65k after 20
-              years.
-            </p>
-            <p>
-              As salary grows, repayments increase, and many graduates who
-              expected to be in the &ldquo;low earner&rdquo; category end up
-              firmly in the middle-earner zone, paying more than the upfront
-              cost over the life of the loan.
-            </p>
-            <p>
-              The chart below shows how this plays out. Notice the gap between
-              the flat-salary line and the growing-salary line &mdash; that gap
-              is the hidden cost of salary growth that a snapshot of your
-              starting salary won&rsquo;t reveal.
-            </p>
-          </div>
-        </section>
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          When Taking the Loan Makes Sense
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            The loan works best at the extremes of the earning spectrum, and as
+            a safety net for uncertainty.
+          </p>
+          <ul className="list-disc space-y-1 pl-6">
+            <li>
+              The graduate expects to stay on a lower salary &mdash; the loan
+              will be partially written off, costing less than paying upfront
+            </li>
+            <li>
+              The graduate expects very high earnings &mdash; they clear the
+              loan quickly and kept their capital invested in the meantime
+            </li>
+            <li>
+              The family would rather keep the {tuitionFormatted} as a financial
+              safety net
+            </li>
+            <li>
+              Repayments adjust automatically if earnings drop &mdash; built-in
+              insurance that paying upfront doesn&rsquo;t offer
+            </li>
+          </ul>
+        </div>
+      </section>
 
-        <ChartFrame
-          caption="Fig. 1 — Total cost: loan vs upfront by salary · Plan 5"
-          figure={`Upfront ${tuitionFormatted}`}
-          figureTone="cost"
-          bodyClassName="h-75 sm:h-90"
-        >
-          <CostComparisonChart />
-        </ChartFrame>
-
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            When Paying Upfront Makes Sense
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              Paying upfront can save money for graduates who will land in the
-              middle-earner zone &mdash; not just the highest earners.
-            </p>
-            <ul className="list-disc space-y-1 pl-6">
-              <li>
-                The graduate expects moderate-to-high earnings over their career
-                (the middle-earner zone where total repayments exceed the
-                upfront cost)
-              </li>
-              <li>
-                The family has the funds available without impacting their own
-                financial security
-              </li>
-              <li>
-                The graduate wants to avoid decades of repayments that end up
-                exceeding the original tuition cost
-              </li>
-            </ul>
-          </div>
-        </section>
-
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            When Taking the Loan Makes Sense
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              The loan works best at the extremes of the earning spectrum, and
-              as a safety net for uncertainty.
-            </p>
-            <ul className="list-disc space-y-1 pl-6">
-              <li>
-                The graduate expects to stay on a lower salary &mdash; the loan
-                will be partially written off, costing less than paying upfront
-              </li>
-              <li>
-                The graduate expects very high earnings &mdash; they clear the
-                loan quickly and kept their capital invested in the meantime
-              </li>
-              <li>
-                The family would rather keep the {tuitionFormatted} as a
-                financial safety net
-              </li>
-              <li>
-                Repayments adjust automatically if earnings drop &mdash;
-                built-in insurance that paying upfront doesn&rsquo;t offer
-              </li>
-            </ul>
-          </div>
-        </section>
-
-        <KeyTakeaways>
-          <li>
-            The loan is not universally cheaper than paying upfront &mdash; it
-            depends on earning trajectory.
-          </li>
-          <li>
-            Starting salary is misleading; salary growth pushes many graduates
-            into higher repayment brackets over time.
-          </li>
-          <li>
-            Middle earners often end up paying the most due to interest
-            compounding over decades of repayments.
-          </li>
-          <li>
-            The loan works best for genuine low earners (partial write-off) or
-            very high earners (fast repayment).
-          </li>
-          <li>
-            <Link href="/" className={guideLink}>
-              Use the student loan repayment calculator
-            </Link>{" "}
-            to model your specific scenario with your expected salary and growth
-            rate.
-          </li>
-        </KeyTakeaways>
-
-        <RelatedGuides
-          current="pay-upfront-or-take-loan"
-          order={["how-interest-works", "plan-2-vs-plan-5"]}
-          tools={["/overpay", "/repaid"]}
-        />
-      </GuideArticle>
-    </PageLayout>
+      <KeyTakeaways>
+        <li>
+          The loan is not universally cheaper than paying upfront &mdash; it
+          depends on earning trajectory.
+        </li>
+        <li>
+          Starting salary is misleading; salary growth pushes many graduates
+          into higher repayment brackets over time.
+        </li>
+        <li>
+          Middle earners often end up paying the most due to interest
+          compounding over decades of repayments.
+        </li>
+        <li>
+          The loan works best for genuine low earners (partial write-off) or
+          very high earners (fast repayment).
+        </li>
+        <li>
+          <Link href="/" className={guideLink}>
+            Use the student loan repayment calculator
+          </Link>{" "}
+          to model your specific scenario with your expected salary and growth
+          rate.
+        </li>
+      </KeyTakeaways>
+    </GuideArticle>
   );
 }

--- a/src/components/guides/plan-2-vs-plan-5/Plan2VsPlan5Guide.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/Plan2VsPlan5Guide.tsx
@@ -1,7 +1,5 @@
 import Link from "next/link";
-import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { ChartFrame } from "@/components/instrument/ChartFrame";
-import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import { formatGBP } from "@/lib/format";
 import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
@@ -24,217 +22,219 @@ const plan5Annual = Math.round(
 
 export function Plan2VsPlan5Guide() {
   return (
-    <PageLayout>
-      <GuideArticle
-        breadcrumbLabel="Plan 2 vs Plan 5"
-        title="Plan 2 vs Plan 5: which is better?"
-        intro={
-          <>
-            Plan 2 and Plan 5 are the two loan types most English university
-            students will encounter. Plan 2 covers those who started between
-            2012 and 2023, while Plan 5 applies from 2023 onwards. They differ
-            in repayment threshold, interest rate, and write-off period — and
-            these differences can mean tens of thousands of pounds more or less
-            repaid over your career.
-          </>
-        }
+    <GuideArticle
+      breadcrumbLabel="Plan 2 vs Plan 5"
+      title="Plan 2 vs Plan 5: which is better?"
+      intro={
+        <>
+          Plan 2 and Plan 5 are the two loan types most English university
+          students will encounter. Plan 2 covers those who started between 2012
+          and 2023, while Plan 5 applies from 2023 onwards. They differ in
+          repayment threshold, interest rate, and write-off period — and these
+          differences can mean tens of thousands of pounds more or less repaid
+          over your career.
+        </>
+      }
+      related={{
+        current: "plan-2-vs-plan-5",
+        order: ["how-interest-works", "pay-upfront-or-take-loan"],
+        tools: ["/which-plan", "/plans", "/repaid"],
+      }}
+    >
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          Side-by-Side Comparison
+        </Heading>
+        <p className="text-muted-foreground">
+          The key terms of each plan at a glance. Plan 5 has a lower threshold
+          and longer write-off, but simpler (and lower) interest.
+        </p>
+      </section>
+
+      <div className="guide-breakout">
+        <ComparisonTable />
+      </div>
+
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          Total repayment by salary
+        </Heading>
+        <p className="text-pretty text-muted-foreground">
+          How much you repay in total depends heavily on your salary. This chart
+          shows the total amount repaid over the life of each loan for a range
+          of starting salaries, assuming a balance of
+          {"\u00a0"}
+          {formatGBP(EXAMPLE_BALANCE)}.
+        </p>
+      </section>
+
+      <ChartFrame
+        className="guide-breakout"
+        caption={`Fig. 1 — Lifetime repaid by salary · ${formatGBP(EXAMPLE_BALANCE)} balance`}
+        bodyClassName="h-75 sm:h-95"
       >
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            Side-by-Side Comparison
-          </Heading>
-          <p className="text-sm text-muted-foreground sm:text-base">
-            The key terms of each plan at a glance. Plan 5 has a lower threshold
-            and longer write-off, but simpler (and lower) interest.
+        <TotalRepaymentBySalaryChart />
+      </ChartFrame>
+
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          Balance over time
+        </Heading>
+        <p className="text-pretty text-muted-foreground">
+          See how the outstanding balance changes month by month. Toggle between
+          salary levels to see how income affects the repayment trajectory for
+          each plan. The dashed markers show each plan&rsquo;s write-off point
+          &mdash; Plan 2 at 30 years, Plan 5 at 40 years.
+        </p>
+      </section>
+
+      <ChartFrame
+        className="guide-breakout"
+        caption={`Fig. 2 — Balance over time · Plan 2 vs Plan 5`}
+        bodyClassName="h-85 sm:h-105"
+      >
+        <BalanceComparisonChart />
+      </ChartFrame>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Which Plan Do I Have?
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            You cannot choose between Plan 2 and Plan 5 &mdash; your plan is
+            determined by when and where you started your course. Plan 2 covers
+            English and Welsh students who started university between September
+            2012 and July 2023. Plan 5 applies to English students who started
+            from September 2023 onwards.
           </p>
-          <ComparisonTable />
-        </section>
-
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            Total repayment by salary
-          </Heading>
-          <p className="text-pretty text-muted-foreground">
-            How much you repay in total depends heavily on your salary. This
-            chart shows the total amount repaid over the life of each loan for a
-            range of starting salaries, assuming a balance of
-            {"\u00a0"}
-            {formatGBP(EXAMPLE_BALANCE)}.
+          <p>
+            The cutoff is August 2023. If you started in the 2022&ndash;23
+            academic year, you are on Plan 2. If you started in September 2023
+            or later, you are on Plan 5. Note that Plan 5 is England-only
+            &mdash; Welsh students who started after August 2023 remain on Plan
+            2.
           </p>
-          <ChartFrame
-            caption={`Fig. 1 \u2014 Lifetime repaid by salary \u00b7 ${formatGBP(EXAMPLE_BALANCE)} balance`}
-            bodyClassName="h-75 sm:h-95"
-          >
-            <TotalRepaymentBySalaryChart />
-          </ChartFrame>
-        </section>
-
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            Balance over time
-          </Heading>
-          <p className="text-pretty text-muted-foreground">
-            See how the outstanding balance changes month by month. Toggle
-            between salary levels to see how income affects the repayment
-            trajectory for each plan. The dashed markers show each plan&rsquo;s
-            write-off point &mdash; Plan 2 at 30 years, Plan 5 at 40 years.
-          </p>
-          <ChartFrame
-            caption={`Fig. 2 \u2014 Balance over time \u00b7 Plan 2 vs Plan 5`}
-            bodyClassName="h-85 sm:h-105"
-          >
-            <BalanceComparisonChart />
-          </ChartFrame>
-        </section>
-
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Which Plan Do I Have?
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              You cannot choose between Plan 2 and Plan 5 &mdash; your plan is
-              determined by when and where you started your course. Plan 2
-              covers English and Welsh students who started university between
-              September 2012 and July 2023. Plan 5 applies to English students
-              who started from September 2023 onwards.
-            </p>
-            <p>
-              The cutoff is August 2023. If you started in the 2022&ndash;23
-              academic year, you are on Plan 2. If you started in September 2023
-              or later, you are on Plan 5. Note that Plan 5 is England-only
-              &mdash; Welsh students who started after August 2023 remain on
-              Plan 2.
-            </p>
-            <p>
-              Not sure?{" "}
-              <Link href="/which-plan" className={guideLink}>
-                Take the which plan quiz
-              </Link>{" "}
-              to find out, or read the full breakdowns for{" "}
-              <Link href="/plans/plan-2" className={guideLink}>
-                Plan 2
-              </Link>{" "}
-              and{" "}
-              <Link href="/plans/plan-5" className={guideLink}>
-                Plan 5
-              </Link>
-              .
-            </p>
-          </div>
-        </section>
-
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            How the Threshold Difference Affects You
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              Plan 5&rsquo;s lower repayment threshold means you start repaying
-              sooner and pay more each month at the same salary. Both plans
-              charge 9% on income above the threshold, but the thresholds are
-              different: {formatGBP(plan2Threshold)} for Plan 2 versus{" "}
-              {formatGBP(plan5Threshold)} for Plan 5.
-            </p>
-            <p>
-              For example, at a {formatGBP(EXAMPLE_SALARY)} salary, a Plan 2
-              borrower repays just {formatGBP(plan2Annual)} per year, while a
-              Plan 5 borrower repays {formatGBP(plan5Annual)} per year &mdash;
-              over three times as much. This gap narrows at higher salaries
-              where both plans collect substantial repayments, but at lower
-              salaries the threshold difference is the dominant factor.
-            </p>
-          </div>
-        </section>
-
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Can You Switch Plans?
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              No. Your plan is permanently determined by your course start date.
-              There is no mechanism to switch between Plan 2 and Plan 5.
-            </p>
-            <p>
-              If you take out a second degree after August 2023, the new loan
-              will be on Plan 5, but your original Plan 2 loan stays on Plan 2.
-              The two loans are repaid separately under their own terms.
-            </p>
-          </div>
-        </section>
-
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Which Plan Should You Worry About?
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              For most borrowers, repayments are automatic through PAYE &mdash;
-              you do not need to do anything. The real question is whether it
-              makes sense to{" "}
-              <Link href="/overpay" className={guideLink}>
-                overpay your loan
-              </Link>
-              .
-            </p>
-            <p>
-              Plan 2 middle earners are hit hardest. They earn too much for the
-              30-year write-off to help significantly, but not enough to pay off
-              the balance quickly before{" "}
-              <Link href="/guides/how-interest-works" className={guideLink}>
-                interest
-              </Link>{" "}
-              (up to RPI + 3%) compounds over decades. These borrowers often end
-              up repaying more in total than Plan 5 borrowers on the same
-              salary.
-            </p>
-            <p>
-              Use the{" "}
-              <Link href="/" className={guideLink}>
-                student loan repayment calculator
-              </Link>{" "}
-              to model your specific scenario and see exactly how much
-              you&rsquo;ll repay under your plan.
-            </p>
-          </div>
-        </section>
-
-        <KeyTakeaways>
-          <li>
-            Lower earners often pay <strong>more</strong> on Plan 5 because the
-            40-year term and lower threshold mean more months of repayments.
-          </li>
-          <li>
-            Middle earners may pay <strong>more</strong> on Plan 2 because
-            interest can reach RPI + 3%, and they earn too much for write-off to
-            help but not enough to pay off the balance quickly.
-          </li>
-          <li>
-            Plan 5&rsquo;s simpler interest (RPI only) makes the balance more
-            predictable, but the longer write-off window is the real cost
-            driver.
-          </li>
-          <li>
-            Plan 5&rsquo;s lower threshold ({formatGBP(plan5Threshold)} vs{" "}
-            {formatGBP(plan2Threshold)}) means earlier and larger repayments at
-            the same salary.
-          </li>
-          <li>
-            Model your own salary in the{" "}
-            <Link href="/" className={guideLink}>
-              student loan calculator
+          <p>
+            Not sure?{" "}
+            <Link href="/which-plan" className={guideLink}>
+              Take the which plan quiz
             </Link>{" "}
-            to see the total cost under each plan.
-          </li>
-        </KeyTakeaways>
+            to find out, or read the full breakdowns for{" "}
+            <Link href="/plans/plan-2" className={guideLink}>
+              Plan 2
+            </Link>{" "}
+            and{" "}
+            <Link href="/plans/plan-5" className={guideLink}>
+              Plan 5
+            </Link>
+            .
+          </p>
+        </div>
+      </section>
 
-        <RelatedGuides
-          current="plan-2-vs-plan-5"
-          order={["how-interest-works", "pay-upfront-or-take-loan"]}
-          tools={["/which-plan", "/plans", "/repaid"]}
-        />
-      </GuideArticle>
-    </PageLayout>
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          How the Threshold Difference Affects You
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            Plan 5&rsquo;s lower repayment threshold means you start repaying
+            sooner and pay more each month at the same salary. Both plans charge
+            9% on income above the threshold, but the thresholds are different:{" "}
+            {formatGBP(plan2Threshold)} for Plan 2 versus{" "}
+            {formatGBP(plan5Threshold)} for Plan 5.
+          </p>
+          <p>
+            For example, at a {formatGBP(EXAMPLE_SALARY)} salary, a Plan 2
+            borrower repays just {formatGBP(plan2Annual)} per year, while a Plan
+            5 borrower repays {formatGBP(plan5Annual)} per year &mdash; over
+            three times as much. This gap narrows at higher salaries where both
+            plans collect substantial repayments, but at lower salaries the
+            threshold difference is the dominant factor.
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Can You Switch Plans?
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            No. Your plan is permanently determined by your course start date.
+            There is no mechanism to switch between Plan 2 and Plan 5.
+          </p>
+          <p>
+            If you take out a second degree after August 2023, the new loan will
+            be on Plan 5, but your original Plan 2 loan stays on Plan 2. The two
+            loans are repaid separately under their own terms.
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Which Plan Should You Worry About?
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            For most borrowers, repayments are automatic through PAYE &mdash;
+            you do not need to do anything. The real question is whether it
+            makes sense to{" "}
+            <Link href="/overpay" className={guideLink}>
+              overpay your loan
+            </Link>
+            .
+          </p>
+          <p>
+            Plan 2 middle earners are hit hardest. They earn too much for the
+            30-year write-off to help significantly, but not enough to pay off
+            the balance quickly before{" "}
+            <Link href="/guides/how-interest-works" className={guideLink}>
+              interest
+            </Link>{" "}
+            (up to RPI + 3%) compounds over decades. These borrowers often end
+            up repaying more in total than Plan 5 borrowers on the same salary.
+          </p>
+          <p>
+            Use the{" "}
+            <Link href="/" className={guideLink}>
+              student loan repayment calculator
+            </Link>{" "}
+            to model your specific scenario and see exactly how much
+            you&rsquo;ll repay under your plan.
+          </p>
+        </div>
+      </section>
+
+      <KeyTakeaways>
+        <li>
+          Lower earners often pay <strong>more</strong> on Plan 5 because the
+          40-year term and lower threshold mean more months of repayments.
+        </li>
+        <li>
+          Middle earners may pay <strong>more</strong> on Plan 2 because
+          interest can reach RPI + 3%, and they earn too much for write-off to
+          help but not enough to pay off the balance quickly.
+        </li>
+        <li>
+          Plan 5&rsquo;s simpler interest (RPI only) makes the balance more
+          predictable, but the longer write-off window is the real cost driver.
+        </li>
+        <li>
+          Plan 5&rsquo;s lower threshold ({formatGBP(plan5Threshold)} vs{" "}
+          {formatGBP(plan2Threshold)}) means earlier and larger repayments at
+          the same salary.
+        </li>
+        <li>
+          Model your own salary in the{" "}
+          <Link href="/" className={guideLink}>
+            student loan calculator
+          </Link>{" "}
+          to see the total cost under each plan.
+        </li>
+      </KeyTakeaways>
+    </GuideArticle>
   );
 }

--- a/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
+++ b/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
@@ -1,7 +1,5 @@
 import Link from "next/link";
-import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { ChartFrame } from "@/components/instrument/ChartFrame";
-import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import { formatPercent } from "@/lib/format";
 import { CURRENT_RATES } from "@/lib/loans/plans";
@@ -16,238 +14,236 @@ const plan1Rate = Math.min(rpi, CURRENT_RATES.boeBaseRate + 1);
 
 export function RpiVsCpiGuide() {
   return (
-    <PageLayout>
-      <GuideArticle
-        breadcrumbLabel="RPI vs CPI"
-        title="RPI vs CPI: why your student loan interest outpaces inflation"
-        intro={
-          <>
-            Your student loan interest is tied to RPI, but when the calculator
-            shows &ldquo;adjusted for inflation,&rdquo; it uses CPI. RPI
-            typically runs 0.5&ndash;1% higher. That gap means your balance
-            grows faster than the general cost of living.
-          </>
-        }
-      >
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            What Are RPI and CPI?
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <ul className="list-disc space-y-2 pl-6">
-              <li>
-                <strong className="text-foreground">
-                  RPI (Retail Prices Index)
-                </strong>
-                : includes housing costs such as mortgage interest and council
-                tax. The Student Loans Company uses RPI to set loan interest
-                rates. Currently {formatPercent(rpi)}.
-              </li>
-              <li>
-                <strong className="text-foreground">
-                  CPI (Consumer Prices Index)
-                </strong>
-                : the Bank of England&apos;s target measure with a 2% target.
-                Excludes housing costs. This is what the calculator&apos;s
-                &ldquo;Adjust for inflation&rdquo; toggle uses.
-              </li>
-              <li>
-                <strong className="text-foreground">
-                  CPIH (CPI including Housing)
-                </strong>
-                : the ONS&apos;s preferred headline measure since 2017. Not used
-                for student loans.
-              </li>
-            </ul>
-            <p>
-              The government stopped using RPI for most purposes because it
-              overstates inflation, but student loans remain tied to it.
-            </p>
-          </div>
-        </section>
-
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Why Student Loans Use RPI
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              Plan 2 was introduced in 2012 when RPI was still widely used
-              across government policy. The government has since acknowledged
-              that RPI overstates inflation due to the &ldquo;formula
-              effect&rdquo; &mdash; it uses an arithmetic mean rather than a
-              geometric mean, which systematically produces higher figures.
-            </p>
-            <p>
-              Plans exist to align RPI with CPIH by 2030, but current loan terms
-              are unlikely to change retroactively. Each plan uses RPI in its
-              interest formula:
-            </p>
-            <ul className="list-disc space-y-1 pl-6">
-              <li>
-                <strong className="text-foreground">Plan 5</strong>: RPI only (
-                {formatPercent(rpi)})
-              </li>
-              <li>
-                <strong className="text-foreground">Plan 2</strong>: RPI to RPI
-                + 3% ({formatPercent(rpi)} &ndash; {formatPercent(maxRate)})
-                depending on income
-              </li>
-              <li>
-                <strong className="text-foreground">Plan 1 &amp; 4</strong>:
-                lesser of RPI or base rate + 1% (currently{" "}
-                {formatPercent(plan1Rate)})
-              </li>
-              <li>
-                <strong className="text-foreground">Postgraduate</strong>: RPI +
-                3% ({formatPercent(maxRate)})
-              </li>
-            </ul>
-          </div>
-        </section>
-
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            The Gap Between RPI and CPI
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              RPI historically exceeds CPI by roughly 0.5&ndash;1 percentage
-              points. With RPI at {formatPercent(rpi)} and the CPI target at{" "}
-              {formatPercent(cpiTarget)}, the current gap is {gap} percentage
-              points.
-            </p>
-            <p>
-              Two factors drive the gap: RPI includes housing costs that CPI
-              excludes, and RPI uses an arithmetic mean formula while CPI uses a
-              geometric mean. The arithmetic mean always produces a higher
-              result when prices are changing, which is why statisticians call
-              it the &ldquo;formula effect.&rdquo;
-            </p>
-            <p>
-              The chart below shows what this gap looks like over the life of a
-              Plan 5 loan.
-            </p>
-          </div>
-        </section>
-
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            Inflation comparison
-          </Heading>
-          <ChartFrame
-            caption={`Fig. 1 \u2014 Balance in real terms \u00b7 Plan 5, \u00a345,000`}
-            figure={`RPI ${formatPercent(rpi)}`}
-            figureTone="cost"
-            bodyClassName="h-85 sm:h-105"
-          >
-            <InflationComparisonChart />
-          </ChartFrame>
-          <p className="text-sm text-muted-foreground">
-            Plan 5, {"\u00a3"}45,000 balance. The gap between the CPI-adjusted
-            and RPI-adjusted lines is the real above-inflation cost.
+    <GuideArticle
+      breadcrumbLabel="RPI vs CPI"
+      title="RPI vs CPI: why your student loan interest outpaces inflation"
+      intro={
+        <>
+          Your student loan interest is tied to RPI, but when the calculator
+          shows &ldquo;adjusted for inflation,&rdquo; it uses CPI. RPI typically
+          runs 0.5&ndash;1% higher. That gap means your balance grows faster
+          than the general cost of living.
+        </>
+      }
+      related={{
+        current: "rpi-vs-cpi",
+        order: ["how-interest-works", "plan-2-vs-plan-5"],
+        tools: ["/interest", "/effective-rate"],
+      }}
+    >
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          What Are RPI and CPI?
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              <strong className="text-foreground">
+                RPI (Retail Prices Index)
+              </strong>
+              : includes housing costs such as mortgage interest and council
+              tax. The Student Loans Company uses RPI to set loan interest
+              rates. Currently {formatPercent(rpi)}.
+            </li>
+            <li>
+              <strong className="text-foreground">
+                CPI (Consumer Prices Index)
+              </strong>
+              : the Bank of England&apos;s target measure with a 2% target.
+              Excludes housing costs. This is what the calculator&apos;s
+              &ldquo;Adjust for inflation&rdquo; toggle uses.
+            </li>
+            <li>
+              <strong className="text-foreground">
+                CPIH (CPI including Housing)
+              </strong>
+              : the ONS&apos;s preferred headline measure since 2017. Not used
+              for student loans.
+            </li>
+          </ul>
+          <p>
+            The government stopped using RPI for most purposes because it
+            overstates inflation, but student loans remain tied to it.
           </p>
-        </section>
+        </div>
+      </section>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Nominal, CPI-Adjusted, and RPI-Adjusted: Three Ways to See Your Loan
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <ul className="list-disc space-y-2 pl-6">
-              <li>
-                <strong className="text-foreground">Nominal</strong>: the raw
-                balance on your SLC account. Grows at the loan interest rate.
-              </li>
-              <li>
-                <strong className="text-foreground">CPI-adjusted</strong>:
-                discounted by CPI &mdash; this is what the calculator&apos;s
-                &ldquo;Adjust for inflation&rdquo; toggle shows. It tells you
-                what the balance is worth in today&apos;s money.
-              </li>
-              <li>
-                <strong className="text-foreground">RPI-adjusted</strong>:
-                discounted by RPI. The balance appears roughly flat because RPI
-                is close to the interest rate itself. But this is misleading
-                because RPI overstates general inflation.
-              </li>
-            </ul>
-            <p>
-              The key insight: the gap between the CPI-adjusted and RPI-adjusted
-              lines is the real above-inflation cost of the loan.
-            </p>
-          </div>
-        </section>
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Why Student Loans Use RPI
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            Plan 2 was introduced in 2012 when RPI was still widely used across
+            government policy. The government has since acknowledged that RPI
+            overstates inflation due to the &ldquo;formula effect&rdquo; &mdash;
+            it uses an arithmetic mean rather than a geometric mean, which
+            systematically produces higher figures.
+          </p>
+          <p>
+            Plans exist to align RPI with CPIH by 2030, but current loan terms
+            are unlikely to change retroactively. Each plan uses RPI in its
+            interest formula:
+          </p>
+          <ul className="list-disc space-y-1 pl-6">
+            <li>
+              <strong className="text-foreground">Plan 5</strong>: RPI only (
+              {formatPercent(rpi)})
+            </li>
+            <li>
+              <strong className="text-foreground">Plan 2</strong>: RPI to RPI +
+              3% ({formatPercent(rpi)} &ndash; {formatPercent(maxRate)})
+              depending on income
+            </li>
+            <li>
+              <strong className="text-foreground">Plan 1 &amp; 4</strong>:
+              lesser of RPI or base rate + 1% (currently{" "}
+              {formatPercent(plan1Rate)})
+            </li>
+            <li>
+              <strong className="text-foreground">Postgraduate</strong>: RPI +
+              3% ({formatPercent(maxRate)})
+            </li>
+          </ul>
+        </div>
+      </section>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            What This Means for Your Plan
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <ul className="list-disc space-y-2 pl-6">
-              <li>
-                <strong className="text-foreground">Plan 5</strong>: &ldquo;RPI
-                only&rdquo; sounds gentle, but since RPI runs higher than CPI,
-                the loan still grows faster than general prices.
-              </li>
-              <li>
-                <strong className="text-foreground">Plan 2</strong>: the sliding
-                scale starts at RPI (already above CPI). High earners face RPI +
-                3%.
-              </li>
-              <li>
-                <strong className="text-foreground">Plan 1 &amp; 4</strong>:
-                capped at the lesser of RPI or base rate + 1%, so these
-                borrowers are somewhat shielded.
-              </li>
-              <li>
-                <strong className="text-foreground">Postgraduate</strong>: RPI +
-                3% means the largest gap above CPI of any plan.
-              </li>
-            </ul>
-            <p>
-              If your loan is growing faster than general prices, explore
-              whether{" "}
-              <Link href="/overpay" className={guideLink}>
-                overpaying
-              </Link>{" "}
-              could reduce the above-inflation cost.
-            </p>
-          </div>
-        </section>
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          The Gap Between RPI and CPI
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            RPI historically exceeds CPI by roughly 0.5&ndash;1 percentage
+            points. With RPI at {formatPercent(rpi)} and the CPI target at{" "}
+            {formatPercent(cpiTarget)}, the current gap is {gap} percentage
+            points.
+          </p>
+          <p>
+            Two factors drive the gap: RPI includes housing costs that CPI
+            excludes, and RPI uses an arithmetic mean formula while CPI uses a
+            geometric mean. The arithmetic mean always produces a higher result
+            when prices are changing, which is why statisticians call it the
+            &ldquo;formula effect.&rdquo;
+          </p>
+          <p>
+            The chart below shows what this gap looks like over the life of a
+            Plan 5 loan.
+          </p>
+        </div>
+      </section>
 
-        <KeyTakeaways>
-          <li>
-            RPI typically runs 0.5&ndash;1% higher than CPI &mdash; your loan
-            interest is tied to the higher measure.
-          </li>
-          <li>
-            &ldquo;Adjusted for inflation&rdquo; in the calculator uses CPI, not
-            RPI. Remaining growth after toggling is real above-inflation cost.
-          </li>
-          <li>
-            Plan 5&apos;s &ldquo;inflation-only&rdquo; interest is
-            RPI-inflation, not CPI-inflation.
-          </li>
-          <li>
-            RPI may align with CPIH by 2030, but current borrowers are unlikely
-            to benefit.
-          </li>
-          <li>
-            See how inflation affects your total repayment with the{" "}
-            <Link href="/" className={guideLink}>
-              student loan calculator
-            </Link>
-            .
-          </li>
-        </KeyTakeaways>
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          Inflation comparison
+        </Heading>
+        <p className="text-sm text-muted-foreground">
+          Plan 5, {"\u00a3"}45,000 balance. The gap between the CPI-adjusted and
+          RPI-adjusted lines is the real above-inflation cost.
+        </p>
+      </section>
 
-        <RelatedGuides
-          current="rpi-vs-cpi"
-          order={["how-interest-works", "plan-2-vs-plan-5"]}
-          tools={["/interest", "/effective-rate"]}
-        />
-      </GuideArticle>
-    </PageLayout>
+      <ChartFrame
+        className="guide-breakout"
+        caption={`Fig. 1 \u2014 Balance in real terms \u00b7 Plan 5, \u00a345,000`}
+        figure={`RPI ${formatPercent(rpi)}`}
+        figureTone="cost"
+        bodyClassName="h-85 sm:h-105"
+      >
+        <InflationComparisonChart />
+      </ChartFrame>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Nominal, CPI-Adjusted, and RPI-Adjusted: Three Ways to See Your Loan
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              <strong className="text-foreground">Nominal</strong>: the raw
+              balance on your SLC account. Grows at the loan interest rate.
+            </li>
+            <li>
+              <strong className="text-foreground">CPI-adjusted</strong>:
+              discounted by CPI &mdash; this is what the calculator&apos;s
+              &ldquo;Adjust for inflation&rdquo; toggle shows. It tells you what
+              the balance is worth in today&apos;s money.
+            </li>
+            <li>
+              <strong className="text-foreground">RPI-adjusted</strong>:
+              discounted by RPI. The balance appears roughly flat because RPI is
+              close to the interest rate itself. But this is misleading because
+              RPI overstates general inflation.
+            </li>
+          </ul>
+          <p>
+            The key insight: the gap between the CPI-adjusted and RPI-adjusted
+            lines is the real above-inflation cost of the loan.
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          What This Means for Your Plan
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              <strong className="text-foreground">Plan 5</strong>: &ldquo;RPI
+              only&rdquo; sounds gentle, but since RPI runs higher than CPI, the
+              loan still grows faster than general prices.
+            </li>
+            <li>
+              <strong className="text-foreground">Plan 2</strong>: the sliding
+              scale starts at RPI (already above CPI). High earners face RPI +
+              3%.
+            </li>
+            <li>
+              <strong className="text-foreground">Plan 1 &amp; 4</strong>:
+              capped at the lesser of RPI or base rate + 1%, so these borrowers
+              are somewhat shielded.
+            </li>
+            <li>
+              <strong className="text-foreground">Postgraduate</strong>: RPI +
+              3% means the largest gap above CPI of any plan.
+            </li>
+          </ul>
+          <p>
+            If your loan is growing faster than general prices, explore whether{" "}
+            <Link href="/overpay" className={guideLink}>
+              overpaying
+            </Link>{" "}
+            could reduce the above-inflation cost.
+          </p>
+        </div>
+      </section>
+
+      <KeyTakeaways>
+        <li>
+          RPI typically runs 0.5&ndash;1% higher than CPI &mdash; your loan
+          interest is tied to the higher measure.
+        </li>
+        <li>
+          &ldquo;Adjusted for inflation&rdquo; in the calculator uses CPI, not
+          RPI. Remaining growth after toggling is real above-inflation cost.
+        </li>
+        <li>
+          Plan 5&apos;s &ldquo;inflation-only&rdquo; interest is RPI-inflation,
+          not CPI-inflation.
+        </li>
+        <li>
+          RPI may align with CPIH by 2030, but current borrowers are unlikely to
+          benefit.
+        </li>
+        <li>
+          See how inflation affects your total repayment with the{" "}
+          <Link href="/" className={guideLink}>
+            student loan calculator
+          </Link>
+          .
+        </li>
+      </KeyTakeaways>
+    </GuideArticle>
   );
 }

--- a/src/components/guides/self-employment/SelfEmploymentGuide.tsx
+++ b/src/components/guides/self-employment/SelfEmploymentGuide.tsx
@@ -7,8 +7,6 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
-import { RelatedGuides } from "@/components/guides/RelatedGuides";
-import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
 import {
@@ -26,15 +24,65 @@ const linkClasses = guideLink;
 
 export function SelfEmploymentGuide() {
   return (
-    <PageLayout>
-      <GuideArticle
-        breadcrumbLabel="Self-Employment"
-        title="Student loans and self-employment"
-        intro={
-          <>
-            If you&rsquo;re self-employed, your student loan repayments work
-            differently from PAYE. Instead of automatic monthly deductions from
-            your payslip, you repay through your annual{" "}
+    <GuideArticle
+      breadcrumbLabel="Self-Employment"
+      title="Student loans and self-employment"
+      intro={
+        <>
+          If you&rsquo;re self-employed, your student loan repayments work
+          differently from PAYE. Instead of automatic monthly deductions from
+          your payslip, you repay through your annual{" "}
+          <a
+            href="https://www.gov.uk/self-assessment-tax-returns"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={linkClasses}
+          >
+            Self Assessment tax return
+          </a>{" "}
+          — and that changes how you need to plan your finances.
+        </>
+      }
+      related={{
+        current: "self-employment",
+        order: ["moving-abroad", "plan-2-vs-plan-5"],
+        tools: ["/", "/repaid"],
+        extraLinks: [
+          {
+            href: "https://www.gov.uk/repaying-your-student-loan/repaying-student-loans-overview",
+            label: "GOV.UK: Repaying Your Student Loan",
+          },
+        ],
+      }}
+    >
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          How Repayments Work Through Self Assessment
+        </Heading>
+
+        <SeamGrid columns={2}>
+          <SeamCell eyebrow="PAYE (employed)">
+            <ul className="list-disc space-y-1.5 pl-5 marker:text-primary">
+              <li>Monthly deductions from payslip</li>
+              <li>Automatic — employer handles it</li>
+              <li>Based on salary each pay period</li>
+            </ul>
+          </SeamCell>
+          <SeamCell eyebrow="Self Assessment (self-employed)">
+            <ul className="list-disc space-y-1.5 pl-5 marker:text-primary">
+              <li>Annual lump sums (Jan &amp; Jul)</li>
+              <li>You calculate and submit</li>
+              <li>Based on net profit for the year</li>
+            </ul>
+          </SeamCell>
+        </SeamGrid>
+
+        <div className="space-y-3 text-muted-foreground">
+          <p>
+            When you&rsquo;re employed, your employer deducts student loan
+            repayments from your salary each month via PAYE. When you&rsquo;re
+            self-employed, there is no employer to do this — HMRC calculates
+            your repayment based on your{" "}
             <a
               href="https://www.gov.uk/self-assessment-tax-returns"
               target="_blank"
@@ -43,289 +91,236 @@ export function SelfEmploymentGuide() {
             >
               Self Assessment tax return
             </a>{" "}
-            — and that changes how you need to plan your finances.
-          </>
-        }
-      >
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            How Repayments Work Through Self Assessment
-          </Heading>
-
-          <SeamGrid columns={2}>
-            <SeamCell eyebrow="PAYE (employed)">
-              <ul className="list-disc space-y-1.5 pl-5 marker:text-primary">
-                <li>Monthly deductions from payslip</li>
-                <li>Automatic — employer handles it</li>
-                <li>Based on salary each pay period</li>
-              </ul>
-            </SeamCell>
-            <SeamCell eyebrow="Self Assessment (self-employed)">
-              <ul className="list-disc space-y-1.5 pl-5 marker:text-primary">
-                <li>Annual lump sums (Jan &amp; Jul)</li>
-                <li>You calculate and submit</li>
-                <li>Based on net profit for the year</li>
-              </ul>
-            </SeamCell>
-          </SeamGrid>
-
-          <div className="space-y-3 text-sm text-muted-foreground sm:text-base">
-            <p>
-              When you&rsquo;re employed, your employer deducts student loan
-              repayments from your salary each month via PAYE. When you&rsquo;re
-              self-employed, there is no employer to do this — HMRC calculates
-              your repayment based on your{" "}
-              <a
-                href="https://www.gov.uk/self-assessment-tax-returns"
-                target="_blank"
-                rel="noopener noreferrer"
-                className={linkClasses}
-              >
-                Self Assessment tax return
-              </a>{" "}
-              instead.
-            </p>
-            <p>
-              This means your repayments are <strong>annual</strong>, not
-              monthly. You typically pay in two lump sums: one in January and
-              one in July (as part of HMRC&rsquo;s{" "}
-              <a
-                href="https://www.gov.uk/understand-self-assessment-bill/payments-on-account"
-                target="_blank"
-                rel="noopener noreferrer"
-                className={linkClasses}
-              >
-                payment on account
-              </a>{" "}
-              system). The repayment is {undergradRate} of your net profit above
-              the repayment threshold for Plan 2 and Plan 5, or {postgradRate}{" "}
-              for Postgraduate Loans.
-            </p>
-            <p>
-              Because payments are based on your <strong>profit</strong> — not
-              your total revenue — business expenses you claim directly reduce
-              your student loan repayment as well as your tax bill.
-            </p>
-          </div>
-        </section>
-
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            What Counts as Income?
-          </Heading>
-          <p className="text-sm text-muted-foreground sm:text-base">
-            HMRC looks at your total taxable income when calculating student
-            loan repayments. For the self-employed, this includes:
+            instead.
           </p>
-          <SeamGrid columns={3}>
-            <SeamCell
-              icon={
-                <HugeiconsIcon
-                  icon={Calculator01Icon}
-                  className="size-5 text-primary"
-                />
-              }
-              title="Net profit"
+          <p>
+            This means your repayments are <strong>annual</strong>, not monthly.
+            You typically pay in two lump sums: one in January and one in July
+            (as part of HMRC&rsquo;s{" "}
+            <a
+              href="https://www.gov.uk/understand-self-assessment-bill/payments-on-account"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={linkClasses}
             >
-              Revenue minus allowable business expenses from self-employment.
-            </SeamCell>
-            <SeamCell
-              icon={
-                <HugeiconsIcon
-                  icon={Briefcase01Icon}
-                  className="size-5 text-primary"
-                />
-              }
-              title="Employment income"
-            >
-              Salary from a PAYE job if you also have one alongside freelancing.
-            </SeamCell>
-            <SeamCell
-              icon={
-                <HugeiconsIcon
-                  icon={Coins01Icon}
-                  className="size-5 text-primary"
-                />
-              }
-              title="Other taxable income"
-            >
-              Rental income, dividends, interest above your personal savings
-              allowance, etc.
-            </SeamCell>
-          </SeamGrid>
-          <p className="text-sm text-muted-foreground sm:text-base">
-            All of these sources are combined to determine whether you exceed
-            the repayment threshold and how much you owe.
+              payment on account
+            </a>{" "}
+            system). The repayment is {undergradRate} of your net profit above
+            the repayment threshold for Plan 2 and Plan 5, or {postgradRate} for
+            Postgraduate Loans.
           </p>
-        </section>
+          <p>
+            Because payments are based on your <strong>profit</strong> — not
+            your total revenue — business expenses you claim directly reduce
+            your student loan repayment as well as your tax bill.
+          </p>
+        </div>
+      </section>
 
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            Mixed Employment
-          </Heading>
-          <div className="space-y-3 text-sm text-muted-foreground sm:text-base">
-            <p>
-              Many freelancers also have a part-time or full-time PAYE job. If
-              this applies to you, HMRC collects repayments through both
-              mechanisms:
-            </p>
-            <ul className="list-inside list-disc space-y-2">
-              <li>
-                Your employer deducts repayments from your salary automatically
-                via PAYE
-              </li>
-              <li>
-                Your Self Assessment tops up the difference based on your
-                combined total income
-              </li>
-            </ul>
-            <p>
-              For example, if your PAYE salary is below the threshold but your
-              combined income (salary + freelance profit) is above it,
-              you&rsquo;ll owe the full repayment through Self Assessment. If
-              your PAYE income alone exceeds the threshold, your employer
-              already deducts repayments — and Self Assessment adds further
-              repayments on your self-employment profit.
-            </p>
-          </div>
-        </section>
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          What Counts as Income?
+        </Heading>
+        <p className="text-muted-foreground">
+          HMRC looks at your total taxable income when calculating student loan
+          repayments. For the self-employed, this includes:
+        </p>
+        <SeamGrid columns={3}>
+          <SeamCell
+            icon={
+              <HugeiconsIcon
+                icon={Calculator01Icon}
+                className="size-5 text-primary"
+              />
+            }
+            title="Net profit"
+          >
+            Revenue minus allowable business expenses from self-employment.
+          </SeamCell>
+          <SeamCell
+            icon={
+              <HugeiconsIcon
+                icon={Briefcase01Icon}
+                className="size-5 text-primary"
+              />
+            }
+            title="Employment income"
+          >
+            Salary from a PAYE job if you also have one alongside freelancing.
+          </SeamCell>
+          <SeamCell
+            icon={
+              <HugeiconsIcon
+                icon={Coins01Icon}
+                className="size-5 text-primary"
+              />
+            }
+            title="Other taxable income"
+          >
+            Rental income, dividends, interest above your personal savings
+            allowance, etc.
+          </SeamCell>
+        </SeamGrid>
+        <p className="text-muted-foreground">
+          All of these sources are combined to determine whether you exceed the
+          repayment threshold and how much you owe.
+        </p>
+      </section>
 
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            Common Mistakes to Avoid
-          </Heading>
-          <SeamGrid columns={2}>
-            {[
-              {
-                title: "Not budgeting for annual payments",
-                description:
-                  "Unlike monthly PAYE deductions, Self Assessment repayments arrive as large lump sums. A sudden bill of several thousand pounds in January can catch freelancers off guard.",
-              },
-              {
-                title: "Late filing penalties",
-                description:
-                  "Missing the 31 January Self Assessment deadline means a \u00A3100 penalty \u2014 plus your student loan repayment is delayed, which can lead to estimated charges from HMRC.",
-              },
-              {
-                title: "Underestimating income",
-                description:
-                  "If your payments on account are based on a lower previous year, you may face a balancing payment when your actual profit is higher than expected.",
-              },
-              {
-                title: "Not claiming legitimate expenses",
-                description:
-                  "Every pound of allowable business expense you miss increases your net profit \u2014 and therefore your student loan repayment. Common overlooked expenses include home office costs, professional subscriptions, and travel.",
-              },
-            ].map((mistake) => (
-              <SeamCell
-                key={mistake.title}
-                icon={
-                  <HugeiconsIcon
-                    icon={AlertCircleIcon}
-                    className="size-5 text-signal"
-                  />
-                }
-                title={mistake.title}
-              >
-                {mistake.description}
-              </SeamCell>
-            ))}
-          </SeamGrid>
-        </section>
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          Mixed Employment
+        </Heading>
+        <div className="space-y-3 text-muted-foreground">
+          <p>
+            Many freelancers also have a part-time or full-time PAYE job. If
+            this applies to you, HMRC collects repayments through both
+            mechanisms:
+          </p>
+          <ul className="list-inside list-disc space-y-2">
+            <li>
+              Your employer deducts repayments from your salary automatically
+              via PAYE
+            </li>
+            <li>
+              Your Self Assessment tops up the difference based on your combined
+              total income
+            </li>
+          </ul>
+          <p>
+            For example, if your PAYE salary is below the threshold but your
+            combined income (salary + freelance profit) is above it,
+            you&rsquo;ll owe the full repayment through Self Assessment. If your
+            PAYE income alone exceeds the threshold, your employer already
+            deducts repayments — and Self Assessment adds further repayments on
+            your self-employment profit.
+          </p>
+        </div>
+      </section>
 
-        <section className="space-y-4">
-          <Heading as="h2" size="section">
-            Practical Tips for Freelancers
-          </Heading>
-          <SeamGrid columns={2}>
-            {[
-              {
-                title: `Set aside ${undergradRate} monthly`,
-                description: `Calculate ${undergradRate} of your profit above the repayment threshold each month and put it in a separate savings account. This avoids a nasty surprise when your tax bill arrives.`,
-              },
-              {
-                title: "Register for Self Assessment early",
-                description: (
-                  <>
-                    You must{" "}
-                    <a
-                      href="https://www.gov.uk/register-for-self-assessment"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={linkClasses}
-                    >
-                      register with HMRC by 5 October
-                    </a>{" "}
-                    following the end of the tax year in which you became
-                    self-employed. Registering late can result in penalties.
-                  </>
-                ),
-              },
-              {
-                title: "Keep good records",
-                description:
-                  "Track all income and expenses throughout the year. Good record-keeping makes filing easier and ensures you claim every expense you\u2019re entitled to.",
-              },
-              {
-                title: "Consider an accountant",
-                description:
-                  "An accountant familiar with student loans can help you optimise your expenses, avoid mistakes, and ensure your repayments are calculated correctly.",
-              },
-            ].map((tip) => (
-              <SeamCell
-                key={tip.title}
-                icon={
-                  <HugeiconsIcon
-                    icon={BulbIcon}
-                    className="size-5 text-primary"
-                  />
-                }
-                title={tip.title}
-              >
-                {tip.description}
-              </SeamCell>
-            ))}
-          </SeamGrid>
-        </section>
-
-        <KeyTakeaways>
-          <li>
-            Self-employed borrowers repay through Self Assessment, not PAYE —
-            expect annual lump-sum payments, not monthly deductions.
-          </li>
-          <li>
-            Repayments are based on <strong>net profit</strong>, so claiming all
-            legitimate business expenses directly reduces what you owe.
-          </li>
-          <li>
-            If you have mixed income (PAYE + freelance), HMRC collects through
-            both mechanisms based on your combined total income.
-          </li>
-          <li>
-            Budget monthly by setting aside {undergradRate} of profit above the
-            threshold to avoid being caught out by large tax bills.
-          </li>
-          <li>
-            Estimate your annual repayments with the{" "}
-            <Link href="/" className={guideLink}>
-              student loan calculator
-            </Link>
-            .
-          </li>
-        </KeyTakeaways>
-
-        <RelatedGuides
-          current="self-employment"
-          order={["moving-abroad", "plan-2-vs-plan-5"]}
-          tools={["/", "/repaid"]}
-          extraLinks={[
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          Common Mistakes to Avoid
+        </Heading>
+        <SeamGrid columns={2}>
+          {[
             {
-              href: "https://www.gov.uk/repaying-your-student-loan/repaying-student-loans-overview",
-              label: "GOV.UK: Repaying Your Student Loan",
+              title: "Not budgeting for annual payments",
+              description:
+                "Unlike monthly PAYE deductions, Self Assessment repayments arrive as large lump sums. A sudden bill of several thousand pounds in January can catch freelancers off guard.",
             },
-          ]}
-        />
-      </GuideArticle>
-    </PageLayout>
+            {
+              title: "Late filing penalties",
+              description:
+                "Missing the 31 January Self Assessment deadline means a \u00A3100 penalty \u2014 plus your student loan repayment is delayed, which can lead to estimated charges from HMRC.",
+            },
+            {
+              title: "Underestimating income",
+              description:
+                "If your payments on account are based on a lower previous year, you may face a balancing payment when your actual profit is higher than expected.",
+            },
+            {
+              title: "Not claiming legitimate expenses",
+              description:
+                "Every pound of allowable business expense you miss increases your net profit \u2014 and therefore your student loan repayment. Common overlooked expenses include home office costs, professional subscriptions, and travel.",
+            },
+          ].map((mistake) => (
+            <SeamCell
+              key={mistake.title}
+              icon={
+                <HugeiconsIcon
+                  icon={AlertCircleIcon}
+                  className="size-5 text-signal"
+                />
+              }
+              title={mistake.title}
+            >
+              {mistake.description}
+            </SeamCell>
+          ))}
+        </SeamGrid>
+      </section>
+
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          Practical Tips for Freelancers
+        </Heading>
+        <SeamGrid columns={2}>
+          {[
+            {
+              title: `Set aside ${undergradRate} monthly`,
+              description: `Calculate ${undergradRate} of your profit above the repayment threshold each month and put it in a separate savings account. This avoids a nasty surprise when your tax bill arrives.`,
+            },
+            {
+              title: "Register for Self Assessment early",
+              description: (
+                <>
+                  You must{" "}
+                  <a
+                    href="https://www.gov.uk/register-for-self-assessment"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={linkClasses}
+                  >
+                    register with HMRC by 5 October
+                  </a>{" "}
+                  following the end of the tax year in which you became
+                  self-employed. Registering late can result in penalties.
+                </>
+              ),
+            },
+            {
+              title: "Keep good records",
+              description:
+                "Track all income and expenses throughout the year. Good record-keeping makes filing easier and ensures you claim every expense you\u2019re entitled to.",
+            },
+            {
+              title: "Consider an accountant",
+              description:
+                "An accountant familiar with student loans can help you optimise your expenses, avoid mistakes, and ensure your repayments are calculated correctly.",
+            },
+          ].map((tip) => (
+            <SeamCell
+              key={tip.title}
+              icon={
+                <HugeiconsIcon
+                  icon={BulbIcon}
+                  className="size-5 text-primary"
+                />
+              }
+              title={tip.title}
+            >
+              {tip.description}
+            </SeamCell>
+          ))}
+        </SeamGrid>
+      </section>
+
+      <KeyTakeaways>
+        <li>
+          Self-employed borrowers repay through Self Assessment, not PAYE —
+          expect annual lump-sum payments, not monthly deductions.
+        </li>
+        <li>
+          Repayments are based on <strong>net profit</strong>, so claiming all
+          legitimate business expenses directly reduces what you owe.
+        </li>
+        <li>
+          If you have mixed income (PAYE + freelance), HMRC collects through
+          both mechanisms based on your combined total income.
+        </li>
+        <li>
+          Budget monthly by setting aside {undergradRate} of profit above the
+          threshold to avoid being caught out by large tax bills.
+        </li>
+        <li>
+          Estimate your annual repayments with the{" "}
+          <Link href="/" className={guideLink}>
+            student loan calculator
+          </Link>
+          .
+        </li>
+      </KeyTakeaways>
+    </GuideArticle>
   );
 }

--- a/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
+++ b/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
@@ -6,10 +6,8 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
-import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { ChartFrame } from "@/components/instrument/ChartFrame";
 import { Panel } from "@/components/instrument/Panel";
-import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import { formatGBP } from "@/lib/format";
 import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
@@ -69,289 +67,283 @@ const linkClasses = guideLink;
 
 export function MortgageGuide() {
   return (
-    <PageLayout>
-      <GuideArticle
-        breadcrumbLabel="Student Loans & Mortgages"
-        title="Does a student loan affect your mortgage?"
-        intro={
-          <>
-            A UK student loan won&rsquo;t stop you getting a mortgage, and it
-            isn&rsquo;t treated as normal debt. But the monthly repayment does
-            quietly shrink how much a lender will let you borrow &mdash; and, as
-            ever, it&rsquo;s middle earners who feel the squeeze most.
-            Here&rsquo;s exactly what lenders look at.
-          </>
-        }
-      >
-        <Panel
-          padding={false}
-          className="divide-y divide-border overflow-hidden"
-        >
-          {quickAnswers.map((item) => (
-            <div
-              key={item.question}
-              className="flex items-center gap-3 p-4 sm:p-5"
-            >
-              <HugeiconsIcon
-                icon={item.icon}
-                className="size-5 shrink-0 text-primary"
-              />
-              <p className="flex-1 font-medium text-foreground">
-                {item.question}
-              </p>
-              <span
-                className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-semibold ${item.answerClass}`}
-              >
-                {item.answer}
-              </span>
-            </div>
-          ))}
-        </Panel>
-
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Does a Student Loan Affect Mortgage Affordability?
-          </Heading>
-          <div className="space-y-3 text-muted-foreground">
-            <p>
-              Yes &mdash; this is the one real way a student loan touches your
-              mortgage. When you apply, a lender doesn&rsquo;t just look at your
-              salary; they run an affordability assessment. They start from your
-              income and subtract your committed monthly outgoings &mdash; tax,
-              National Insurance, pension contributions, childcare, existing
-              credit, and your student loan repayment &mdash; to see
-              what&rsquo;s genuinely left to cover a mortgage.
-            </p>
-            <p>
-              Your student loan repayment is one of those committed deductions.
-              Because it comes straight off your pay, it lowers the net income
-              figure the lender works from, which can reduce the size of
-              mortgage you&rsquo;re offered. In debt-to-income terms, the
-              repayment nudges your ratio the wrong way.
-            </p>
-            <p>
-              The repayment behaves like an extra slice of income tax: you pay{" "}
-              {repaymentRateDisplay} of everything you earn above your
-              plan&rsquo;s threshold. The more you earn, the larger the monthly
-              deduction &mdash; and the bigger the dent in your borrowing power.
-            </p>
-          </div>
-        </section>
-
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            How Much You Repay at Each Salary
-          </Heading>
-          <ChartFrame
-            caption="Fig. 1 — Monthly repayment by salary · Plan 2 vs Plan 5"
-            bodyClassName="h-75 sm:h-90"
+    <GuideArticle
+      breadcrumbLabel="Student Loans & Mortgages"
+      title="Does a student loan affect your mortgage?"
+      intro={
+        <>
+          A UK student loan won&rsquo;t stop you getting a mortgage, and it
+          isn&rsquo;t treated as normal debt. But the monthly repayment does
+          quietly shrink how much a lender will let you borrow &mdash; and, as
+          ever, it&rsquo;s middle earners who feel the squeeze most.
+          Here&rsquo;s exactly what lenders look at.
+        </>
+      }
+      related={{
+        current: "student-loan-vs-mortgage",
+        order: ["plan-2-vs-plan-5", "how-interest-works"],
+        tools: ["/", "/repaid"],
+        extraLinks: [
+          {
+            href: "https://www.gov.uk/repaying-your-student-loan/what-you-pay",
+            label: "GOV.UK: What You Pay",
+          },
+        ],
+      }}
+    >
+      <Panel padding={false} className="divide-y divide-border overflow-hidden">
+        {quickAnswers.map((item) => (
+          <div
+            key={item.question}
+            className="flex items-center gap-3 p-4 sm:p-5"
           >
-            <RepaymentImpactChart />
-          </ChartFrame>
-          <p className="text-sm text-muted-foreground">
-            Based on current thresholds: Plan 2 at {formatGBP(plan2Threshold)}{" "}
-            and Plan 5 at {formatGBP(plan5Threshold)} per year. Both charge{" "}
-            {repaymentRateDisplay} on income above the threshold, so Plan
-            5&rsquo;s lower threshold means repayments start sooner.
+            <HugeiconsIcon
+              icon={item.icon}
+              className="size-5 shrink-0 text-primary"
+            />
+            <p className="flex-1 font-medium text-foreground">
+              {item.question}
+            </p>
+            <span
+              className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-semibold ${item.answerClass}`}
+            >
+              {item.answer}
+            </span>
+          </div>
+        ))}
+      </Panel>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Does a Student Loan Affect Mortgage Affordability?
+        </Heading>
+        <div className="space-y-3 text-muted-foreground">
+          <p>
+            Yes &mdash; this is the one real way a student loan touches your
+            mortgage. When you apply, a lender doesn&rsquo;t just look at your
+            salary; they run an affordability assessment. They start from your
+            income and subtract your committed monthly outgoings &mdash; tax,
+            National Insurance, pension contributions, childcare, existing
+            credit, and your student loan repayment &mdash; to see what&rsquo;s
+            genuinely left to cover a mortgage.
           </p>
-        </section>
+          <p>
+            Your student loan repayment is one of those committed deductions.
+            Because it comes straight off your pay, it lowers the net income
+            figure the lender works from, which can reduce the size of mortgage
+            you&rsquo;re offered. In debt-to-income terms, the repayment nudges
+            your ratio the wrong way.
+          </p>
+          <p>
+            The repayment behaves like an extra slice of income tax: you pay{" "}
+            {repaymentRateDisplay} of everything you earn above your
+            plan&rsquo;s threshold. The more you earn, the larger the monthly
+            deduction &mdash; and the bigger the dent in your borrowing power.
+          </p>
+        </div>
+      </section>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            What It Does to Your Borrowing Power
-          </Heading>
-          <div className="space-y-3 text-muted-foreground">
-            <p>
-              Most lenders offer roughly 4 to 4.5 times income as a mortgage,
-              but they apply that multiple after committed expenditure &mdash;
-              including your student loan repayment.
-            </p>
-            <p>
-              Someone earning &pound;40,000 on Plan 2 repays about{" "}
-              {formatGBP(example40kMonthly)} a month, or around{" "}
-              {formatGBP(example40kAnnual)} a year. On a 4.5x basis that could
-              trim the maximum mortgage by roughly{" "}
-              {formatGBP(example40kMortgageReduction)}. At &pound;60,000 the
-              repayment climbs to about {formatGBP(example60kMonthly)} a month,
-              knocking off closer to {formatGBP(example60kMortgageReduction)} on
-              the same multiplier.
-            </p>
-            <p>
-              These are illustrative &mdash; every lender assesses affordability
-              slightly differently &mdash; but they show the direction of
-              travel. Use the{" "}
-              <Link href="/" className={linkClasses}>
-                student loan repayment calculator
-              </Link>{" "}
-              to see your exact monthly repayment at your salary.
-            </p>
-          </div>
-        </section>
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          How Much You Repay at Each Salary
+        </Heading>
+        <p className="text-sm text-muted-foreground">
+          Based on current thresholds: Plan 2 at {formatGBP(plan2Threshold)} and
+          Plan 5 at {formatGBP(plan5Threshold)} per year. Both charge{" "}
+          {repaymentRateDisplay} on income above the threshold, so Plan
+          5&rsquo;s lower threshold means repayments start sooner.
+        </p>
+      </section>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Do Student Loans Count as Income for a Mortgage?
-          </Heading>
-          <div className="space-y-3 text-muted-foreground">
-            <p>
-              No &mdash; and this trips people up in two ways, both with the
-              same answer.
-            </p>
-            <p>
-              A student loan is money you borrowed, not money you earn, so a
-              lender will never count your maintenance loan or tuition loan as
-              income to boost how much you can borrow. Only earned income
-              &mdash; and sometimes guaranteed bonuses or overtime &mdash;
-              counts towards affordability.
-            </p>
-            <p>
-              The repayment isn&rsquo;t income either; it&rsquo;s a deduction.
-              It only ever reduces the income figure a lender uses, and never
-              adds to it. In short, a student loan can lower your affordability
-              but can never raise it.
-            </p>
-          </div>
-        </section>
+      <ChartFrame
+        className="guide-breakout"
+        caption="Fig. 1 — Monthly repayment by salary · Plan 2 vs Plan 5"
+        bodyClassName="h-75 sm:h-90"
+      >
+        <RepaymentImpactChart />
+      </ChartFrame>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Do You Have to Declare Your Student Loan?
-          </Heading>
-          <div className="space-y-3 text-muted-foreground">
-            <p>
-              Yes &mdash; be upfront about it. A mortgage application asks you
-              to set out your income and regular outgoings honestly, and your
-              student loan repayment is one of those outgoings.
-            </p>
-            <p>
-              If you&rsquo;re employed, the repayment already shows on your
-              payslips, so a lender will usually see it during their checks
-              whether or not you list it separately. Leaving it off
-              doesn&rsquo;t help you and can undermine the application.
-            </p>
-            <p>
-              Exactly where it goes on the form is lender-specific: some ask
-              about student loan repayments directly, others fold them into
-              &ldquo;regular commitments&rdquo;. A mortgage broker can tell you
-              how a particular lender treats it. The key point is to declare the
-              monthly amount honestly &mdash; it&rsquo;s a deduction from
-              income, not a conventional debt like a credit card.
-            </p>
-          </div>
-        </section>
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          What It Does to Your Borrowing Power
+        </Heading>
+        <div className="space-y-3 text-muted-foreground">
+          <p>
+            Most lenders offer roughly 4 to 4.5 times income as a mortgage, but
+            they apply that multiple after committed expenditure &mdash;
+            including your student loan repayment.
+          </p>
+          <p>
+            Someone earning &pound;40,000 on Plan 2 repays about{" "}
+            {formatGBP(example40kMonthly)} a month, or around{" "}
+            {formatGBP(example40kAnnual)} a year. On a 4.5x basis that could
+            trim the maximum mortgage by roughly{" "}
+            {formatGBP(example40kMortgageReduction)}. At &pound;60,000 the
+            repayment climbs to about {formatGBP(example60kMonthly)} a month,
+            knocking off closer to {formatGBP(example60kMortgageReduction)} on
+            the same multiplier.
+          </p>
+          <p>
+            These are illustrative &mdash; every lender assesses affordability
+            slightly differently &mdash; but they show the direction of travel.
+            Use the{" "}
+            <Link href="/" className={linkClasses}>
+              student loan repayment calculator
+            </Link>{" "}
+            to see your exact monthly repayment at your salary.
+          </p>
+        </div>
+      </section>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Does a Student Loan Show on Your Credit File?
-          </Heading>
-          <div className="space-y-3 text-muted-foreground">
-            <p>
-              No. Income-contingent UK student loans (Plan 1, 2, 4, 5 and
-              Postgraduate Loans) are run by the Student Loans Company, which
-              doesn&rsquo;t share your balance or repayments with credit
-              reference agencies. The loan won&rsquo;t appear on your credit
-              report and doesn&rsquo;t affect your credit score.
-            </p>
-            <p>
-              That&rsquo;s good news for a mortgage: however large your balance,
-              it can&rsquo;t drag down the credit score a lender checks, and it
-              can&rsquo;t trigger a credit-based rejection. The only way it
-              touches your mortgage is through affordability &mdash; the monthly
-              repayment described above.
-            </p>
-            <p>
-              It&rsquo;s still worth keeping the rest of your credit file
-              healthy &mdash; on-time bills and low card balances &mdash;
-              because that is what lenders actually score.
-            </p>
-          </div>
-        </section>
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Do Student Loans Count as Income for a Mortgage?
+        </Heading>
+        <div className="space-y-3 text-muted-foreground">
+          <p>
+            No &mdash; and this trips people up in two ways, both with the same
+            answer.
+          </p>
+          <p>
+            A student loan is money you borrowed, not money you earn, so a
+            lender will never count your maintenance loan or tuition loan as
+            income to boost how much you can borrow. Only earned income &mdash;
+            and sometimes guaranteed bonuses or overtime &mdash; counts towards
+            affordability.
+          </p>
+          <p>
+            The repayment isn&rsquo;t income either; it&rsquo;s a deduction. It
+            only ever reduces the income figure a lender uses, and never adds to
+            it. In short, a student loan can lower your affordability but can
+            never raise it.
+          </p>
+        </div>
+      </section>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Should You Pay Off Your Student Loan Before Applying?
-          </Heading>
-          <div className="space-y-3 text-muted-foreground">
-            <p>
-              It&rsquo;s tempting to think clearing the loan will unlock a
-              bigger mortgage. Occasionally it does: if you&rsquo;re a small
-              amount short of the borrowing you need and close to the end of
-              your loan term, removing the monthly repayment can tip an
-              application over the line.
-            </p>
-            <p>
-              For most people, though, the maths doesn&rsquo;t favour it. Cash
-              you throw at the loan is cash that isn&rsquo;t in your deposit,
-              and a bigger deposit usually does far more for a mortgage &mdash;
-              a lower loan-to-value ratio unlocks better interest rates and more
-              lenders. The affordability you gain by clearing the repayment is
-              often modest next to that.
-            </p>
-            <p>
-              This is where the middle-earner squeeze bites hardest. Low earners
-              repay little, so the affordability hit is small; the highest
-              earners can absorb the repayment easily. It&rsquo;s middle earners
-              &mdash; comfortably over the threshold but nowhere near clearing
-              the balance &mdash; who lose the most borrowing power now and go
-              on to repay the most over the life of the loan. The student loan
-              works against them at exactly the moment they&rsquo;re trying to
-              buy.
-            </p>
-            <p>
-              Before overpaying to boost a mortgage, model it. The{" "}
-              <Link href="/overpay" className={linkClasses}>
-                overpay calculator
-              </Link>{" "}
-              shows whether putting a lump sum against your loan actually pays
-              off, or whether that money is better kept for your deposit. And
-              get independent mortgage advice for your own situation.
-            </p>
-          </div>
-        </section>
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Do You Have to Declare Your Student Loan?
+        </Heading>
+        <div className="space-y-3 text-muted-foreground">
+          <p>
+            Yes &mdash; be upfront about it. A mortgage application asks you to
+            set out your income and regular outgoings honestly, and your student
+            loan repayment is one of those outgoings.
+          </p>
+          <p>
+            If you&rsquo;re employed, the repayment already shows on your
+            payslips, so a lender will usually see it during their checks
+            whether or not you list it separately. Leaving it off doesn&rsquo;t
+            help you and can undermine the application.
+          </p>
+          <p>
+            Exactly where it goes on the form is lender-specific: some ask about
+            student loan repayments directly, others fold them into
+            &ldquo;regular commitments&rdquo;. A mortgage broker can tell you
+            how a particular lender treats it. The key point is to declare the
+            monthly amount honestly &mdash; it&rsquo;s a deduction from income,
+            not a conventional debt like a credit card.
+          </p>
+        </div>
+      </section>
 
-        <KeyTakeaways>
-          <li>
-            A UK student loan <strong>won&rsquo;t stop</strong> you getting a
-            mortgage and isn&rsquo;t treated as conventional debt.
-          </li>
-          <li>
-            It <strong>does</strong> affect affordability: lenders deduct your
-            monthly repayment from income, reducing how much you can borrow.
-          </li>
-          <li>
-            It <strong>doesn&rsquo;t count as income</strong> &mdash; it can
-            only lower the figure a lender uses, never raise it.
-          </li>
-          <li>
-            <strong>Declare</strong> the monthly repayment honestly; on PAYE it
-            shows on your payslips anyway.
-          </li>
-          <li>
-            It <strong>doesn&rsquo;t appear</strong> on your credit file or
-            affect your credit score.
-          </li>
-          <li>
-            Paying it off to boost borrowing rarely beats a bigger deposit
-            &mdash; middle earners feel the squeeze most, so model it with the{" "}
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Does a Student Loan Show on Your Credit File?
+        </Heading>
+        <div className="space-y-3 text-muted-foreground">
+          <p>
+            No. Income-contingent UK student loans (Plan 1, 2, 4, 5 and
+            Postgraduate Loans) are run by the Student Loans Company, which
+            doesn&rsquo;t share your balance or repayments with credit reference
+            agencies. The loan won&rsquo;t appear on your credit report and
+            doesn&rsquo;t affect your credit score.
+          </p>
+          <p>
+            That&rsquo;s good news for a mortgage: however large your balance,
+            it can&rsquo;t drag down the credit score a lender checks, and it
+            can&rsquo;t trigger a credit-based rejection. The only way it
+            touches your mortgage is through affordability &mdash; the monthly
+            repayment described above.
+          </p>
+          <p>
+            It&rsquo;s still worth keeping the rest of your credit file healthy
+            &mdash; on-time bills and low card balances &mdash; because that is
+            what lenders actually score.
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Should You Pay Off Your Student Loan Before Applying?
+        </Heading>
+        <div className="space-y-3 text-muted-foreground">
+          <p>
+            It&rsquo;s tempting to think clearing the loan will unlock a bigger
+            mortgage. Occasionally it does: if you&rsquo;re a small amount short
+            of the borrowing you need and close to the end of your loan term,
+            removing the monthly repayment can tip an application over the line.
+          </p>
+          <p>
+            For most people, though, the maths doesn&rsquo;t favour it. Cash you
+            throw at the loan is cash that isn&rsquo;t in your deposit, and a
+            bigger deposit usually does far more for a mortgage &mdash; a lower
+            loan-to-value ratio unlocks better interest rates and more lenders.
+            The affordability you gain by clearing the repayment is often modest
+            next to that.
+          </p>
+          <p>
+            This is where the middle-earner squeeze bites hardest. Low earners
+            repay little, so the affordability hit is small; the highest earners
+            can absorb the repayment easily. It&rsquo;s middle earners &mdash;
+            comfortably over the threshold but nowhere near clearing the balance
+            &mdash; who lose the most borrowing power now and go on to repay the
+            most over the life of the loan. The student loan works against them
+            at exactly the moment they&rsquo;re trying to buy.
+          </p>
+          <p>
+            Before overpaying to boost a mortgage, model it. The{" "}
             <Link href="/overpay" className={linkClasses}>
               overpay calculator
-            </Link>
-            .
-          </li>
-        </KeyTakeaways>
+            </Link>{" "}
+            shows whether putting a lump sum against your loan actually pays
+            off, or whether that money is better kept for your deposit. And get
+            independent mortgage advice for your own situation.
+          </p>
+        </div>
+      </section>
 
-        <RelatedGuides
-          current="student-loan-vs-mortgage"
-          order={["plan-2-vs-plan-5", "how-interest-works"]}
-          tools={["/", "/repaid"]}
-          extraLinks={[
-            {
-              href: "https://www.gov.uk/repaying-your-student-loan/what-you-pay",
-              label: "GOV.UK: What You Pay",
-            },
-          ]}
-        />
-      </GuideArticle>
-    </PageLayout>
+      <KeyTakeaways>
+        <li>
+          A UK student loan <strong>won&rsquo;t stop</strong> you getting a
+          mortgage and isn&rsquo;t treated as conventional debt.
+        </li>
+        <li>
+          It <strong>does</strong> affect affordability: lenders deduct your
+          monthly repayment from income, reducing how much you can borrow.
+        </li>
+        <li>
+          It <strong>doesn&rsquo;t count as income</strong> &mdash; it can only
+          lower the figure a lender uses, never raise it.
+        </li>
+        <li>
+          <strong>Declare</strong> the monthly repayment honestly; on PAYE it
+          shows on your payslips anyway.
+        </li>
+        <li>
+          It <strong>doesn&rsquo;t appear</strong> on your credit file or affect
+          your credit score.
+        </li>
+        <li>
+          Paying it off to boost borrowing rarely beats a bigger deposit &mdash;
+          middle earners feel the squeeze most, so model it with the{" "}
+          <Link href="/overpay" className={linkClasses}>
+            overpay calculator
+          </Link>
+          .
+        </li>
+      </KeyTakeaways>
+    </GuideArticle>
   );
 }

--- a/src/components/guides/threshold-freeze/ThresholdFreezeGuide.tsx
+++ b/src/components/guides/threshold-freeze/ThresholdFreezeGuide.tsx
@@ -1,9 +1,7 @@
 import { InformationCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
-import { RelatedGuides } from "@/components/guides/RelatedGuides";
 import { ChartFrame } from "@/components/instrument/ChartFrame";
-import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { formatGBP } from "@/lib/format";
@@ -32,294 +30,291 @@ const currentTaxYear = getCurrentTaxYearLabel();
 
 export function ThresholdFreezeGuide() {
   return (
-    <PageLayout>
-      <GuideArticle
-        breadcrumbLabel="Threshold Freeze Explained"
-        title="The Plan 2 threshold is being frozen again"
-        intro={
-          <>
-            Every few years, the government freezes the salary at which Plan 2
-            graduates start repaying. Each freeze quietly increases what you pay
-            each month. It&apos;s happened before, it&apos;s happening again,
-            and Parliament is finally asking whether it&apos;s fair.
-          </>
-        }
+    <GuideArticle
+      breadcrumbLabel="Threshold Freeze Explained"
+      title="The Plan 2 threshold is being frozen again"
+      intro={
+        <>
+          Every few years, the government freezes the salary at which Plan 2
+          graduates start repaying. Each freeze quietly increases what you pay
+          each month. It&apos;s happened before, it&apos;s happening again, and
+          Parliament is finally asking whether it&apos;s fair.
+        </>
+      }
+      related={{
+        current: "threshold-freeze",
+        order: ["plan-2-vs-plan-5", "how-interest-works"],
+        tools: ["/repaid", "/effective-rate"],
+        extraLinks: [
+          {
+            href: "https://committees.parliament.uk/work/9682/student-loans-and-taxation-of-graduates/",
+            label:
+              "Treasury Committee: Student Loans and Taxation of Graduates",
+          },
+        ],
+      }}
+    >
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          The Good News First
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            After four years frozen at {formatGBP(SECOND_FREEZE_THRESHOLD)}, the
+            Plan 2 threshold is finally moving again. It rose to{" "}
+            <strong className="text-foreground">
+              {formatGBP(THRESHOLD_2025_26)}
+            </strong>{" "}
+            in April 2025, and rises again to{" "}
+            <strong className="text-foreground">
+              {formatGBP(FREEZE_THRESHOLD)}
+            </strong>{" "}
+            in April 2026 &mdash; two consecutive years of RPI-linked increases
+            that push the threshold up by over £2,000.
+          </p>
+          <p>
+            That&apos;s genuinely positive. A higher threshold means you keep
+            more of your salary before repayments kick in. But what comes next
+            isn&apos;t as welcome.
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          The 2025 Budget: Another Three-Year Freeze
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            In the Autumn Budget on 30 October 2025, Chancellor Rachel Reeves
+            announced that the Plan 2 threshold will{" "}
+            <strong className="text-foreground">
+              freeze at {formatGBP(FREEZE_THRESHOLD)} for three years
+            </strong>{" "}
+            from April 2027 to April 2030. Inflation-linked rises won&apos;t
+            resume until 2030/31.
+          </p>
+          <p>
+            The effect is straightforward: if your salary rises but the
+            threshold doesn&apos;t, a bigger slice of your income sits above the
+            line each year. Every pay rise becomes a slightly larger student
+            loan bill &mdash; without any change to the 9% rate on your payslip.
+          </p>
+          <p>
+            By 2029/30, an inflation-linked threshold would be roughly{" "}
+            {formatGBP(PROJECTED_INFLATION_LINKED)}. Instead it&apos;ll be{" "}
+            {formatGBP(FREEZE_THRESHOLD)} &mdash; a gap of{" "}
+            <strong className="text-foreground">
+              {formatGBP(THRESHOLD_GAP)}
+            </strong>
+            . At {formatGBP(EXAMPLE_SALARY)}, that gap costs you about{" "}
+            <strong className="text-foreground">
+              {formatGBP(EXTRA_ANNUAL)} extra per year
+            </strong>{" "}
+            in repayments.
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          This Is the Third Time
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            Freezing the Plan 2 threshold isn&apos;t new. It&apos;s a pattern:
+          </p>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              <strong className="text-foreground">
+                2012&ndash;2018: Frozen at £21,000 for six years.
+              </strong>{" "}
+              When Plan 2 launched, the threshold was set at £21,000 and never
+              moved. In November 2015, the government confirmed it would stay
+              frozen until at least 2021. Theresa May reversed this in October
+              2017, raising it to £25,000 from April 2018.
+            </li>
+            <li>
+              <strong className="text-foreground">
+                2021&ndash;2025: Frozen at £27,295 for four years.
+              </strong>{" "}
+              After rising with average earnings for a few years, the threshold
+              was frozen again at £27,295 from 2021/22 through 2024/25. Without
+              this freeze, it would have been closer to £31,000 by now.
+            </li>
+            <li>
+              <strong className="text-foreground">
+                2027&ndash;2030: Frozen at {formatGBP(FREEZE_THRESHOLD)} for
+                three years.
+              </strong>{" "}
+              The threshold gets one year of growth (to{" "}
+              {formatGBP(FREEZE_THRESHOLD)} in April 2026), then freezes again.
+            </li>
+          </ul>
+          <p>
+            In the 14 years since Plan 2 began, the threshold has only risen
+            with inflation for about four of them. The rest of the time,
+            it&apos;s been frozen.
+          </p>
+        </div>
+      </section>
+
+      <Alert>
+        <HugeiconsIcon icon={InformationCircleIcon} className="size-4" />
+        <AlertTitle>Figures update automatically</AlertTitle>
+        <AlertDescription>
+          Our calculator checks GOV.UK daily for new thresholds and interest
+          rates. <Link href="/our-data">See how we stay current</Link>.
+        </AlertDescription>
+      </Alert>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          What the Threshold Would Look Like Without Freezes
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            The chart below compares three trajectories for the Plan 2 threshold
+            from 2025/26 to 2030/31:
+          </p>
+          <ul className="list-disc space-y-1 pl-6">
+            <li>
+              <strong className="text-foreground">Inflation-linked</strong>{" "}
+              &mdash; if the threshold had always kept pace with RPI.
+            </li>
+            <li>
+              <strong className="text-foreground">Old policy</strong> &mdash;
+              what was in place before the Budget (frozen at{" "}
+              {formatGBP(THRESHOLD_2025_26)} through April 2027, then resuming
+              RPI).
+            </li>
+            <li>
+              <strong className="text-foreground">New policy</strong> &mdash;
+              bumped to {formatGBP(FREEZE_THRESHOLD)} in April 2026, then frozen
+              again through 2029/30.
+            </li>
+          </ul>
+          <p>
+            The new policy trades a short-term bump for a longer freeze. By
+            2029/30, it falls well behind where an inflation-linked threshold
+            would be.
+          </p>
+        </div>
+      </section>
+
+      <ChartFrame
+        className="guide-breakout"
+        caption="Fig. 1 — Plan 2 threshold trajectories · 2025/26–2030/31"
+        figure={`Gap ${formatGBP(THRESHOLD_GAP)}`}
+        figureTone="cost"
       >
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            The Good News First
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              After four years frozen at {formatGBP(SECOND_FREEZE_THRESHOLD)},
-              the Plan 2 threshold is finally moving again. It rose to{" "}
-              <strong className="text-foreground">
-                {formatGBP(THRESHOLD_2025_26)}
-              </strong>{" "}
-              in April 2025, and rises again to{" "}
-              <strong className="text-foreground">
-                {formatGBP(FREEZE_THRESHOLD)}
-              </strong>{" "}
-              in April 2026 &mdash; two consecutive years of RPI-linked
-              increases that push the threshold up by over £2,000.
-            </p>
-            <p>
-              That&apos;s genuinely positive. A higher threshold means you keep
-              more of your salary before repayments kick in. But what comes next
-              isn&apos;t as welcome.
-            </p>
-          </div>
-        </section>
+        <ThresholdComparisonChart />
+      </ChartFrame>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            The 2025 Budget: Another Three-Year Freeze
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              In the Autumn Budget on 30 October 2025, Chancellor Rachel Reeves
-              announced that the Plan 2 threshold will{" "}
-              <strong className="text-foreground">
-                freeze at {formatGBP(FREEZE_THRESHOLD)} for three years
-              </strong>{" "}
-              from April 2027 to April 2030. Inflation-linked rises won&apos;t
-              resume until 2030/31.
-            </p>
-            <p>
-              The effect is straightforward: if your salary rises but the
-              threshold doesn&apos;t, a bigger slice of your income sits above
-              the line each year. Every pay rise becomes a slightly larger
-              student loan bill &mdash; without any change to the 9% rate on
-              your payslip.
-            </p>
-            <p>
-              By 2029/30, an inflation-linked threshold would be roughly{" "}
-              {formatGBP(PROJECTED_INFLATION_LINKED)}. Instead it&apos;ll be{" "}
-              {formatGBP(FREEZE_THRESHOLD)} &mdash; a gap of{" "}
-              <strong className="text-foreground">
-                {formatGBP(THRESHOLD_GAP)}
-              </strong>
-              . At {formatGBP(EXAMPLE_SALARY)}, that gap costs you about{" "}
-              <strong className="text-foreground">
-                {formatGBP(EXTRA_ANNUAL)} extra per year
-              </strong>{" "}
-              in repayments.
-            </p>
-          </div>
-        </section>
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          What About Other Plans?
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            The freeze only applies to{" "}
+            <strong className="text-foreground">Plan 2</strong> (2012&ndash;23
+            borrowers in England and Wales) &mdash; the largest cohort. Other
+            plans are unaffected:
+          </p>
+          <ul className="list-disc space-y-1 pl-6">
+            <li>
+              <strong className="text-foreground">Plan 5</strong> (2023+
+              borrowers): The{" "}
+              {formatGBP(PLAN_CONFIGS.PLAN_5.monthlyThreshold * 12)} threshold
+              actually <em>starts rising</em> with RPI from April 2027.
+            </li>
+            <li>
+              <strong className="text-foreground">Plan 1</strong> and{" "}
+              <strong className="text-foreground">Plan 4</strong>: Continue
+              annual RPI adjustments as normal.
+            </li>
+          </ul>
+          <p>
+            Wales has also indicated it will not apply the freeze for Welsh Plan
+            2 borrowers.
+          </p>
+        </div>
+      </section>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            This Is the Third Time
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              Freezing the Plan 2 threshold isn&apos;t new. It&apos;s a pattern:
-            </p>
-            <ul className="list-disc space-y-2 pl-6">
-              <li>
-                <strong className="text-foreground">
-                  2012&ndash;2018: Frozen at £21,000 for six years.
-                </strong>{" "}
-                When Plan 2 launched, the threshold was set at £21,000 and never
-                moved. In November 2015, the government confirmed it would stay
-                frozen until at least 2021. Theresa May reversed this in October
-                2017, raising it to £25,000 from April 2018.
-              </li>
-              <li>
-                <strong className="text-foreground">
-                  2021&ndash;2025: Frozen at £27,295 for four years.
-                </strong>{" "}
-                After rising with average earnings for a few years, the
-                threshold was frozen again at £27,295 from 2021/22 through
-                2024/25. Without this freeze, it would have been closer to
-                £31,000 by now.
-              </li>
-              <li>
-                <strong className="text-foreground">
-                  2027&ndash;2030: Frozen at {formatGBP(FREEZE_THRESHOLD)} for
-                  three years.
-                </strong>{" "}
-                The threshold gets one year of growth (to{" "}
-                {formatGBP(FREEZE_THRESHOLD)} in April 2026), then freezes
-                again.
-              </li>
-            </ul>
-            <p>
-              In the 14 years since Plan 2 began, the threshold has only risen
-              with inflation for about four of them. The rest of the time,
-              it&apos;s been frozen.
-            </p>
-          </div>
-        </section>
+      <section className="space-y-3">
+        <Heading as="h2" size="section" id="current-repayment-thresholds">
+          Current Repayment Thresholds ({currentTaxYear})
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            These are the salary thresholds that apply for the {currentTaxYear}{" "}
+            tax year. Undergraduate borrowers repay{" "}
+            {String(REPAYMENT_RATE * 100)}% of everything they earn above their
+            plan&apos;s threshold &mdash; which is exactly why the freeze bites
+            hardest for middle earners, whose pay rises push more of their
+            salary above a line that isn&apos;t moving.
+          </p>
+        </div>
+      </section>
 
-        <Alert>
-          <HugeiconsIcon icon={InformationCircleIcon} className="size-4" />
-          <AlertTitle>Figures update automatically</AlertTitle>
-          <AlertDescription>
-            Our calculator checks GOV.UK daily for new thresholds and interest
-            rates. <Link href="/our-data">See how we stay current</Link>.
-          </AlertDescription>
-        </Alert>
+      <div className="guide-breakout">
+        <CurrentThresholdsTable />
+      </div>
 
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            What the Threshold Would Look Like Without Freezes
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              The chart below compares three trajectories for the Plan 2
-              threshold from 2025/26 to 2030/31:
-            </p>
-            <ul className="list-disc space-y-1 pl-6">
-              <li>
-                <strong className="text-foreground">Inflation-linked</strong>{" "}
-                &mdash; if the threshold had always kept pace with RPI.
-              </li>
-              <li>
-                <strong className="text-foreground">Old policy</strong> &mdash;
-                what was in place before the Budget (frozen at{" "}
-                {formatGBP(THRESHOLD_2025_26)} through April 2027, then resuming
-                RPI).
-              </li>
-              <li>
-                <strong className="text-foreground">New policy</strong> &mdash;
-                bumped to {formatGBP(FREEZE_THRESHOLD)} in April 2026, then
-                frozen again through 2029/30.
-              </li>
-            </ul>
-            <p>
-              The new policy trades a short-term bump for a longer freeze. By
-              2029/30, it falls well behind where an inflation-linked threshold
-              would be.
-            </p>
-          </div>
-        </section>
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          Parliament Is Asking Questions
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            On 12 March 2026, the Treasury Committee launched an inquiry into{" "}
+            <strong className="text-foreground">
+              &ldquo;Student Loans and Taxation of Graduates&rdquo;
+            </strong>
+            . Chair Dame Meg Hillier framed it directly: &ldquo;What we&apos;re
+            asking is, have the goalposts been moved in a way which is unfair to
+            graduates?&rdquo;
+          </p>
+          <p>
+            The inquiry focuses on whether the repeated freezes &mdash; combined
+            with Plan 2&apos;s complex interest rules &mdash; mean graduates are
+            repaying far more than they were led to expect. The average Plan 2
+            balance is £43,645, compared to £10,252 for Plan 1 borrowers.
+          </p>
+          <p>
+            The evidence deadline is{" "}
+            <strong className="text-foreground">14 April 2026</strong>, and
+            anyone over 16 can submit their experience. The outcome could shape
+            future threshold policy.
+          </p>
+        </div>
+      </section>
 
-        <ChartFrame
-          caption="Fig. 1 — Plan 2 threshold trajectories · 2025/26–2030/31"
-          figure={`Gap ${formatGBP(THRESHOLD_GAP)}`}
-          figureTone="cost"
-        >
-          <ThresholdComparisonChart />
-        </ChartFrame>
-
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            What About Other Plans?
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              The freeze only applies to{" "}
-              <strong className="text-foreground">Plan 2</strong> (2012&ndash;23
-              borrowers in England and Wales) &mdash; the largest cohort. Other
-              plans are unaffected:
-            </p>
-            <ul className="list-disc space-y-1 pl-6">
-              <li>
-                <strong className="text-foreground">Plan 5</strong> (2023+
-                borrowers): The{" "}
-                {formatGBP(PLAN_CONFIGS.PLAN_5.monthlyThreshold * 12)} threshold
-                actually <em>starts rising</em> with RPI from April 2027.
-              </li>
-              <li>
-                <strong className="text-foreground">Plan 1</strong> and{" "}
-                <strong className="text-foreground">Plan 4</strong>: Continue
-                annual RPI adjustments as normal.
-              </li>
-            </ul>
-            <p>
-              Wales has also indicated it will not apply the freeze for Welsh
-              Plan 2 borrowers.
-            </p>
-          </div>
-        </section>
-
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Current Repayment Thresholds ({currentTaxYear})
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              These are the salary thresholds that apply for the{" "}
-              {currentTaxYear} tax year. Undergraduate borrowers repay{" "}
-              {String(REPAYMENT_RATE * 100)}% of everything they earn above
-              their plan&apos;s threshold &mdash; which is exactly why the
-              freeze bites hardest for middle earners, whose pay rises push more
-              of their salary above a line that isn&apos;t moving.
-            </p>
-          </div>
-          <CurrentThresholdsTable />
-        </section>
-
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            Parliament Is Asking Questions
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              On 12 March 2026, the Treasury Committee launched an inquiry into{" "}
-              <strong className="text-foreground">
-                &ldquo;Student Loans and Taxation of Graduates&rdquo;
-              </strong>
-              . Chair Dame Meg Hillier framed it directly: &ldquo;What
-              we&apos;re asking is, have the goalposts been moved in a way which
-              is unfair to graduates?&rdquo;
-            </p>
-            <p>
-              The inquiry focuses on whether the repeated freezes &mdash;
-              combined with Plan 2&apos;s complex interest rules &mdash; mean
-              graduates are repaying far more than they were led to expect. The
-              average Plan 2 balance is £43,645, compared to £10,252 for Plan 1
-              borrowers.
-            </p>
-            <p>
-              The evidence deadline is{" "}
-              <strong className="text-foreground">14 April 2026</strong>, and
-              anyone over 16 can submit their experience. The outcome could
-              shape future threshold policy.
-            </p>
-          </div>
-        </section>
-
-        <section className="space-y-3">
-          <Heading as="h2" size="section">
-            See the Impact on Your Repayments
-          </Heading>
-          <div className="space-y-2 text-muted-foreground">
-            <p>
-              The numbers above use a {formatGBP(EXAMPLE_SALARY)} salary as an
-              example. To see what the freeze means at your income, try the{" "}
-              <Link href="/" className={guideLink}>
-                repayment calculator
-              </Link>{" "}
-              &mdash; set threshold growth to 0% to model the freeze, or 3% for
-              inflation-linked growth. You can also check{" "}
-              <Link href="/repaid" className={guideLink}>
-                when your loan will be paid off
-              </Link>{" "}
-              and how the freeze pushes up{" "}
-              <Link href="/effective-rate" className={guideLink}>
-                the effective interest rate you pay
-              </Link>
-              .
-            </p>
-          </div>
-        </section>
-
-        <RelatedGuides
-          current="threshold-freeze"
-          order={["plan-2-vs-plan-5", "how-interest-works"]}
-          tools={["/repaid", "/effective-rate"]}
-          extraLinks={[
-            {
-              href: "https://committees.parliament.uk/work/9682/student-loans-and-taxation-of-graduates/",
-              label:
-                "Treasury Committee: Student Loans and Taxation of Graduates",
-            },
-          ]}
-        />
-      </GuideArticle>
-    </PageLayout>
+      <section className="space-y-3">
+        <Heading as="h2" size="section">
+          See the Impact on Your Repayments
+        </Heading>
+        <div className="space-y-2 text-muted-foreground">
+          <p>
+            The numbers above use a {formatGBP(EXAMPLE_SALARY)} salary as an
+            example. To see what the freeze means at your income, try the{" "}
+            <Link href="/" className={guideLink}>
+              repayment calculator
+            </Link>{" "}
+            &mdash; set threshold growth to 0% to model the freeze, or 3% for
+            inflation-linked growth. You can also check{" "}
+            <Link href="/repaid" className={guideLink}>
+              when your loan will be paid off
+            </Link>{" "}
+            and how the freeze pushes up{" "}
+            <Link href="/effective-rate" className={guideLink}>
+              the effective interest rate you pay
+            </Link>
+            .
+          </p>
+        </div>
+      </section>
+    </GuideArticle>
   );
 }


### PR DESCRIPTION
## Why

The home page and guides-index page were recently redesigned to go full-width and take advantage of very wide monitors. The individual guide (article) pages were never brought along — they stayed a narrow `max-w-2xl` centred column that left most of a wide screen as empty margin. This extends the same full-width design language to the guides themselves, and along the way spends genuinely ultra-wide space on reading legibility rather than emptiness.

## What changes for the reader

Individual guide pages now use the wide **workspace** shell instead of the narrow reading column.

At **1500px and up**, a guide opens into three zones:

- a sticky **"On this page"** contents rail on the left (section anchors + freshness meta);
- a centred **~66ch reading column** in the middle, where prose stays at a comfortable measure but charts and data tables break out wider than the sentences that frame them;
- a sticky **companion rail** on the right — a standing "open the calculator" call-to-action, related guides, references, and tools.

**Below 1500px** the layout collapses back to a single centred column with the companion block at the foot of the article — the same reading experience guides had before.

## Anchors work without JavaScript

The section anchor ids and the contents list are rendered server-side (derived from the article's section headings), so shareable `#section` URLs and crawlers work with no JS. The scroll-spy that highlights the current section, and the smooth-scroll on click, are a progressive enhancement layered on top. Headings whose visible text includes the tax year carry explicit, stable ids so those anchors don't break when the annual figure automation rewrites the heading text.

## Using even wider screens

Rather than run edge-to-edge or pile on margin, the guide prose scales fluidly from 16px up to 18px on very wide viewports. Because the reading column is measured in `ch`, the measure grows in *pixels* while characters-per-line stays ~66 — the extra width buys larger, more legible type, not longer lines. The overall ultra-wide composition is deliberately capped (~1650–1800px) for reading comfort.

Deliberate scoping decisions: the scroll-spy is an enhancement over always-present server-rendered anchors; the Key Takeaways summary scales with the body copy, while compact grid/step UI keeps its fixed sizing.