### PR TITLE
refactor: replace guide-body css with tailwind utilities

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,11 +49,10 @@ export default defineConfig(
       "better-tailwindcss/enforce-consistent-line-wrapping": "off",
       "better-tailwindcss/no-unknown-classes": [
         "error",
-        // `guide-body` / `guide-breakout` drive the guide reading-column grid in
-        // globals.css `@layer components` (`guide-breakout` exists only as the
-        // `.guide-body > .guide-breakout` target), not as Tailwind utilities, so
-        // the resolver can't see them.
-        { ignore: ["dark", "light", "guide-body", "guide-breakout"] },
+        // `dark` / `light` scope the theme CSS variables for a subtree; they are
+        // plain marker classes, not Tailwind utilities, so the resolver can't
+        // see them.
+        { ignore: ["dark", "light"] },
       ],
     },
   },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -289,50 +289,8 @@
   }
 }
 
-/* ==========================================================================
-   GUIDE READING WORKSPACE — the long-form article body. A centred prose measure
-   (~66ch) with a wider breakout track: charts and data tables opt into
-   `.guide-breakout` to read wider than the prose that frames them, while the
-   sentences stay at a comfortable measure. Works at every width — below the
-   `work` workspace breakpoint the tracks collapse so the body is just a centred
-   column with full-width figures, matching the pre-redesign reading experience.
-   ========================================================================== */
-@layer components {
-  .guide-body {
-    display: grid;
-    grid-template-columns:
-      [full-start] minmax(0, 1fr)
-      [content-start] min(66ch, 100%)
-      [content-end] minmax(0, 1fr)
-      [full-end];
-    row-gap: clamp(2.25rem, 3.4vw, 3.25rem);
-    /* Fluid reading size: 16px through laptop widths, easing up to 18px only on
-       very wide viewports (~2000px+). Because the `content` track is measured in
-       `ch`, the prose column grows in pixels while characters-per-line stays
-       ~66 — spending ultrawide space on legibility, not a longer line. Headings
-       and the mono readouts keep their own scales. */
-    font-size: clamp(1rem, 0.75rem + 0.2vw, 1.125rem);
-  }
-  /* Prose sits in the reading measure; every child gets min-width:0 so a wide
-     table or chart can shrink instead of forcing horizontal overflow. */
-  .guide-body > * {
-    grid-column: content;
-    min-width: 0;
-  }
-  /* Figures span the full column — wider than the prose, still column-relative
-     so they never collide with the sticky rails on the workspace grid. */
-  .guide-body > .guide-breakout {
-    grid-column: full;
-  }
-  /* Anchor targets (section headings the contents rail links to) clear the
-     sticky header when jumped to. */
-  .guide-body :is(h2, h3)[id] {
-    scroll-margin-top: 5.5rem;
-  }
-}
-
 /* The guide lead paragraph — a step above body, sized in `em` so it rides the
-   fluid reading base (`.guide-body`'s font-size) instead of a fixed rem. Body
+   fluid reading base (the guide body's font-size) instead of a fixed rem. Body
    copy just inherits that base; only the lead needs a ratio of its own. */
 @utility guide-lead {
   font-size: 1.0625em;

--- a/src/components/guides/guide-parts.tsx
+++ b/src/components/guides/guide-parts.tsx
@@ -57,6 +57,7 @@ type SectionHeadingElement = React.ReactElement<{
   children?: ReactNode;
   id?: string;
   size?: string;
+  className?: string;
 }>;
 
 const isSectionHeading = (
@@ -90,7 +91,12 @@ function processGuideBody(children: ReactNode): {
     }
     seen.add(id);
     sections.push({ id, label });
-    return cloneElement(heading, { id });
+    // `scroll-mt-22` (5.5rem) clears the sticky header when the contents rail
+    // jumps to this anchor — applied to exactly the headings that receive ids.
+    return cloneElement(heading, {
+      id,
+      className: cn(heading.props.className, "scroll-mt-22"),
+    });
   };
 
   // Recurse through structural wrappers (`<section>` and fragments) so a heading
@@ -128,7 +134,7 @@ function processGuideBody(children: ReactNode): {
  *   - a sticky **contents** rail (an auto-built "On this page" table of contents
  *     plus the freshness meta) anchoring the left edge;
  *   - the **reading column** in the middle — prose held at a ~66ch measure while
- *     charts and data tables (`.guide-breakout`) read wider;
+ *     charts and data tables ({@link guideBreakout}) read wider;
  *   - a sticky **companion** rail (calculator CTA, related guides, tools)
  *     anchoring the right edge — the same block that stacks beneath the article
  *     on narrow screens.
@@ -181,9 +187,18 @@ export function GuideArticle({
           </dl>
         </aside>
 
-        {/* Reading column — header + body share the ~66ch content track; figures
-            marked `guide-breakout` span wider. */}
-        <article className="guide-body mx-auto max-w-200 min-w-0 work:mx-0 work:max-w-none">
+        {/* Reading column — a centred prose measure (~66ch middle track) framed
+            by two flexible margin tracks. Header + body children sit in the
+            content track (`*:col-start-2`); figures marked `guideBreakout`
+            span all three tracks to read wider than the prose. `min-w-0` on
+            every child lets a wide table or chart shrink instead of forcing
+            horizontal overflow. The font-size is a fluid reading base: 16px
+            through laptop widths, easing to 18px only on very wide viewports —
+            because the content track is measured in `ch`, the prose column
+            grows in pixels while characters-per-line stays ~66. Below the `work`
+            breakpoint the tracks collapse to a single centred column with
+            full-width figures, matching the pre-redesign reading experience. */}
+        <article className="mx-auto grid max-w-200 min-w-0 grid-cols-[minmax(0,1fr)_min(66ch,100%)_minmax(0,1fr)] gap-y-[clamp(2.25rem,3.4vw,3.25rem)] text-[clamp(1rem,0.75rem+0.2vw,1.125rem)] *:col-start-2 *:min-w-0 work:mx-0 work:max-w-none">
           <header className="space-y-4">
             <Breadcrumb>
               <BreadcrumbList>
@@ -232,6 +247,16 @@ export function GuideArticle({
 /** Inline prose link: spruce-ink with a hairline underline that thickens on hover. */
 export const guideLink =
   "font-medium text-cta underline decoration-1 underline-offset-4 transition-[text-decoration-color,color] hover:text-cta/80";
+
+/**
+ * Breakout figures (charts, wide tables) span all three tracks of the reading
+ * grid to read wider than the prose that frames them. The `!` overrides the
+ * grid's `*:col-start-2` default — the breakout must always win, mirroring the
+ * specificity boost the old `.guide-body > .guide-breakout` rule relied on.
+ * Column-relative (not viewport-relative) so figures never collide with the
+ * sticky rails on the workspace grid. Apply to a direct child of the article.
+ */
+export const guideBreakout = "col-span-full!";
 
 /* Spec-sheet table cell treatments — engraved sans headers, mono figures. */
 /** Engraved sans header cell (text column). */

--- a/src/components/guides/how-interest-works/InterestGuide.tsx
+++ b/src/components/guides/how-interest-works/InterestGuide.tsx
@@ -4,7 +4,7 @@ import { Heading } from "@/components/typography/Heading";
 import { formatGBP, formatPercent } from "@/lib/format";
 import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
 import { getCurrentTaxYearLabel } from "@/lib/taxYear";
-import { GuideArticle, guideLink } from "../guide-parts";
+import { GuideArticle, guideBreakout, guideLink } from "../guide-parts";
 import { CurrentRatesTable } from "./CurrentRatesTable";
 import { InterestRateChart } from "./InterestRateChart";
 
@@ -96,7 +96,7 @@ export function InterestGuide() {
       </section>
 
       <ChartFrame
-        className="guide-breakout"
+        className={guideBreakout}
         caption="Fig. 1 — Annual interest rate by salary · Plan 2 vs Plan 5"
         figure={`${formatPercent(maxRate)} max`}
         figureTone="cost"
@@ -159,7 +159,7 @@ export function InterestGuide() {
         </div>
       </section>
 
-      <div className="guide-breakout">
+      <div className={guideBreakout}>
         <CurrentRatesTable />
       </div>
 

--- a/src/components/guides/interest-rate-cap/InterestRateCapGuide.tsx
+++ b/src/components/guides/interest-rate-cap/InterestRateCapGuide.tsx
@@ -3,7 +3,7 @@ import { Heading } from "@/components/typography/Heading";
 import { formatGBP, formatPercent } from "@/lib/format";
 import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
 import { getCurrentTaxYearLabel } from "@/lib/taxYear";
-import { GuideArticle, KeyTakeaways } from "../guide-parts";
+import { GuideArticle, guideBreakout, KeyTakeaways } from "../guide-parts";
 import { BalanceWithCapChart } from "./BalanceWithCapChart";
 import { CurrentCapTable } from "./CurrentCapTable";
 import { TOTAL_YEARS, YEARS_ABOVE_CAP } from "./historical-rates";
@@ -77,7 +77,7 @@ export function InterestRateCapGuide() {
         </div>
       </section>
 
-      <div className="guide-breakout">
+      <div className={guideBreakout}>
         <CurrentCapTable />
       </div>
 
@@ -123,7 +123,7 @@ export function InterestRateCapGuide() {
       </section>
 
       <ChartFrame
-        className="guide-breakout"
+        className={guideBreakout}
         caption="Fig. 1 — Maximum Plan 2 rate charged by year"
         figure="Cap 6%"
         figureTone="cost"
@@ -159,7 +159,7 @@ export function InterestRateCapGuide() {
       </section>
 
       <ChartFrame
-        className="guide-breakout"
+        className={guideBreakout}
         caption="Fig. 2 — Balance with and without the 6% cap"
         figure="Cap 6%"
         figureTone="cost"
@@ -189,7 +189,7 @@ export function InterestRateCapGuide() {
       </section>
 
       <ChartFrame
-        className="guide-breakout"
+        className={guideBreakout}
         caption="Fig. 3 — Total repaid by salary · sustained 7% RPI"
       >
         <TotalCostComparisonChart />

--- a/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
+++ b/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
@@ -23,6 +23,7 @@ import { PLAN_CONFIGS } from "@/lib/loans/plans";
 import { surfaceCard } from "@/lib/surfaces";
 import {
   GuideArticle,
+  guideBreakout,
   guideLink,
   KeyTakeaways,
   SeamCell,
@@ -188,7 +189,7 @@ export function MovingAbroadGuide() {
         </p>
       </section>
 
-      <div className="guide-breakout">
+      <div className={guideBreakout}>
         <ScrollFadeWrapper className={surfaceCard}>
           <Table>
             <TableHeader>

--- a/src/components/guides/pay-upfront-or-take-loan/PayUpfrontGuide.tsx
+++ b/src/components/guides/pay-upfront-or-take-loan/PayUpfrontGuide.tsx
@@ -7,7 +7,12 @@ import {
   PLAN_DISPLAY_INFO,
   TUITION_FEE_CAP,
 } from "@/lib/loans/plans";
-import { GuideArticle, guideLink, KeyTakeaways } from "../guide-parts";
+import {
+  GuideArticle,
+  guideBreakout,
+  guideLink,
+  KeyTakeaways,
+} from "../guide-parts";
 import { CostComparisonChart } from "./CostComparisonChart";
 
 const tuitionTotal = TUITION_FEE_CAP * 3;
@@ -124,7 +129,7 @@ export function PayUpfrontGuide() {
       </section>
 
       <ChartFrame
-        className="guide-breakout"
+        className={guideBreakout}
         caption="Fig. 1 — Total cost: loan vs upfront by salary · Plan 5"
         figure={`Upfront ${tuitionFormatted}`}
         figureTone="cost"

--- a/src/components/guides/plan-2-vs-plan-5/Plan2VsPlan5Guide.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/Plan2VsPlan5Guide.tsx
@@ -3,7 +3,12 @@ import { ChartFrame } from "@/components/instrument/ChartFrame";
 import { Heading } from "@/components/typography/Heading";
 import { formatGBP } from "@/lib/format";
 import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
-import { GuideArticle, guideLink, KeyTakeaways } from "../guide-parts";
+import {
+  GuideArticle,
+  guideBreakout,
+  guideLink,
+  KeyTakeaways,
+} from "../guide-parts";
 import { BalanceComparisonChart } from "./BalanceComparisonChart";
 import { ComparisonTable } from "./ComparisonTable";
 import { TotalRepaymentBySalaryChart } from "./TotalRepaymentBySalaryChart";
@@ -51,7 +56,7 @@ export function Plan2VsPlan5Guide() {
         </p>
       </section>
 
-      <div className="guide-breakout">
+      <div className={guideBreakout}>
         <ComparisonTable />
       </div>
 
@@ -69,7 +74,7 @@ export function Plan2VsPlan5Guide() {
       </section>
 
       <ChartFrame
-        className="guide-breakout"
+        className={guideBreakout}
         caption={`Fig. 1 — Lifetime repaid by salary · ${formatGBP(EXAMPLE_BALANCE)} balance`}
         bodyClassName="h-75 sm:h-95"
       >
@@ -89,7 +94,7 @@ export function Plan2VsPlan5Guide() {
       </section>
 
       <ChartFrame
-        className="guide-breakout"
+        className={guideBreakout}
         caption={`Fig. 2 — Balance over time · Plan 2 vs Plan 5`}
         bodyClassName="h-85 sm:h-105"
       >

--- a/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
+++ b/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
@@ -3,7 +3,12 @@ import { ChartFrame } from "@/components/instrument/ChartFrame";
 import { Heading } from "@/components/typography/Heading";
 import { formatPercent } from "@/lib/format";
 import { CURRENT_RATES } from "@/lib/loans/plans";
-import { GuideArticle, guideLink, KeyTakeaways } from "../guide-parts";
+import {
+  GuideArticle,
+  guideBreakout,
+  guideLink,
+  KeyTakeaways,
+} from "../guide-parts";
 import { InflationComparisonChart } from "./InflationComparisonChart";
 
 const rpi = CURRENT_RATES.rpi;
@@ -144,7 +149,7 @@ export function RpiVsCpiGuide() {
       </section>
 
       <ChartFrame
-        className="guide-breakout"
+        className={guideBreakout}
         caption={`Fig. 1 \u2014 Balance in real terms \u00b7 Plan 5, \u00a345,000`}
         figure={`RPI ${formatPercent(rpi)}`}
         figureTone="cost"

--- a/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
+++ b/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
@@ -11,7 +11,12 @@ import { Panel } from "@/components/instrument/Panel";
 import { Heading } from "@/components/typography/Heading";
 import { formatGBP } from "@/lib/format";
 import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
-import { GuideArticle, guideLink, KeyTakeaways } from "../guide-parts";
+import {
+  GuideArticle,
+  guideBreakout,
+  guideLink,
+  KeyTakeaways,
+} from "../guide-parts";
 import { RepaymentImpactChart } from "./RepaymentImpactChart";
 
 const plan2Threshold = PLAN_DISPLAY_INFO.PLAN_2.yearlyThreshold;
@@ -156,7 +161,7 @@ export function MortgageGuide() {
       </section>
 
       <ChartFrame
-        className="guide-breakout"
+        className={guideBreakout}
         caption="Fig. 1 — Monthly repayment by salary · Plan 2 vs Plan 5"
         bodyClassName="h-75 sm:h-90"
       >

--- a/src/components/guides/threshold-freeze/ThresholdFreezeGuide.tsx
+++ b/src/components/guides/threshold-freeze/ThresholdFreezeGuide.tsx
@@ -7,7 +7,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { formatGBP } from "@/lib/format";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
 import { getCurrentTaxYearLabel } from "@/lib/taxYear";
-import { GuideArticle, guideLink } from "../guide-parts";
+import { GuideArticle, guideBreakout, guideLink } from "../guide-parts";
 import { CurrentThresholdsTable } from "./CurrentThresholdsTable";
 import { ThresholdComparisonChart } from "./ThresholdComparisonChart";
 
@@ -203,7 +203,7 @@ export function ThresholdFreezeGuide() {
       </section>
 
       <ChartFrame
-        className="guide-breakout"
+        className={guideBreakout}
         caption="Fig. 1 — Plan 2 threshold trajectories · 2025/26–2030/31"
         figure={`Gap ${formatGBP(THRESHOLD_GAP)}`}
         figureTone="cost"
@@ -258,7 +258,7 @@ export function ThresholdFreezeGuide() {
         </div>
       </section>
 
-      <div className="guide-breakout">
+      <div className={guideBreakout}>
         <CurrentThresholdsTable />
       </div>
 


### PR DESCRIPTION
## Why

`guide-body` and `guide-breakout` were bespoke CSS classes defined in `globals.css` under `@layer components` — not Tailwind utilities. Because the `better-tailwindcss/no-unknown-classes` lint resolver only sees real Tailwind utilities, both names had to be allow-listed as lint exceptions. This expresses the same guide reading-column layout with standard Tailwind utilities so that exception can be dropped, keeping the codebase's utility-first approach consistent.

## What changed

The guide article's reading column — a centred ~66ch prose measure with wider "breakout" figures for charts and tables — is now built from inline Tailwind utilities on the `<article>` element rather than the `.guide-body` component class. Breakout figures opt in via a shared exported `guideBreakout` class-string constant (mirroring the existing `guideLink`/`specHead` constants in `guide-parts.tsx`) instead of a `guide-breakout` CSS class. The anchor-heading `scroll-margin` now applies precisely to the headings that receive ids, at clone time.

The `better-tailwindcss/no-unknown-classes` ignore list now carries only the `dark`/`light` theme marker classes.

The rendered layout is unchanged — verified pixel-identical at wide, narrow, and ultra-wide viewports.