### PR TITLE
refactor: converge domain language onto CONTEXT.md glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,7 +53,7 @@ A voluntary extra payment beyond the mandatory repayment. A **lump sum** is a on
 _Avoid_: voluntary payment, voluntary overpayment, extra payment, paying extra
 
 **Write-off**:
-The cancellation of any remaining balance at the end of the plan's term (25–40 years). Genuinely opposite to "paid off" — do not blur them.
+The cancellation of any remaining balance at the end of the plan's term (25–40 years). Genuinely opposite to "paid off" — do not blur them. (Exception: the moving-abroad myth FAQ and its SEO keyword deliberately echo the myth's own words — "wiped"/"wipe"/"cancel" — to debunk the belief that moving abroad clears your loan; the factual statements there still use "written off".)
 _Avoid_: forgiven, cancelled, wiped, cleared
 
 **Paid off**:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -139,7 +139,7 @@ A cool, spruce-biased neutral field with a single green brand voice and a single
 ### Primary
 
 - **Spruce** (`#0C5C44`; dark `#34B08A`): The brand and the only affordance color. Slider fill, selected-preset wash, the brand mark, sparkline strokes, link underlines, focus rings, the "your salary" dot. If something is interactive or on-brand, it is spruce.
-- **Spruce Ink** (`#094A37`; dark `#50C99F`): A stronger spruce for text that must read as a link or an emphasized label against the surface (the "Total repaid" key, inline "change" links, deeplinks). Spruce carries fills; Spruce Ink carries type.
+- **Spruce Ink** (`#094A37`; dark `#50C99F`): A stronger spruce for text that must read as a link or an emphasised label against the surface (the "Total repaid" key, inline "change" links, deeplinks). Spruce carries fills; Spruce Ink carries type.
 
 ### Secondary
 
@@ -234,7 +234,7 @@ Lead with the character, then the spec. Every interactive element resolves to sp
 
 ### Scenario presets (selectable)
 
-- **Character:** Named salary presets plus one "Tailor to you" custom option; a compact selectable button-card.
+- **Character:** Named salary presets plus one "Tailor to you" option; a compact selectable button-card.
 - **Style:** `Surface` fill, 1px `Hair` border, 9px radius, `Soft` text with a bold `Ink` value line. Hover → border to `Soft`.
 - **Selected** (`aria-pressed="true"`): border to spruce, background to `Accent Wash`, value line to spruce-ink.
 - **Responsive:** a container query on the group re-flows the grid 2 → 4 → 5 columns; "Tailor to you" spans full-width until there is room for a single 5-across row.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # UK Student Loan Study
 
-An interactive calculator to help understand UK student loan repayment under Plan 2/Plan 5 and Postgraduate loan schemes.
+An interactive calculator to help understand UK student loan repayment under Plan 2/Plan 5 and Postgraduate loans.
 
 ## Features
 
 - Calculate total repayment amounts based on salary
-- Visualize repayment timelines and effective interest rates
-- Compare Plan 2 (pre-2023) vs Plan 5 (post-2023) schemes
-- Account for postgraduate loans running concurrently
-- See personalized projections based on your salary
+- Visualise repayment timelines and effective rates
+- Compare Plan 2 (pre-2023) vs Plan 5 (post-2023)
+- Account for Postgraduate loans running concurrently
+- See personalised projections based on your salary
 
 ## Tech Stack
 
@@ -83,7 +83,7 @@ The app is deployed on Vercel. Push to `main` to trigger a deployment.
 
 - Repayment threshold: 2,083/month
 - Repayment rate: 9% above threshold
-- Interest: RPI only (no income-based uplift)
+- Interest: RPI only (no sliding scale)
 - Write-off: 40 years after first repayment
 
 ### Postgraduate Loans

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -8,33 +8,33 @@ For detailed explanations, see [uk-student-loans-research.md](./uk-student-loans
 
 ## Current Thresholds (2025/26)
 
-| Plan         | Annual  | Monthly | Weekly | Rate |
-| ------------ | ------- | ------- | ------ | ---- |
-| **Plan 1**   | £26,065 | £2,172  | £501   | 9%   |
-| **Plan 2**   | £28,470 | £2,372  | £547   | 9%   |
-| **Plan 4**   | £32,745 | £2,728  | £629   | 9%   |
-| **Plan 5**   | £25,000 | £2,083  | £480   | 9%   |
-| **Postgrad** | £21,000 | £1,750  | £403   | 6%   |
+| Plan             | Annual  | Monthly | Weekly | Rate |
+| ---------------- | ------- | ------- | ------ | ---- |
+| **Plan 1**       | £26,065 | £2,172  | £501   | 9%   |
+| **Plan 2**       | £28,470 | £2,372  | £547   | 9%   |
+| **Plan 4**       | £32,745 | £2,728  | £629   | 9%   |
+| **Plan 5**       | £25,000 | £2,083  | £480   | 9%   |
+| **Postgraduate** | £21,000 | £1,750  | £403   | 6%   |
 
 ## Thresholds from April 2026
 
-| Plan         | Annual  | Notes                 |
-| ------------ | ------- | --------------------- |
-| **Plan 1**   | £26,900 | Confirmed             |
-| **Plan 2**   | £29,385 | Confirmed             |
-| **Plan 4**   | TBC     | Expected RPI increase |
-| **Plan 5**   | £25,000 | Confirmed             |
-| **Postgrad** | £21,000 | Unchanged             |
+| Plan             | Annual  | Notes                 |
+| ---------------- | ------- | --------------------- |
+| **Plan 1**       | £26,900 | Confirmed             |
+| **Plan 2**       | £29,385 | Confirmed             |
+| **Plan 4**       | TBC     | Expected RPI increase |
+| **Plan 5**       | £25,000 | Confirmed             |
+| **Postgraduate** | £21,000 | Unchanged             |
 
 ## Interest Rates (Sept 2025 - Aug 2026)
 
-| Plan         | Method                       | Current Rate |
-| ------------ | ---------------------------- | ------------ |
-| **Plan 1**   | Lower of RPI or BoE+1%       | 3.2%         |
-| **Plan 2**   | RPI to RPI+3% (income-based) | 3.2% - 6.2%  |
-| **Plan 4**   | Lower of RPI or BoE+1%       | 3.2%         |
-| **Plan 5**   | RPI only                     | 3.2%         |
-| **Postgrad** | RPI + 3%                     | 6.2%         |
+| Plan             | Method                        | Current Rate |
+| ---------------- | ----------------------------- | ------------ |
+| **Plan 1**       | Lower of RPI or BoE+1%        | 3.2%         |
+| **Plan 2**       | RPI to RPI+3% (sliding scale) | 3.2% - 6.2%  |
+| **Plan 4**       | Lower of RPI or BoE+1%        | 3.2%         |
+| **Plan 5**       | RPI only                      | 3.2%         |
+| **Postgraduate** | RPI + 3%                      | 6.2%         |
 
 ## Plan 2 Interest Sliding Scale (2025/26)
 
@@ -56,17 +56,17 @@ For detailed explanations, see [uk-student-loans-research.md](./uk-student-loans
 | **Plan 4** (pre-Aug 2007)  | Age 65 or 30 years |
 | **Plan 4** (Aug 2007+)     | 30 years           |
 | **Plan 5**                 | 40 years           |
-| **Postgrad**               | 30 years           |
+| **Postgraduate**           | 30 years           |
 
 ## Who's On Which Plan?
 
-| Plan         | Criteria                                          |
-| ------------ | ------------------------------------------------- |
-| **Plan 1**   | England/Wales pre-Sept 2012; ALL Northern Ireland |
-| **Plan 2**   | England Sept 2012 - July 2023; Wales Sept 2012+   |
-| **Plan 4**   | ALL Scotland                                      |
-| **Plan 5**   | England Aug 2023+ only                            |
-| **Postgrad** | Master's/Doctoral in England/Wales                |
+| Plan             | Criteria                                          |
+| ---------------- | ------------------------------------------------- |
+| **Plan 1**       | England/Wales pre-Sept 2012; ALL Northern Ireland |
+| **Plan 2**       | England Sept 2012 - July 2023; Wales Sept 2012+   |
+| **Plan 4**       | ALL Scotland                                      |
+| **Plan 5**       | England Aug 2023+ only                            |
+| **Postgraduate** | Master's/Doctoral in England/Wales                |
 
 ## Key Dates
 
@@ -118,12 +118,12 @@ Monthly threshold: £2,083
 Repayment: (£2,917 - £2,083) × 9% = £75.06/month
 ```
 
-**Example 3: Combined Plan 2 + Postgrad, £40,000 salary**
+**Example 3: Combined Plan 2 + Postgraduate, £40,000 salary**
 
 ```
 Monthly income: £3,333
 Plan 2: (£3,333 - £2,372) × 9% = £86.49
-Postgrad: (£3,333 - £1,750) × 6% = £94.98
+Postgraduate: (£3,333 - £1,750) × 6% = £94.98
 Total: £181.47/month
 ```
 

--- a/docs/uk-student-loans-research.md
+++ b/docs/uk-student-loans-research.md
@@ -97,7 +97,7 @@ You're on Plan 2 if:
 
 ### Interest Rate (Sliding Scale)
 
-Plan 2 uses an income-based sliding scale for interest after you finish studying.
+Plan 2 uses a sliding scale for interest after you finish studying.
 
 **While studying:** 6.2% (RPI + 3%)
 
@@ -283,13 +283,13 @@ If you have both undergraduate and postgraduate loans, you repay both simultaneo
 
 ### Interest Rates (Sept 2025 - Aug 2026)
 
-| Plan         | Method                       | Current Rate |
-| ------------ | ---------------------------- | ------------ |
-| Plan 1       | Lower of RPI or BoE+1%       | 3.2%         |
-| Plan 2       | RPI to RPI+3% (income-based) | 3.2% - 6.2%  |
-| Plan 4       | Lower of RPI or BoE+1%       | 3.2%         |
-| Plan 5       | RPI only                     | 3.2%         |
-| Postgraduate | RPI + 3%                     | 6.2%         |
+| Plan         | Method                        | Current Rate |
+| ------------ | ----------------------------- | ------------ |
+| Plan 1       | Lower of RPI or BoE+1%        | 3.2%         |
+| Plan 2       | RPI to RPI+3% (sliding scale) | 3.2% - 6.2%  |
+| Plan 4       | Lower of RPI or BoE+1%        | 3.2%         |
+| Plan 5       | RPI only                      | 3.2%         |
+| Postgraduate | RPI + 3%                      | 6.2%         |
 
 ### Write-Off Periods
 
@@ -390,7 +390,7 @@ Loans are automatically cancelled in these circumstances:
 
 - **Death:** SLC cancels upon receiving death certificate
 - **Permanent disability:** May be cancelled if claiming certain disability benefits (evidence required)
-- **Write-off period reached:** Automatic cancellation regardless of outstanding balance
+- **Write-off period reached:** The remaining balance is written off automatically
 
 ---
 

--- a/e2e/config-wizard.spec.ts
+++ b/e2e/config-wizard.spec.ts
@@ -18,7 +18,7 @@ test.describe("Config wizard dialog", () => {
     await expect(
       page.getByRole("dialog", { name: "Configure your loans" }),
     ).toBeVisible();
-    await expect(page.getByText("Customise your loans")).toBeVisible();
+    await expect(page.getByText("Tailor your loans")).toBeVisible();
   });
 
   test("toggle plan checkbox + enter balance → Done becomes enabled", async ({

--- a/e2e/preset-results.spec.ts
+++ b/e2e/preset-results.spec.ts
@@ -41,12 +41,12 @@ test.describe("Home page preset selection", () => {
     expect(after.totalText).not.toBe(before.totalText);
   });
 
-  test("clicking UG + Masters preset shows combined results", async ({
+  test("clicking Undergraduate + Masters preset shows combined results", async ({
     page,
   }) => {
     const before = await getResultValues(page);
 
-    await clickPreset(page, "UG + Masters");
+    await clickPreset(page, "Undergraduate + Masters");
     await waitForResultChange(page, before.totalText);
 
     const after = await getResultValues(page);

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -4,7 +4,7 @@
 
 ## Purpose
 
-UK student loans are often misunderstood. Middle earners typically repay the most - more than high earners (who pay off quickly) and low earners (who have debt written off). This site visualises this inequity and helps users understand their personal situation.
+UK student loans are often misunderstood. Middle earners typically repay the most - more than high earners (who pay off quickly) and low earners (who have their balance written off). This site visualises this inequity and helps users understand their personal situation.
 
 ## Tools
 
@@ -14,7 +14,7 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - [Total Repayments](https://studentloanstudy.uk/repaid): Track how much you'll repay on your student loan over time
 - [Payoff Timeline](https://studentloanstudy.uk/balance): See when you'll pay off your student loan and how your balance changes over time
 - [Interest Breakdown](https://studentloanstudy.uk/interest): Understand how much of your repayments go to interest vs principal
-- [Effective Rate](https://studentloanstudy.uk/effective-rate): Compare your loan's true effective annual rate to the Bank of England base rate
+- [Effective Rate](https://studentloanstudy.uk/effective-rate): Compare your loan's effective annual rate to the Bank of England base rate
 - [Our Data](https://studentloanstudy.uk/our-data): How we keep figures current — daily automation checks GOV.UK and the Bank of England
 
 ## Guides

--- a/scripts/check-govuk-figures/scrape-govuk.ts
+++ b/scripts/check-govuk-figures/scrape-govuk.ts
@@ -18,7 +18,7 @@ const PLAN_NAME_MAP: Record<string, string> = {
   postgraduate: "POSTGRADUATE",
 };
 
-function normalizePlanName(raw: string): string {
+function normalisePlanName(raw: string): string {
   const lower = raw.trim().toLowerCase();
   for (const [key, value] of Object.entries(PLAN_NAME_MAP)) {
     if (lower.includes(key)) return value;
@@ -93,7 +93,7 @@ async function scrapeThresholds(page: Page): Promise<{
         `Threshold row has unexpected cell count: ${cells.length}`,
       );
     }
-    const planName = normalizePlanName(cells[0]);
+    const planName = normalisePlanName(cells[0]);
     const yearlyThreshold = parseCurrency(cells[1]);
     const monthlyThreshold = parseCurrency(cells[2]);
     return {
@@ -107,16 +107,16 @@ async function scrapeThresholds(page: Page): Promise<{
     throw new Error(`Expected 5 threshold rows, got ${thresholds.length}`);
   }
 
-  // Find the second table — Plan 2 interest scale
+  // Find the second table — Plan 2 sliding scale
   const plan2Rows = await page.$$eval("table", (tables) => {
-    // The second table is the income-based interest table
+    // The second table is the sliding scale table
     const interestTables = tables.filter((t) => {
       const headerText =
         t.querySelector("thead, tr:first-child")?.textContent ?? "";
       return !headerText.toLowerCase().includes("plan type");
     });
     if (interestTables.length === 0) {
-      throw new Error("Could not find Plan 2 interest scale table");
+      throw new Error("Could not find Plan 2 sliding scale table");
     }
     const table = interestTables[0];
     const rows = Array.from(table.querySelectorAll("tbody tr"));
@@ -126,7 +126,7 @@ async function scrapeThresholds(page: Page): Promise<{
     });
   });
 
-  // Parse the interest scale thresholds from table rows
+  // Parse the sliding scale thresholds from table rows
   let lowerThreshold = 0;
   let upperThreshold = 0;
 
@@ -146,7 +146,7 @@ async function scrapeThresholds(page: Page): Promise<{
 
   if (lowerThreshold === 0 || upperThreshold === 0) {
     throw new Error(
-      `Could not extract Plan 2 interest scale thresholds. Lower: ${lowerThreshold}, Upper: ${upperThreshold}`,
+      `Could not extract Plan 2 sliding scale thresholds. Lower: ${lowerThreshold}, Upper: ${upperThreshold}`,
     );
   }
 
@@ -186,7 +186,7 @@ async function scrapeRepaymentRates(
 
 async function scrapeInterestRates(page: Page): Promise<ScrapedInterestRate[]> {
   // Interest rate list items follow patterns like "3.2% if you\u2019re on Plan 1"
-  // GOV.UK uses curly apostrophes (\u2019), so we normalize to straight quotes before matching
+  // GOV.UK uses curly apostrophes (\u2019), so we normalise to straight quotes before matching
   const listItems = await page.$$eval("li", (items) =>
     items
       .filter((li) => {

--- a/scripts/check-govuk-figures/templates.ts
+++ b/scripts/check-govuk-figures/templates.ts
@@ -215,7 +215,7 @@ export function generateLlmsTxt(scraped: ScrapedGovUkData): string {
 
 ## Purpose
 
-UK student loans are often misunderstood. Middle earners typically repay the most - more than high earners (who pay off quickly) and low earners (who have debt written off). This site visualises this inequity and helps users understand their personal situation.
+UK student loans are often misunderstood. Middle earners typically repay the most - more than high earners (who pay off quickly) and low earners (who have their balance written off). This site visualises this inequity and helps users understand their personal situation.
 
 ## Tools
 
@@ -225,7 +225,7 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - [Total Repayments](https://studentloanstudy.uk/repaid): Track how much you'll repay on your student loan over time
 - [Payoff Timeline](https://studentloanstudy.uk/balance): See when you'll pay off your student loan and how your balance changes over time
 - [Interest Breakdown](https://studentloanstudy.uk/interest): Understand how much of your repayments go to interest vs principal
-- [Effective Rate](https://studentloanstudy.uk/effective-rate): Compare your loan's true effective annual rate to the Bank of England base rate
+- [Effective Rate](https://studentloanstudy.uk/effective-rate): Compare your loan's effective annual rate to the Bank of England base rate
 - [Our Data](https://studentloanstudy.uk/our-data): How we keep figures current — daily automation checks GOV.UK and the Bank of England
 
 ## Guides

--- a/scripts/check-govuk-figures/update-files.ts
+++ b/scripts/check-govuk-figures/update-files.ts
@@ -128,7 +128,7 @@ function comparePlans(scraped: ScrapedGovUkData): Mismatch[] {
     }
   }
 
-  // Plan 2 interest scale
+  // Plan 2 sliding scale
   const plan2 = PLAN_CONFIGS.PLAN_2;
   if (
     plan2.interestLowerThreshold !== scraped.plan2InterestScale.lowerThreshold

--- a/scripts/generate-social-images.mjs
+++ b/scripts/generate-social-images.mjs
@@ -89,13 +89,13 @@ const socialSvg = `<svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH
   <!-- Subtle grid overlay - fades towards edges -->
   <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#grid)"/>
 
-  <!-- Abstract chart visualization in background (left side) -->
+  <!-- Abstract chart visualisation in background (left side) -->
   <g opacity="0.4">
     <path d="M0 ${HEIGHT} L0 480 Q100 420 200 450 T400 380 T600 300 L600 ${HEIGHT} Z" fill="url(#chartGradient)"/>
     <path d="M0 480 Q100 420 200 450 T400 380 T600 300" fill="none" stroke="${EMERALD_500}" stroke-width="1.5" opacity="0.3"/>
   </g>
 
-  <!-- Abstract chart visualization (right side, mirrored feel) -->
+  <!-- Abstract chart visualisation (right side, mirrored feel) -->
   <g opacity="0.3">
     <path d="M${WIDTH} ${HEIGHT} L${WIDTH} 500 Q1100 460 1000 420 T800 480 T600 520 L600 ${HEIGHT} Z" fill="url(#chartGradient)"/>
     <path d="M${WIDTH} 500 Q1100 460 1000 420 T800 480 T600 520" fill="none" stroke="${EMERALD_500}" stroke-width="1" opacity="0.25"/>

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -9,7 +9,7 @@ const faqSchema = {
       name: "Why do middle earners pay the most on UK student loans?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Middle earners often pay the most because high earners pay off their loans quickly (accumulating less interest), while low earners have their remaining debt written off after 25-40 years. Middle earners pay for decades, accumulating significant interest before write-off, often repaying more than the original loan amount.",
+        text: "Middle earners often pay the most because high earners pay off their loans quickly (accumulating less interest), while low earners have their remaining balance written off after 25-40 years. Middle earners pay for decades, accumulating significant interest before write-off, often repaying more than they borrowed.",
       },
     },
     {

--- a/src/app/effective-rate/layout.tsx
+++ b/src/app/effective-rate/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Effective Rate — True Cost of Your Student Loan",
+  title: "Effective Rate — What Your Student Loan Really Costs",
   description:
-    "Discover the true effective annual rate of your UK student loan and compare it to the Bank of England base rate. See how your rate changes with different salaries.",
+    "Discover the effective annual rate of your UK student loan and compare it to the Bank of England base rate. See how your rate changes with different salaries.",
   keywords: [
     "student loan effective rate",
-    "student loan true cost",
+    "cost of a UK student loan",
     "UK student loan interest rate comparison",
     "student loan vs base rate",
   ],
@@ -14,9 +14,9 @@ export const metadata: Metadata = {
     canonical: "/effective-rate",
   },
   openGraph: {
-    title: "Effective Rate — True Cost of Your Student Loan",
+    title: "Effective Rate — What Your Student Loan Really Costs",
     description:
-      "Discover the true effective annual rate of your UK student loan and compare it to the Bank of England base rate. See how your rate changes with different salaries.",
+      "Discover the effective annual rate of your UK student loan and compare it to the Bank of England base rate. See how your rate changes with different salaries.",
     url: "https://studentloanstudy.uk/effective-rate",
     type: "website",
   },
@@ -50,7 +50,7 @@ const faqSchema = {
       name: "What is the effective rate on a student loan?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "The effective rate is the true annualized cost of your student loan, calculated as an internal rate of return (IRR). Unlike the headline interest rate, it accounts for write-offs — if your loan is partially forgiven, your effective cost is lower than the stated interest rate.",
+        text: "The effective rate is the true annualised cost of your student loan, calculated as an internal rate of return (IRR). Unlike the headline interest rate, it accounts for write-offs — if your loan is partially written off, your effective cost is lower than the stated interest rate.",
       },
     },
     {

--- a/src/app/effective-rate/page.tsx
+++ b/src/app/effective-rate/page.tsx
@@ -14,10 +14,9 @@ export async function generateMetadata({
   const meta = parseMetadataParams(params);
 
   if (!meta.hasShareParams) {
-    const defaultTitle =
-      "Student Loan Effective Interest Rate — Your True Cost";
+    const defaultTitle = "Student Loan Effective Rate — What It Really Costs";
     const defaultDescription =
-      "See the true effective interest rate on your UK student loan versus the Bank of England base rate. Middle earners pay the most — they repay in full while low and high earners get more written off.";
+      "See the effective rate on your UK student loan versus the Bank of England base rate. Middle earners pay the most — high earners pay off quickly, while low earners have more written off.";
 
     return {
       title: defaultTitle,
@@ -33,7 +32,7 @@ export async function generateMetadata({
   }
 
   const title = `${meta.planName} loan of ${meta.formattedBalance} at ${meta.formattedSalary} — Effective Rate`;
-  const description = `See the true effective annual rate of a ${meta.planName} UK student loan with ${meta.formattedBalance} balance and ${meta.formattedSalary} annual salary.`;
+  const description = `See the effective annual rate of a ${meta.planName} UK student loan with ${meta.formattedBalance} balance and ${meta.formattedSalary} annual salary.`;
 
   return {
     title,

--- a/src/app/guides/interest-rate-cap/layout.tsx
+++ b/src/app/guides/interest-rate-cap/layout.tsx
@@ -78,7 +78,7 @@ const faqSchema = {
       name: "Does the 6% cap change my monthly student loan repayments?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "No. Monthly repayments are based on your income (9% of earnings above the threshold), not the interest rate. The cap only affects how fast your outstanding balance grows.",
+        text: "No. Monthly repayments are based on your income (9% of income above the threshold), not the interest rate. The cap only affects how fast your balance grows.",
       },
     },
   ],

--- a/src/app/guides/pay-upfront-or-take-loan/layout.tsx
+++ b/src/app/guides/pay-upfront-or-take-loan/layout.tsx
@@ -65,7 +65,7 @@ const faqSchema = {
       name: "Is it worth paying university fees upfront?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: `It depends on the graduate's earning trajectory, not just their starting salary. Low earners benefit from the loan being partially written off. Middle earners — those who earn enough to keep repaying for decades but not enough to clear the balance — often end up paying more than the upfront cost due to interest compounding. High earners clear the loan quickly and pay close to the upfront amount. Salary growth is the key factor: a £30k starting salary can reach £65k after 20 years at 4% annual growth, pushing many graduates into the middle-earner zone.`,
+        text: `It depends on the graduate's earning trajectory, not just their starting salary. Low earners benefit from the loan being partially written off. Middle earners — those who earn enough to keep repaying for decades but not enough to pay off the balance — often end up paying more than the upfront cost due to interest compounding. High earners pay off the loan quickly and pay close to the upfront amount. Salary growth is the key factor: a £30k starting salary can reach £65k after 20 years at 4% annual growth, pushing many graduates into the middle-earner zone.`,
       },
     },
     {
@@ -73,7 +73,7 @@ const faqSchema = {
       name: "Should parents pay tuition or let their child take a student loan?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: `It depends on future earnings. Plan 5 loans are written off after ${String(writeOffYears)} years, so low earners pay less than the upfront cost. However, salary growth means many graduates who start on moderate salaries end up in the middle-earner zone, where total repayments exceed the original ${tuitionFormatted} tuition cost. Paying upfront makes sense if the graduate expects moderate-to-high career earnings and the family can afford it without impacting financial security.`,
+        text: `It depends on future income. Plan 5 loans are written off after ${String(writeOffYears)} years, so low earners pay less than the upfront cost. However, salary growth means many graduates who start on moderate salaries end up in the middle-earner zone, where total repayments exceed the original ${tuitionFormatted} tuition cost. Paying upfront makes sense if the graduate expects a moderate-to-high career income and the family can afford it without impacting financial security.`,
       },
     },
     {

--- a/src/app/interest/layout.tsx
+++ b/src/app/interest/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Interest Paid — Student Loan Interest Breakdown",
   description:
-    "See a year-by-year breakdown of how your UK student loan repayments split between interest and principal. Understand whether you're reducing your balance — and how write-off affects the true cost.",
+    "See a year-by-year breakdown of how your UK student loan repayments split between interest and principal. Understand whether you're reducing your balance — and how write-off affects the overall cost.",
   keywords: [
     "student loan interest breakdown",
     "student loan interest vs principal",
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Interest Paid — Student Loan Interest Breakdown",
     description:
-      "See a year-by-year breakdown of how your UK student loan repayments split between interest and principal. Understand whether you're reducing your balance — and how write-off affects the true cost.",
+      "See a year-by-year breakdown of how your UK student loan repayments split between interest and principal. Understand whether you're reducing your balance — and how write-off affects the overall cost.",
     url: "https://studentloanstudy.uk/interest",
     type: "website",
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from "next";
 import { Archivo, Martian_Mono } from "next/font/google";
 import { AssumptionsWizardProvider } from "@/context/AssumptionsWizardContext";
 import { LoanProvider } from "@/context/LoanContext";
-import { PersonalizedResultsProvider } from "@/context/PersonalizedResultsContext";
+import { PersonalisedResultsProvider } from "@/context/PersonalisedResultsContext";
 import { ThemeProvider } from "@/context/ThemeContext";
 import { cn } from "@/lib/utils";
 import "./globals.css";
@@ -118,9 +118,9 @@ export default function RootLayout({
         <ThemeProvider>
           <LoanProvider>
             <AssumptionsWizardProvider>
-              <PersonalizedResultsProvider>
+              <PersonalisedResultsProvider>
                 {children}
-              </PersonalizedResultsProvider>
+              </PersonalisedResultsProvider>
             </AssumptionsWizardProvider>
           </LoanProvider>
         </ThemeProvider>

--- a/src/app/manifest.json
+++ b/src/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "UK Student Loan Study - Student Loan Repayment Calculator",
   "short_name": "UK Student Loan Study",
-  "description": "Interactive calculator to understand UK student loan repayment. Compare Plan 2 and Plan 5, visualize total repayments, and see effective interest rates based on your salary.",
+  "description": "Interactive calculator to understand UK student loan repayment. Compare Plan 2 and Plan 5, visualise total repayments, and see effective rates based on your salary.",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -28,8 +28,7 @@ const SUGGESTED_LINKS = [
   {
     href: "/overpay",
     title: "Overpay calculator",
-    description:
-      "Find out if paying extra towards your student loan is worth it.",
+    description: "Find out if overpaying your student loan is worth it.",
   },
   {
     href: "/which-plan",

--- a/src/app/overpay/layout.tsx
+++ b/src/app/overpay/layout.tsx
@@ -71,7 +71,7 @@ const faqSchema = {
       name: "How do I make an early repayment on my student loan?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "You can make voluntary overpayments at any time by logging into your Student Loans Company account and paying by debit card or bank transfer. There is no penalty for early repayment. Before overpaying, check whether your loan will be written off — if it will, overpaying means you pay more than you need to.",
+        text: "You can make overpayments at any time by logging into your Student Loans Company account and paying by debit card or bank transfer. There is no penalty for early repayment. Before overpaying, check whether your loan will be written off — if it will, overpaying means you pay more than you need to.",
       },
     },
   ],

--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -106,10 +106,11 @@ export default function PlansHubPage() {
           <p className="max-w-2xl text-muted-foreground">
             Whichever plan you are on, the total you repay follows the same
             shape. Low earners repay little and reach the write-off with a
-            balance forgiven. High earners clear the loan quickly, before much
-            interest builds. It is the middle &mdash; graduates earning enough
-            to make real repayments, but not enough to outrun the interest
-            &mdash; who repay the most, often far more than they borrowed.
+            balance written off. High earners pay off the loan quickly, before
+            much interest builds. It is the middle &mdash; graduates earning
+            enough to make real repayments, but not enough to outrun the
+            interest &mdash; who repay the most, often far more than they
+            borrowed.
           </p>
           <p className="max-w-2xl text-muted-foreground">
             That is the whole reason this site exists. Put your salary into the{" "}

--- a/src/app/repaid/layout.tsx
+++ b/src/app/repaid/layout.tsx
@@ -1,13 +1,13 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Total Repayments — Student Loan Total Cost Calculator",
+  title: "Total Repayments — Student Loan Repayment Calculator",
   description:
     "Find out how much you'll repay on your UK student loan in total. See cumulative repayments over time, monthly costs, and whether you'll pay more or less than you borrowed — based on your salary and plan type.",
   keywords: [
     "student loan total repayments",
     "how much will I repay student loan",
-    "student loan total cost calculator",
+    "how much does a student loan cost",
     "UK student loan repayment calculator",
     "student loan repayments over time",
     "student loan cumulative repayments",
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
     canonical: "/repaid",
   },
   openGraph: {
-    title: "Total Repayments — Student Loan Total Cost Calculator",
+    title: "Total Repayments — Student Loan Repayment Calculator",
     description:
       "Find out how much you'll repay on your UK student loan in total. See cumulative repayments over time, monthly costs, and whether you'll pay more or less than you borrowed — based on your salary and plan type.",
     url: "https://studentloanstudy.uk/repaid",
@@ -68,7 +68,7 @@ const faqSchema = {
       name: "How are total student loan repayments calculated?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "The calculator projects your repayments month by month, deducting 9% of income above the repayment threshold (6% for Postgraduate loans). It accumulates these payments over the full loan term to show your total cost, factoring in salary growth and comparing against the write-off date.",
+        text: "The calculator projects your repayments month by month, deducting 9% of income above the repayment threshold (6% for Postgraduate loans). It accumulates these repayments over the full loan term to show your total repayments, factoring in salary growth and comparing against the write-off date.",
       },
     },
   ],

--- a/src/components/charts/BalanceOverTimeChart.tsx
+++ b/src/components/charts/BalanceOverTimeChart.tsx
@@ -36,11 +36,11 @@ export function BalanceOverTimeChart() {
       xDataKey="month"
       xLabel="Time"
       xFormatter={formatYearFromMonth}
-      yLabel={showPresentValue ? "Balance (inflation-adjusted)" : "Balance"}
+      yLabel={showPresentValue ? "Balance (present value)" : "Balance"}
       yFormatter={(v) => currencyFormatter.format(v)}
       ariaLabel={
         showPresentValue
-          ? "Student loan repayment chart showing how long to pay off your loan. Inflation-adjusted balance decreases over time as you make repayments."
+          ? "Student loan repayment chart showing how long to pay off your loan. Present-value balance decreases over time as you make repayments."
           : "Student loan repayment chart showing how long to pay off your loan. Balance decreases over time as you make repayments."
       }
       chartConfig={chartConfig}

--- a/src/components/charts/TotalRepaymentChart.tsx
+++ b/src/components/charts/TotalRepaymentChart.tsx
@@ -54,13 +54,11 @@ export function TotalRepaymentChart() {
       data={data}
       xDataKey="salary"
       xFormatter={(v) => currencyFormatter.format(v)}
-      yLabel={
-        showPresentValue ? "Total repayment (inflation-adjusted)" : undefined
-      }
+      yLabel={showPresentValue ? "Total repayment (present value)" : undefined}
       yFormatter={(v) => currencyFormatter.format(v)}
       ariaLabel={
         showPresentValue
-          ? "UK student loan calculator results showing inflation-adjusted total repayment by salary. Middle earners pay the most, while lower earners benefit from loan write-off."
+          ? "UK student loan calculator results showing present-value total repayment by salary. Middle earners pay the most, while lower earners benefit from loan write-off."
           : "UK student loan calculator results showing total repayment by salary. Middle earners pay the most, while lower earners benefit from loan write-off."
       }
       chartConfig={chartConfig}

--- a/src/components/detail/BalanceDetailPage.tsx
+++ b/src/components/detail/BalanceDetailPage.tsx
@@ -45,7 +45,7 @@ export function BalanceDetailPage() {
 
   const legend: ChartLegendItem[] = result
     ? [
-        { label: "Outstanding balance", color: "var(--chart-1)" },
+        { label: "Balance", color: "var(--chart-1)" },
         ...(result.stats.peakBalanceMonth > 0
           ? [
               {

--- a/src/components/detail/EffectiveRateDetailPage.tsx
+++ b/src/components/detail/EffectiveRateDetailPage.tsx
@@ -36,7 +36,7 @@ export function EffectiveRateDetailPage() {
 
   return (
     <DetailPageShell
-      heading="True Cost of Your Loan"
+      heading="The Effective Rate of Your Loan"
       description="Compare your loan's effective annual rate to the Bank of England base rate across different salaries."
     >
       {salaryResult ? (
@@ -84,7 +84,7 @@ export function EffectiveRateDetailPage() {
 
           <p className="max-w-prose text-sm text-muted-foreground">
             The effective rate accounts for write-offs — lower earners pay less
-            because more of their debt is forgiven.
+            because more of their balance is written off.
           </p>
         </div>
       ) : (

--- a/src/components/detail/InterestDetailPage.tsx
+++ b/src/components/detail/InterestDetailPage.tsx
@@ -24,7 +24,7 @@ function getChartCaption(
   )?.year;
 
   if (!firstGreenYear) {
-    return "Your repayments never exceeded the monthly interest — the outstanding balance is cleared at write-off.";
+    return "Your repayments never exceeded the monthly interest — the remaining balance is written off.";
   }
   if (firstGreenYear === 1) {
     return "Your repayments covered the interest every year — you were always reducing your balance.";
@@ -88,7 +88,7 @@ export function InterestDetailPage() {
               <p>
                 You were charged{" "}
                 {currencyFormatter.format(result.stats.attributedInterestPaid)}{" "}
-                in interest. When the loan is written off, the cleared balance
+                in interest. When the loan is written off, the remaining balance
                 is treated as a final principal repayment, so the adjusted
                 figure above counts only what you repaid on top of your original
                 loan.

--- a/src/components/detail/OutcomeBadge.tsx
+++ b/src/components/detail/OutcomeBadge.tsx
@@ -13,7 +13,7 @@ interface OutcomeBadgeProps {
 /**
  * A flat Instrument status chip: a hairline-ruled pill with an engraved sans
  * label and a single tonal dot — the Principal data green for a positive outcome
- * (paid in full), the Interest clay for a caution (written off). No filled status
+ * (paid off), the Interest clay for a caution (written off). No filled status
  * backgrounds, no rounded
  * Ledger badge — the meaning rides on the dot and the word.
  */

--- a/src/components/detail/PayoffHeroStats.tsx
+++ b/src/components/detail/PayoffHeroStats.tsx
@@ -28,7 +28,7 @@ export function PayoffHeroStats({
   return (
     <MetricReadout columns={3} className="animate-timeline-enter">
       <MetricCell
-        label={writtenOff ? "Written off in" : "Cleared in"}
+        label={writtenOff ? "Written off in" : "Paid off in"}
         value={
           <>
             {payoffYears}
@@ -47,7 +47,7 @@ export function PayoffHeroStats({
               label: "Ahead of schedule",
               variant: "success",
             },
-            { when: true, label: "Paid in full", variant: "success" },
+            { when: true, label: "Paid off", variant: "success" },
           ]}
         />
       </MetricCell>
@@ -74,7 +74,7 @@ export function PayoffHeroStats({
 export function PayoffHeroStatsSkeleton() {
   return (
     <MetricReadout columns={3}>
-      <MetricCell label="Cleared in" loading tone="emphasis" />
+      <MetricCell label="Paid off in" loading tone="emphasis" />
       <MetricCell label="Peak balance" loading tone="cost" />
       <MetricCell label="Total repaid" loading />
     </MetricReadout>

--- a/src/components/detail/RepaidHeroStats.tsx
+++ b/src/components/detail/RepaidHeroStats.tsx
@@ -34,7 +34,7 @@ export function RepaidHeroStats({
       </MetricCell>
       <MetricCell label="Monthly repayment · start" value={monthlyRepayment} />
       <MetricCell
-        label={writtenOff ? "Written off in" : "Cleared in"}
+        label={writtenOff ? "Written off in" : "Paid off in"}
         value={
           <>
             {payoffYears}
@@ -52,7 +52,7 @@ export function RepaidHeroStats({
               label: "Ahead of schedule",
               variant: "success",
             },
-            { when: true, label: "Paid in full", variant: "success" },
+            { when: true, label: "Paid off", variant: "success" },
           ]}
         />
       </MetricCell>
@@ -65,7 +65,7 @@ export function RepaidHeroStatsSkeleton() {
     <MetricReadout columns={3}>
       <MetricCell label="Total repaid" loading tone="emphasis" />
       <MetricCell label="Monthly repayment · start" loading />
-      <MetricCell label="Cleared in" loading />
+      <MetricCell label="Paid off in" loading />
     </MetricReadout>
   );
 }

--- a/src/components/guides/RelatedGuides.tsx
+++ b/src/components/guides/RelatedGuides.tsx
@@ -43,8 +43,8 @@ const TOOLS: Partial<Record<string, ToolLink>> = {
   },
   "/effective-rate": {
     href: "/effective-rate",
-    title: "Effective interest rate",
-    description: "Your true rate vs the Bank of England base rate.",
+    title: "Effective rate",
+    description: "Your effective rate vs the Bank of England base rate.",
   },
   "/which-plan": {
     href: "/which-plan",

--- a/src/components/guides/how-interest-works/InterestGuide.tsx
+++ b/src/components/guides/how-interest-works/InterestGuide.tsx
@@ -150,7 +150,7 @@ export function InterestGuide() {
               Here are the interest rates in force across every plan for the{" "}
               {currentTaxYear} tax year, based on RPI of {formatPercent(rpi)}.
               Middle earners on Plan 2 feel this most: they sit on the sliding
-              scale, charged above RPI without earning enough to clear the
+              scale, charged above RPI without earning enough to pay off the
               balance before interest compounds.
             </p>
           </div>
@@ -187,7 +187,7 @@ export function InterestGuide() {
               <Link href="/overpay" className={guideLink}>
                 overpaying your loan
               </Link>{" "}
-              could reduce the total cost.
+              could reduce what you repay overall.
             </p>
           </div>
         </section>

--- a/src/components/guides/interest-rate-cap/InterestRateCapGuide.tsx
+++ b/src/components/guides/interest-rate-cap/InterestRateCapGuide.tsx
@@ -211,8 +211,9 @@ export function InterestRateCapGuide() {
                 <strong className="text-foreground">
                   Graduates who will repay in full
                 </strong>{" "}
-                &mdash; if your salary is high enough to clear the loan before
-                the 30-year write-off, lower interest means a lower total cost.
+                &mdash; if your salary is high enough to pay off the loan before
+                the 30-year write-off, lower interest means you repay less
+                overall.
               </li>
             </ul>
             <p>

--- a/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
+++ b/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
@@ -267,7 +267,7 @@ export function MovingAbroadGuide() {
                 If you fail to complete the overseas income assessment, SLC
                 doesn&rsquo;t simply stop collecting. Instead, they apply{" "}
                 <strong>fixed repayment amounts</strong> that are not based on
-                your actual earnings.
+                your actual income.
               </p>
               <ul className="mt-2 list-inside list-disc space-y-1 marker:text-signal">
                 <li>

--- a/src/components/guides/moving-abroad/overseas-data.ts
+++ b/src/components/guides/moving-abroad/overseas-data.ts
@@ -52,7 +52,7 @@ export type MovingAbroadFaq = {
 export const movingAbroadFaqs: MovingAbroadFaq[] = [
   {
     question: "Does your student loan get wiped if you move abroad?",
-    answer: `No. Moving abroad does not cancel your student loan or wipe the balance, and there is no rule that writes it off after three years overseas. Your loan is only cleared at the end of your plan's write-off period — typically 25, 30 or 40 years depending on your plan — and that clock keeps ticking wherever you live, whether or not you make repayments. Living abroad changes how much you repay, not whether the debt still exists.`,
+    answer: `No. Moving abroad does not cancel your student loan or wipe the balance, and there is no rule that writes it off after three years overseas. Your loan is only written off at the end of your plan's term — typically 25, 30 or 40 years depending on your plan — and that clock keeps ticking wherever you live, whether or not you make repayments. Living abroad changes how much you repay, not whether the balance still exists.`,
   },
   {
     question:

--- a/src/components/guides/pay-upfront-or-take-loan/PayUpfrontGuide.tsx
+++ b/src/components/guides/pay-upfront-or-take-loan/PayUpfrontGuide.tsx
@@ -62,8 +62,8 @@ export function PayUpfrontGuide() {
               Under Plan 5, tuition fee loans are written off{" "}
               <strong className="text-foreground">{writeOffYears} years</strong>{" "}
               after the graduate becomes eligible to repay. Repayments are 9% of
-              earnings above the {threshold} threshold, and interest is charged
-              at RPI only.
+              income above the {threshold} threshold, and interest is charged at
+              RPI only.
             </p>
             <p>
               The total you end up paying depends on your earning trajectory
@@ -80,14 +80,14 @@ export function PayUpfrontGuide() {
               <li>
                 <strong className="text-foreground">Middle earners</strong>{" "}
                 &mdash; this is the trap. You earn enough to keep repaying for
-                decades but not enough to clear the balance before interest
+                decades but not enough to pay off the balance before interest
                 compounds. Total repayments can exceed the upfront cost,
                 sometimes significantly. This is the group that ends up paying
                 the most.
               </li>
               <li>
                 <strong className="text-foreground">High earners</strong>{" "}
-                &mdash; clear the loan relatively quickly, so interest
+                &mdash; pay off the loan relatively quickly, so interest
                 doesn&rsquo;t compound much. Total cost is close to or slightly
                 above the upfront price, and you kept your capital in the
                 meantime.
@@ -143,7 +143,7 @@ export function PayUpfrontGuide() {
             </p>
             <ul className="list-disc space-y-1 pl-6">
               <li>
-                The graduate expects moderate-to-high earnings over their career
+                The graduate expects a moderate-to-high income over their career
                 (the middle-earner zone where total repayments exceed the
                 upfront cost)
               </li>
@@ -174,7 +174,7 @@ export function PayUpfrontGuide() {
                 will be partially written off, costing less than paying upfront
               </li>
               <li>
-                The graduate expects very high earnings &mdash; they clear the
+                The graduate expects a very high income &mdash; they pay off the
                 loan quickly and kept their capital invested in the meantime
               </li>
               <li>
@@ -182,8 +182,8 @@ export function PayUpfrontGuide() {
                 financial safety net
               </li>
               <li>
-                Repayments adjust automatically if earnings drop &mdash;
-                built-in insurance that paying upfront doesn&rsquo;t offer
+                Repayments adjust automatically if income drops &mdash; built-in
+                insurance that paying upfront doesn&rsquo;t offer
               </li>
             </ul>
           </div>

--- a/src/components/guides/plan-2-vs-plan-5/Plan2VsPlan5Guide.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/Plan2VsPlan5Guide.tsx
@@ -74,10 +74,10 @@ export function Plan2VsPlan5Guide() {
             Balance over time
           </Heading>
           <p className="text-pretty text-muted-foreground">
-            See how the outstanding balance changes month by month. Toggle
-            between salary levels to see how income affects the repayment
-            trajectory for each plan. The dashed markers show each plan&rsquo;s
-            write-off point &mdash; Plan 2 at 30 years, Plan 5 at 40 years.
+            See how the balance changes month by month. Toggle between salary
+            levels to see how income affects the repayment trajectory for each
+            plan. The dashed markers show each plan&rsquo;s write-off point
+            &mdash; Plan 2 at 30 years, Plan 5 at 40 years.
           </p>
           <ChartFrame
             caption={`Fig. 2 \u2014 Balance over time \u00b7 Plan 2 vs Plan 5`}
@@ -225,7 +225,7 @@ export function Plan2VsPlan5Guide() {
             <Link href="/" className={guideLink}>
               student loan calculator
             </Link>{" "}
-            to see the total cost under each plan.
+            to see the total repayments under each plan.
           </li>
         </KeyTakeaways>
 

--- a/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
+++ b/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
@@ -136,7 +136,7 @@ export function RpiVsCpiGuide() {
             Inflation comparison
           </Heading>
           <ChartFrame
-            caption={`Fig. 1 \u2014 Balance in real terms \u00b7 Plan 5, \u00a345,000`}
+            caption={`Fig. 1 \u2014 Balance (present value) \u00b7 Plan 5, \u00a345,000`}
             figure={`RPI ${formatPercent(rpi)}`}
             figureTone="cost"
             bodyClassName="h-85 sm:h-105"

--- a/src/components/guides/threshold-freeze/ThresholdFreezeGuide.tsx
+++ b/src/components/guides/threshold-freeze/ThresholdFreezeGuide.tsx
@@ -241,7 +241,7 @@ export function ThresholdFreezeGuide() {
           </Heading>
           <div className="space-y-2 text-muted-foreground">
             <p>
-              These are the salary thresholds that apply for the{" "}
+              These are the repayment thresholds that apply for the{" "}
               {currentTaxYear} tax year. Undergraduate borrowers repay{" "}
               {String(REPAYMENT_RATE * 100)}% of everything they earn above
               their plan&apos;s threshold &mdash; which is exactly why the
@@ -300,7 +300,7 @@ export function ThresholdFreezeGuide() {
               </Link>{" "}
               and how the freeze pushes up{" "}
               <Link href="/effective-rate" className={guideLink}>
-                the effective interest rate you pay
+                the effective rate you pay
               </Link>
               .
             </p>

--- a/src/components/home/ConfigOverlay.tsx
+++ b/src/components/home/ConfigOverlay.tsx
@@ -6,7 +6,7 @@ import type { InputMode } from "@/hooks/useInputPanelMode";
 
 interface ConfigOverlayProps {
   mode: InputMode;
-  hasPersonalized: boolean;
+  hasPersonalised: boolean;
   onComplete: () => void;
   onClose: () => void;
 }
@@ -14,7 +14,7 @@ interface ConfigOverlayProps {
 /** Full-screen modal dialog wrapping the loan-config panel. */
 export function ConfigOverlay({
   mode,
-  hasPersonalized,
+  hasPersonalised,
   onComplete,
   onClose,
 }: ConfigOverlayProps) {
@@ -27,7 +27,7 @@ export function ConfigOverlay({
       className="flex min-h-dvh flex-col overflow-y-auto bg-background"
     >
       <LoanConfigPanel
-        isEditing={hasPersonalized}
+        isEditing={hasPersonalised}
         initialPlanTypes={mode.initialPlanTypes}
         onComplete={onComplete}
         onClose={onClose}

--- a/src/components/home/LoanConfigPanel.tsx
+++ b/src/components/home/LoanConfigPanel.tsx
@@ -298,7 +298,7 @@ export function LoanConfigPanel({
     <div className="flex min-h-dvh flex-col bg-background">
       <header className="sticky top-0 z-10 border-b border-border bg-background/80 backdrop-blur-sm">
         <div className="mx-auto flex max-w-3xl items-center justify-between px-4 py-3">
-          <h2 className="text-lg font-semibold">Customise your loans</h2>
+          <h2 className="text-lg font-semibold">Tailor your loans</h2>
           <div className="flex items-center gap-2">
             {localLoans.length > 0 && (
               <button

--- a/src/components/home/instrument/ChartInsight.tsx
+++ b/src/components/home/instrument/ChartInsight.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { usePersonalizedResults } from "@/context/PersonalizedResultsContext";
+import { usePersonalisedResults } from "@/context/PersonalisedResultsContext";
 import type { Insight } from "@/utils/insights";
 
 // The peak/costly zone reads brick (the one cost signal); the "written off" and
@@ -20,7 +20,7 @@ const COST_ZONES = new Set<Insight["type"]>(["middle-earner"]);
  * and stays aligned under the title instead of orphaning against the right edge.
  */
 export function ChartInsight() {
-  const { insight } = usePersonalizedResults();
+  const { insight } = usePersonalisedResults();
 
   if (!insight) return null;
 

--- a/src/components/home/instrument/Controls.tsx
+++ b/src/components/home/instrument/Controls.tsx
@@ -117,7 +117,7 @@ function SalarySlider() {
 interface PresetsProps {
   onPresetApplied: (preset: Preset) => void;
   onPersonalise: () => void;
-  hasPersonalized: boolean;
+  hasPersonalised: boolean;
 }
 
 type ScenFade = "none" | "left" | "right" | "both";
@@ -143,7 +143,7 @@ const SCEN_CHIP =
   "group flex flex-[0_0_auto] flex-col gap-[0.15rem] min-w-[8.5rem] [scroll-snap-align:start] leading-[1.2] text-left border border-border rounded-[9px] px-[0.7rem] py-[0.5rem] bg-card text-muted-foreground [transition:border-color_0.15s,background_0.15s,color_0.15s] [&:not([aria-pressed=true]):hover]:border-muted-foreground @cozy:min-w-0 work:min-w-0 aria-pressed:border-primary aria-pressed:bg-accent-wash";
 
 // "Tailor to you" is a different *kind* of action than the preset chips — an
-// escape hatch into customisation rather than a mutually-exclusive quick-pick.
+// escape hatch into personalisation rather than a mutually-exclusive quick-pick.
 // A dashed primary outline + icon marks it as distinct; it flips to a solid
 // selected treatment (matching the presets) once the config is personalised.
 const TAILOR_CHIP =
@@ -156,21 +156,23 @@ const TAILOR_CHIP =
 function TailorButton({
   variant,
   className,
-  isCustomConfig,
+  isPersonalisedConfig,
   onPersonalise,
 }: {
   variant: "grid" | "bar";
   className: string;
-  isCustomConfig: boolean;
+  isPersonalisedConfig: boolean;
   onPersonalise: () => void;
 }) {
-  const label = isCustomConfig ? "Edit details" : "Tailor to you";
-  const description = isCustomConfig ? "Your configuration" : "Your details";
+  const label = isPersonalisedConfig ? "Edit details" : "Tailor to you";
+  const description = isPersonalisedConfig
+    ? "Your configuration"
+    : "Your details";
   return (
     <button
       className={`${TAILOR_CHIP} ${className}`}
       type="button"
-      aria-pressed={isCustomConfig}
+      aria-pressed={isPersonalisedConfig}
       onClick={onPersonalise}
     >
       {variant === "grid" ? (
@@ -209,13 +211,13 @@ function TailorButton({
 function Presets({
   onPresetApplied,
   onPersonalise,
-  hasPersonalized,
+  hasPersonalised,
 }: PresetsProps) {
   const activePreset = useActivePreset();
   const [optimisticActiveId, setOptimisticActiveId] = useOptimistic(
     activePreset?.id ?? null,
   );
-  const isCustomConfig = hasPersonalized && !optimisticActiveId;
+  const isPersonalisedConfig = hasPersonalised && !optimisticActiveId;
 
   // Drive the horizontal-scroll edge fade from the live scroll position so it
   // only shows on a side that actually has more chips (was a static right fade).
@@ -277,7 +279,7 @@ function Presets({
         <TailorButton
           variant="grid"
           className="hidden flex-col gap-[0.15rem] work:col-span-full work:flex @cozy:col-span-full @cozy:flex @snug:col-auto"
-          isCustomConfig={isCustomConfig}
+          isPersonalisedConfig={isPersonalisedConfig}
           onPersonalise={onPersonalise}
         />
       </div>
@@ -287,7 +289,7 @@ function Presets({
       <TailorButton
         variant="bar"
         className="mt-2 flex w-full items-center gap-2 work:hidden @cozy:hidden"
-        isCustomConfig={isCustomConfig}
+        isPersonalisedConfig={isPersonalisedConfig}
         onPersonalise={onPersonalise}
       />
     </div>
@@ -300,7 +302,7 @@ function Presets({
 
 interface ControlsProps {
   mode: InputMode;
-  hasPersonalized: boolean;
+  hasPersonalised: boolean;
   handlePersonalise: () => void;
   handlePresetApplied: (preset: Preset) => void;
   handleWizardComplete: () => void;
@@ -309,7 +311,7 @@ interface ControlsProps {
 
 export function Controls({
   mode,
-  hasPersonalized,
+  hasPersonalised,
   handlePersonalise,
   handlePresetApplied,
   handleWizardComplete,
@@ -322,12 +324,12 @@ export function Controls({
         <Presets
           onPresetApplied={handlePresetApplied}
           onPersonalise={handlePersonalise}
-          hasPersonalized={hasPersonalized}
+          hasPersonalised={hasPersonalised}
         />
       </div>
       <ConfigOverlay
         mode={mode}
-        hasPersonalized={hasPersonalized}
+        hasPersonalised={hasPersonalised}
         onComplete={handleWizardComplete}
         onClose={handleWizardClose}
       />

--- a/src/components/home/instrument/Fold.tsx
+++ b/src/components/home/instrument/Fold.tsx
@@ -11,7 +11,7 @@ import { Readout } from "./Readout";
 export function Fold({ initialMode }: { initialMode?: InputMode }) {
   const {
     mode,
-    hasPersonalized,
+    hasPersonalised,
     handlePersonalise,
     handlePresetApplied,
     handleWizardComplete,
@@ -29,7 +29,7 @@ export function Fold({ initialMode }: { initialMode?: InputMode }) {
         <Readout onTailor={handlePersonalise} />
         <Controls
           mode={mode}
-          hasPersonalized={hasPersonalized}
+          hasPersonalised={hasPersonalised}
           handlePersonalise={handlePersonalise}
           handlePresetApplied={handlePresetApplied}
           handleWizardComplete={handleWizardComplete}

--- a/src/components/home/instrument/Readout.tsx
+++ b/src/components/home/instrument/Readout.tsx
@@ -4,7 +4,7 @@ import { Sparkline } from "@/components/charts/Sparkline";
 import { MetricCell } from "@/components/instrument/MetricReadout";
 import { Figure } from "@/components/typography/Figure";
 import { percentageFormatter } from "@/constants";
-import { usePersonalizedResults } from "@/context/PersonalizedResultsContext";
+import { usePersonalisedResults } from "@/context/PersonalisedResultsContext";
 import {
   useCurrentSalary,
   useLoanConfig,
@@ -80,7 +80,7 @@ function RateVizSkeleton() {
 }
 
 export function Readout({ onTailor }: { onTailor: () => void }) {
-  const { cards, summary } = usePersonalizedResults();
+  const { cards, summary } = usePersonalisedResults();
   const salary = useCurrentSalary();
   const { loans, underGradBalance, postGradBalance } = useLoanConfig();
   const salaryGrowthRate = useSalaryGrowthRate();

--- a/src/components/home/instrument/RulesSection.tsx
+++ b/src/components/home/instrument/RulesSection.tsx
@@ -60,11 +60,11 @@ export function RulesSection() {
             03
           </span>
           <h3 className="col-start-2 mb-[0.35rem] text-lead font-semibold tracking-[-0.011em]">
-            The balance clears at {PLAN2_WRITEOFF} years
+            The balance is written off at {PLAN2_WRITEOFF} years
           </h3>
           <p className="col-start-2 text-body leading-[1.55] text-pretty text-muted-foreground">
             Anything unpaid {PLAN2_WRITEOFF} years after you were first due to
-            repay is cancelled. On a middle income, reaching that point is the
+            repay is written off. On a middle income, reaching that point is the
             norm, not the exception.
           </p>
           <span className="col-start-2 mt-[0.55rem] font-sans text-meta text-muted-foreground">

--- a/src/components/home/instrument/ToolsSection.tsx
+++ b/src/components/home/instrument/ToolsSection.tsx
@@ -18,7 +18,7 @@ const TOOLS: ToolLink[] = [
     title: "Overpayment calculator",
     href: "/overpay",
     description:
-      "Test whether paying extra actually saves you money on your plan.",
+      "Test whether overpaying actually saves you money on your plan.",
   },
   {
     title: "Compare plans",

--- a/src/components/home/instrument/leverData.ts
+++ b/src/components/home/instrument/leverData.ts
@@ -108,10 +108,10 @@ export function useLeverData(): LeverData {
       name: `Overpay ${formatGBP(MONTHLY_OVERPAY)} a month`,
       description:
         overpayDelta === 0
-          ? `For this case, overpaying ${formatGBP(MONTHLY_OVERPAY)} a month wouldn't change your lifetime total.`
+          ? `For this case, overpaying ${formatGBP(MONTHLY_OVERPAY)} a month wouldn't change the total you repay.`
           : yearsEarly > 0
-            ? `Voluntary payments clear the balance about ${String(yearsEarly)} year${yearsEarly === 1 ? "" : "s"} early and cut off the interest that would otherwise keep rolling up.`
-            : `Voluntary payments chip the balance down faster and cut off interest before it compounds further.`,
+            ? `Overpayments pay off the balance about ${String(yearsEarly)} year${yearsEarly === 1 ? "" : "s"} early and cut off the interest that would otherwise keep rolling up.`
+            : `Overpayments chip the balance down faster and cut off interest before it compounds further.`,
       delta: deltaText(overpayDelta),
       direction: dir(overpayDelta),
       barPct: barPct(overpayDelta),
@@ -122,10 +122,10 @@ export function useLeverData(): LeverData {
       name: `Earn ${formatGBP(RAISE)} more a year`,
       description:
         raiseDelta === 0
-          ? `For this case, earning ${formatGBP(RAISE)} more a year wouldn't change your lifetime total.`
+          ? `For this case, earning ${formatGBP(RAISE)} more a year wouldn't change the total you repay.`
           : raiseDelta < 0
-            ? `A higher salary clears the loan before the write-off, so you pay less overall — not more.`
-            : `A higher salary means larger repayments in the years before write-off, so the lifetime total rises.`,
+            ? `A higher salary pays off the loan before the write-off, so you pay less overall — not more.`
+            : `A higher salary means larger repayments in the years before write-off, so the total you repay rises.`,
       delta: deltaText(raiseDelta),
       direction: dir(raiseDelta),
       barPct: barPct(raiseDelta),
@@ -134,7 +134,7 @@ export function useLeverData(): LeverData {
       name: "Take a one-year career break",
       description:
         careerDelta === 0
-          ? `For this case, a one-year career break wouldn't change your lifetime total.`
+          ? `For this case, a one-year career break wouldn't change the total you repay.`
           : careerDelta > 0
             ? `A year at little or no income pauses repayments, so more interest rolls into the years that follow — nudging the total up.`
             : `A year at little or no income pauses repayments; with the balance written off anyway, you simply repay less over the term.`,

--- a/src/components/home/instrument/planInfo.ts
+++ b/src/components/home/instrument/planInfo.ts
@@ -6,7 +6,7 @@ import type { Loan } from "@/lib/loans/types";
 
 /**
  * Display name for the active configuration's primary plan — the first
- * non-postgraduate loan, falling back to Postgraduate if every loan is a PGL.
+ * non-Postgraduate loan, falling back to Postgraduate if all loans are Postgraduate.
  */
 export function primaryPlanName(loans: Loan[]): string {
   for (const loan of loans) {

--- a/src/components/our-data/OurDataPage.tsx
+++ b/src/components/our-data/OurDataPage.tsx
@@ -124,7 +124,7 @@ const CROSS_CHECK_LINKS = [
   {
     source: "GOV.UK",
     label: "Write-off periods",
-    description: "When your loan gets cancelled",
+    description: "When your loan gets written off",
     href: "https://www.gov.uk/repaying-your-student-loan/when-your-student-loan-gets-written-off-or-cancelled",
   },
   {

--- a/src/components/overpay/OverpayComparisonChart.tsx
+++ b/src/components/overpay/OverpayComparisonChart.tsx
@@ -76,11 +76,11 @@ export function OverpayComparisonChart({
         xDataKey="month"
         xLabel="Time"
         xFormatter={formatYear}
-        yLabel={showPresentValue ? "Balance (inflation-adjusted)" : "Balance"}
+        yLabel={showPresentValue ? "Balance (present value)" : "Balance"}
         yFormatter={(v) => currencyFormatter.format(v)}
         ariaLabel={
           showPresentValue
-            ? "Student loan overpayment calculator chart comparing inflation-adjusted balance with and without overpaying over time"
+            ? "Student loan overpayment calculator chart comparing present-value balance with and without overpaying over time"
             : "Student loan overpayment calculator chart comparing balance with and without overpaying over time"
         }
         chartConfig={chartConfig}

--- a/src/components/plans/PlanDetailPage.tsx
+++ b/src/components/plans/PlanDetailPage.tsx
@@ -214,7 +214,7 @@ export function PlanDetailPage({ planKey }: PlanDetailPageProps) {
           <p className="max-w-2xl text-muted-foreground">{plan.middleEarner}</p>
           <p className="max-w-2xl text-muted-foreground">
             Middle earners repay the most across every UK plan &mdash; enough to
-            make real repayments, but not enough to clear the balance before
+            make real repayments, but not enough to pay off the balance before
             interest bites. Put your own salary into the{" "}
             <Link href="/" className={PROSE_LINK}>
               student loan repayment calculator

--- a/src/components/seo/JsonLd.tsx
+++ b/src/components/seo/JsonLd.tsx
@@ -12,7 +12,7 @@ export type JsonLdObject = { readonly [key: string]: JsonLdValue };
  * `<script type="application/ld+json">` tag for search engines.
  *
  * `<` is escaped to `<` per the Next.js JSON-LD guidance so that a stray
- * `</script>` sequence inside serialized content cannot break out of the tag.
+ * `</script>` sequence inside serialised content cannot break out of the tag.
  */
 export function JsonLd({ data }: { data: JsonLdObject }) {
   return (

--- a/src/components/shared/AssumptionsCallout.test.tsx
+++ b/src/components/shared/AssumptionsCallout.test.tsx
@@ -50,7 +50,7 @@ describe("AssumptionsCallout", () => {
     expect(mockOpenAssumptions).toHaveBeenCalledOnce();
   });
 
-  it("shows BOE base rate when Plan 1 is active", () => {
+  it("shows BoE base rate when Plan 1 is active", () => {
     render(<AssumptionsCallout />, {
       wrapper: ({ children }: { children: ReactNode }) => (
         <LoanProvider
@@ -100,7 +100,7 @@ describe("AssumptionsCallout", () => {
     expect(screen.queryByText(/inflation/)).toBeNull();
   });
 
-  it("hides BOE base rate when only Plan 2 is active", () => {
+  it("hides BoE base rate when only Plan 2 is active", () => {
     render(<AssumptionsCallout />, {
       wrapper: ({ children }: { children: ReactNode }) => (
         <LoanProvider

--- a/src/components/shared/ControlBar.tsx
+++ b/src/components/shared/ControlBar.tsx
@@ -102,13 +102,13 @@ function SalarySlider() {
 interface ExpandedPresetsProps {
   onPresetApplied: (preset: Preset) => void;
   onPersonalise: () => void;
-  hasPersonalized: boolean;
+  hasPersonalised: boolean;
 }
 
 function ExpandedPresets({
   onPresetApplied,
   onPersonalise,
-  hasPersonalized,
+  hasPersonalised,
 }: ExpandedPresetsProps) {
   const activePreset = useActivePreset();
 
@@ -116,7 +116,7 @@ function ExpandedPresets({
     activePreset?.id ?? null,
   );
 
-  const isCustomConfig = hasPersonalized && !optimisticActiveId;
+  const isPersonalisedConfig = hasPersonalised && !optimisticActiveId;
 
   return (
     <div className="space-y-2">
@@ -181,7 +181,7 @@ function ExpandedPresets({
               "shrink-0 rounded-lg border px-3 py-2 text-left transition-colors",
               "w-40 sm:w-auto",
               "hidden sm:block",
-              isCustomConfig
+              isPersonalisedConfig
                 ? "border-primary bg-accent-wash"
                 : "border-dashed border-primary/40 hover:border-primary hover:bg-primary/5",
             )}
@@ -191,10 +191,10 @@ function ExpandedPresets({
                 icon={PreferenceHorizontalIcon}
                 className="size-4"
               />
-              {isCustomConfig ? "Edit configuration" : "Tailor to you"}
+              {isPersonalisedConfig ? "Edit details" : "Tailor to you"}
             </span>
             <span className="block text-xs text-muted-foreground">
-              {isCustomConfig
+              {isPersonalisedConfig
                 ? "Change your loan details"
                 : "Enter your exact details"}
             </span>
@@ -208,7 +208,7 @@ function ExpandedPresets({
         onClick={onPersonalise}
         className={cn(
           "flex w-full items-center gap-2 rounded-lg border px-3 py-2 text-left transition-colors sm:hidden",
-          isCustomConfig
+          isPersonalisedConfig
             ? "border-primary bg-accent-wash"
             : "border-dashed border-primary/40 hover:border-primary hover:bg-primary/5",
         )}
@@ -219,10 +219,10 @@ function ExpandedPresets({
         />
         <span>
           <span className="text-sm font-medium text-primary">
-            {isCustomConfig ? "Edit configuration" : "Tailor to you"}
+            {isPersonalisedConfig ? "Edit details" : "Tailor to you"}
           </span>
           <span className="ml-2 text-xs text-muted-foreground">
-            {isCustomConfig
+            {isPersonalisedConfig
               ? "Change your loan details"
               : "Enter your exact details"}
           </span>
@@ -243,7 +243,7 @@ interface ControlBarProps {
 export function ControlBar({ initialMode }: ControlBarProps) {
   const {
     mode,
-    hasPersonalized,
+    hasPersonalised,
     handlePersonalise,
     handlePresetApplied,
     handleWizardComplete,
@@ -252,18 +252,18 @@ export function ControlBar({ initialMode }: ControlBarProps) {
 
   return (
     <section
-      aria-label="Calculator settings"
+      aria-label="Calculator controls"
       className={cn(surfaceCard, "space-y-3 p-3 sm:p-4")}
     >
       <SalarySlider />
       <ExpandedPresets
         onPresetApplied={handlePresetApplied}
         onPersonalise={handlePersonalise}
-        hasPersonalized={hasPersonalized}
+        hasPersonalised={hasPersonalised}
       />
       <ConfigOverlay
         mode={mode}
-        hasPersonalized={hasPersonalized}
+        hasPersonalised={hasPersonalised}
         onComplete={handleWizardComplete}
         onClose={handleWizardClose}
       />

--- a/src/components/shared/InsightCards.tsx
+++ b/src/components/shared/InsightCards.tsx
@@ -8,7 +8,7 @@ import {
   MetricReadout,
 } from "@/components/instrument/MetricReadout";
 import { Heading } from "@/components/typography/Heading";
-import { usePersonalizedResults } from "@/context/PersonalizedResultsContext";
+import { usePersonalisedResults } from "@/context/PersonalisedResultsContext";
 import { DETAIL_PAGES } from "@/lib/detailPages";
 import {
   ProportionViz,
@@ -26,7 +26,7 @@ interface InsightCardsProps {
 const [REPAID, BALANCE, INTEREST, RATE] = DETAIL_PAGES;
 
 export function InsightCards({ excludeHref }: InsightCardsProps) {
-  const { cards: data } = usePersonalizedResults();
+  const { cards: data } = usePersonalisedResults();
 
   const loading = data == null;
 

--- a/src/components/wizard/AssumptionsWizard.tsx
+++ b/src/components/wizard/AssumptionsWizard.tsx
@@ -20,7 +20,7 @@ import {
 } from "./wizardReducer";
 import type { AssumptionsWizardStep } from "./wizardReducer";
 
-/** BOE base rate only affects Plan 1 & Plan 4 interest */
+/** BoE base rate only affects Plan 1 & Plan 4 interest */
 const BOE_RELEVANT_PLANS = new Set(["PLAN_1", "PLAN_4"]);
 
 interface AssumptionsWizardProps {

--- a/src/components/wizard/LivePreview.tsx
+++ b/src/components/wizard/LivePreview.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { currencyFormatter } from "@/constants";
-import { usePersonalizedResults } from "@/context/PersonalizedResultsContext";
+import { usePersonalisedResults } from "@/context/PersonalisedResultsContext";
 import { useShowPresentValue } from "@/hooks/useStoreSelectors";
 
 export function LivePreview() {
-  const { summary } = usePersonalizedResults();
+  const { summary } = usePersonalisedResults();
   const showPresentValue = useShowPresentValue();
 
   if (!summary) return null;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -70,7 +70,7 @@ export const RPI_OPTIONS: RateOption[] = [
   { value: 5, label: "5%", description: "Prices rising fast" },
 ];
 
-/** BOE base rate options for the assumptions wizard (percentage format, e.g. 3.75 = 3.75%).
+/** BoE base rate options for the assumptions wizard (percentage format, e.g. 3.75 = 3.75%).
  *  The "current rate" option derives from CURRENT_RATES so it stays in sync
  *  with the daily GOV.UK automation.
  */

--- a/src/context/PersonalisedResultsContext.test.tsx
+++ b/src/context/PersonalisedResultsContext.test.tsx
@@ -5,9 +5,9 @@ import { MIN_SALARY } from "@/constants";
 import type { LoanState } from "@/types/store";
 import { LoanProvider } from "./LoanContext";
 import {
-  PersonalizedResultsProvider,
-  usePersonalizedResults,
-} from "./PersonalizedResultsContext";
+  PersonalisedResultsProvider,
+  usePersonalisedResults,
+} from "./PersonalisedResultsContext";
 
 const defaultTestConfig: Partial<LoanState> = {
   loans: [{ planType: "PLAN_2", balance: 50_000 }],
@@ -19,13 +19,13 @@ function createWrapper(overrides?: Partial<LoanState>) {
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
       <LoanProvider initialStateOverride={mergedConfig}>
-        <PersonalizedResultsProvider>{children}</PersonalizedResultsProvider>
+        <PersonalisedResultsProvider>{children}</PersonalisedResultsProvider>
       </LoanProvider>
     );
   };
 }
 
-describe("usePersonalizedResults (summary + insight)", () => {
+describe("usePersonalisedResults (summary + insight)", () => {
   beforeEach(() => {
     vi.setSystemTime(new Date("2024-01-15"));
     localStorage.clear();
@@ -36,7 +36,7 @@ describe("usePersonalizedResults (summary + insight)", () => {
   });
 
   it("returns null initially before worker responds", () => {
-    const { result } = renderHook(() => usePersonalizedResults(), {
+    const { result } = renderHook(() => usePersonalisedResults(), {
       wrapper: createWrapper(),
     });
 
@@ -44,7 +44,7 @@ describe("usePersonalizedResults (summary + insight)", () => {
   });
 
   it("returns summary with totalPaid, monthlyRepayment, and monthsToPayoff", async () => {
-    const { result } = renderHook(() => usePersonalizedResults(), {
+    const { result } = renderHook(() => usePersonalisedResults(), {
       wrapper: createWrapper(),
     });
 
@@ -58,7 +58,7 @@ describe("usePersonalizedResults (summary + insight)", () => {
   });
 
   it("returns positive totalPaid for active loans", async () => {
-    const { result } = renderHook(() => usePersonalizedResults(), {
+    const { result } = renderHook(() => usePersonalisedResults(), {
       wrapper: createWrapper(),
     });
 
@@ -69,7 +69,7 @@ describe("usePersonalizedResults (summary + insight)", () => {
   });
 
   it("returns positive monthlyRepayment when salary exceeds threshold", async () => {
-    const { result } = renderHook(() => usePersonalizedResults(), {
+    const { result } = renderHook(() => usePersonalisedResults(), {
       wrapper: createWrapper({ salary: 45_000 }),
     });
 
@@ -80,7 +80,7 @@ describe("usePersonalizedResults (summary + insight)", () => {
   });
 
   it("returns positive monthsToPayoff for active loans", async () => {
-    const { result } = renderHook(() => usePersonalizedResults(), {
+    const { result } = renderHook(() => usePersonalisedResults(), {
       wrapper: createWrapper(),
     });
 
@@ -91,7 +91,7 @@ describe("usePersonalizedResults (summary + insight)", () => {
   });
 
   it("returns null summary when no loans have balance", async () => {
-    const { result } = renderHook(() => usePersonalizedResults(), {
+    const { result } = renderHook(() => usePersonalisedResults(), {
       wrapper: createWrapper({ loans: [] }),
     });
 
@@ -103,14 +103,14 @@ describe("usePersonalizedResults (summary + insight)", () => {
 
   it("returns higher monthlyRepayment for higher salary", async () => {
     const { result: lowSalaryResult } = renderHook(
-      () => usePersonalizedResults(),
+      () => usePersonalisedResults(),
       {
         wrapper: createWrapper({ salary: 35_000 }),
       },
     );
 
     const { result: highSalaryResult } = renderHook(
-      () => usePersonalizedResults(),
+      () => usePersonalisedResults(),
       {
         wrapper: createWrapper({ salary: 80_000 }),
       },
@@ -132,7 +132,7 @@ describe("usePersonalizedResults (summary + insight)", () => {
   });
 
   it("returns zero monthlyRepayment for salary below threshold", async () => {
-    const { result } = renderHook(() => usePersonalizedResults(), {
+    const { result } = renderHook(() => usePersonalisedResults(), {
       wrapper: createWrapper({ salary: MIN_SALARY }),
     });
 
@@ -142,9 +142,9 @@ describe("usePersonalizedResults (summary + insight)", () => {
     });
   });
 
-  it("includes postgrad loan in summary when present", async () => {
+  it("includes Postgraduate loan in summary when present", async () => {
     const { result: undergradOnly } = renderHook(
-      () => usePersonalizedResults(),
+      () => usePersonalisedResults(),
       {
         wrapper: createWrapper({
           loans: [{ planType: "PLAN_2", balance: 50_000 }],
@@ -154,7 +154,7 @@ describe("usePersonalizedResults (summary + insight)", () => {
     );
 
     const { result: withPostgrad } = renderHook(
-      () => usePersonalizedResults(),
+      () => usePersonalisedResults(),
       {
         wrapper: createWrapper({
           loans: [
@@ -171,7 +171,7 @@ describe("usePersonalizedResults (summary + insight)", () => {
       expect(withPostgrad.current.summary).not.toBeNull();
     });
 
-    // Adding a postgrad loan should increase total repayment
+    // Adding a Postgraduate loan should increase total repayment
     if (
       withPostgrad.current.summary !== null &&
       undergradOnly.current.summary !== null
@@ -184,7 +184,7 @@ describe("usePersonalizedResults (summary + insight)", () => {
 
   it("returns lower totalPaid with present value enabled", async () => {
     const { result: nominalResult } = renderHook(
-      () => usePersonalizedResults(),
+      () => usePersonalisedResults(),
       {
         wrapper: createWrapper({
           showPresentValue: false,
@@ -193,7 +193,7 @@ describe("usePersonalizedResults (summary + insight)", () => {
       },
     );
 
-    const { result: pvResult } = renderHook(() => usePersonalizedResults(), {
+    const { result: pvResult } = renderHook(() => usePersonalisedResults(), {
       wrapper: createWrapper({
         showPresentValue: true,
         discountRate: 0.05,
@@ -211,7 +211,7 @@ describe("usePersonalizedResults (summary + insight)", () => {
 
   it("monthlyRepayment and monthsToPayoff are the same in PV mode", async () => {
     const { result: nominalResult } = renderHook(
-      () => usePersonalizedResults(),
+      () => usePersonalisedResults(),
       {
         wrapper: createWrapper({
           showPresentValue: false,
@@ -220,7 +220,7 @@ describe("usePersonalizedResults (summary + insight)", () => {
       },
     );
 
-    const { result: pvResult } = renderHook(() => usePersonalizedResults(), {
+    const { result: pvResult } = renderHook(() => usePersonalisedResults(), {
       wrapper: createWrapper({
         showPresentValue: true,
         discountRate: 0.05,
@@ -241,7 +241,7 @@ describe("usePersonalizedResults (summary + insight)", () => {
 
   it("insight description changes when showPresentValue is true", async () => {
     const { result: nominalResult } = renderHook(
-      () => usePersonalizedResults(),
+      () => usePersonalisedResults(),
       {
         wrapper: createWrapper({
           showPresentValue: false,
@@ -250,7 +250,7 @@ describe("usePersonalizedResults (summary + insight)", () => {
       },
     );
 
-    const { result: pvResult } = renderHook(() => usePersonalizedResults(), {
+    const { result: pvResult } = renderHook(() => usePersonalisedResults(), {
       wrapper: createWrapper({
         showPresentValue: true,
         discountRate: 0.05,
@@ -267,14 +267,14 @@ describe("usePersonalizedResults (summary + insight)", () => {
   });
 
   it("returns different results for different plan types", async () => {
-    const { result: plan2Result } = renderHook(() => usePersonalizedResults(), {
+    const { result: plan2Result } = renderHook(() => usePersonalisedResults(), {
       wrapper: createWrapper({
         loans: [{ planType: "PLAN_2", balance: 50_000 }],
         salary: 45_000,
       }),
     });
 
-    const { result: plan5Result } = renderHook(() => usePersonalizedResults(), {
+    const { result: plan5Result } = renderHook(() => usePersonalisedResults(), {
       wrapper: createWrapper({
         loans: [{ planType: "PLAN_5", balance: 50_000 }],
         salary: 45_000,
@@ -299,7 +299,7 @@ describe("usePersonalizedResults (summary + insight)", () => {
   });
 });
 
-describe("usePersonalizedResults (cards)", () => {
+describe("usePersonalisedResults (cards)", () => {
   beforeEach(() => {
     vi.setSystemTime(new Date("2024-01-15"));
     localStorage.clear();
@@ -310,7 +310,7 @@ describe("usePersonalizedResults (cards)", () => {
   });
 
   it("returns all 4 card datasets with stat and label", async () => {
-    const { result } = renderHook(() => usePersonalizedResults(), {
+    const { result } = renderHook(() => usePersonalisedResults(), {
       wrapper: createWrapper(),
     });
 
@@ -340,7 +340,7 @@ describe("usePersonalizedResults (cards)", () => {
   });
 
   it("balance sparkline starts at initial balance and decreases", async () => {
-    const { result } = renderHook(() => usePersonalizedResults(), {
+    const { result } = renderHook(() => usePersonalisedResults(), {
       wrapper: createWrapper(),
     });
 
@@ -356,7 +356,7 @@ describe("usePersonalizedResults (cards)", () => {
   });
 
   it("cumulative sparkline is monotonically increasing", async () => {
-    const { result } = renderHook(() => usePersonalizedResults(), {
+    const { result } = renderHook(() => usePersonalisedResults(), {
       wrapper: createWrapper(),
     });
 
@@ -373,7 +373,7 @@ describe("usePersonalizedResults (cards)", () => {
 
   it("PV mode returns lower cumulative totals", async () => {
     const { result: nominalResult } = renderHook(
-      () => usePersonalizedResults(),
+      () => usePersonalisedResults(),
       {
         wrapper: createWrapper({
           showPresentValue: false,
@@ -382,7 +382,7 @@ describe("usePersonalizedResults (cards)", () => {
       },
     );
 
-    const { result: pvResult } = renderHook(() => usePersonalizedResults(), {
+    const { result: pvResult } = renderHook(() => usePersonalisedResults(), {
       wrapper: createWrapper({
         showPresentValue: true,
         discountRate: 0.05,
@@ -401,7 +401,7 @@ describe("usePersonalizedResults (cards)", () => {
   });
 
   it("empty loans returns dash stats", async () => {
-    const { result } = renderHook(() => usePersonalizedResults(), {
+    const { result } = renderHook(() => usePersonalisedResults(), {
       wrapper: createWrapper({ loans: [] }),
     });
 

--- a/src/context/PersonalisedResultsContext.tsx
+++ b/src/context/PersonalisedResultsContext.tsx
@@ -19,19 +19,19 @@ import type {
   InsightPayload,
 } from "@/workers/simulation.worker";
 
-interface PersonalizedResults {
+interface PersonalisedResults {
   summary: InsightSummary | null;
   insight: Insight | null;
   cards: InsightCardsResult | null;
 }
 
-const PersonalizedResultsContext = createContext<PersonalizedResults>({
+const PersonalisedResultsContext = createContext<PersonalisedResults>({
   summary: null,
   insight: null,
   cards: null,
 });
 
-export function PersonalizedResultsProvider({
+export function PersonalisedResultsProvider({
   children,
 }: {
   children: ReactNode;
@@ -64,19 +64,19 @@ export function PersonalizedResultsProvider({
     summary = { ...summary, totalPaid: summary.pvTotalPaid };
   }
 
-  const value: PersonalizedResults = {
+  const value: PersonalisedResults = {
     summary,
     insight: result?.insight ?? null,
     cards: result?.cards ?? null,
   };
 
   return (
-    <PersonalizedResultsContext value={value}>
+    <PersonalisedResultsContext value={value}>
       {children}
-    </PersonalizedResultsContext>
+    </PersonalisedResultsContext>
   );
 }
 
-export function usePersonalizedResults(): PersonalizedResults {
-  return use(PersonalizedResultsContext);
+export function usePersonalisedResults(): PersonalisedResults {
+  return use(PersonalisedResultsContext);
 }

--- a/src/context/loanReducer.test.ts
+++ b/src/context/loanReducer.test.ts
@@ -109,7 +109,7 @@ describe("loanReducer", () => {
       expect(newState.loans).toEqual([{ planType: "PLAN_5", balance: 50_000 }]);
     });
 
-    it("should preserve custom rpiRate and boeBaseRate when applying preset", () => {
+    it("should preserve personalised rpiRate and boeBaseRate when applying preset", () => {
       let state = loanReducer(initialState, updateFieldAction("rpiRate", 6.0));
       state = loanReducer(state, updateFieldAction("boeBaseRate", 5.5));
 

--- a/src/hooks/simulationWorkerSingleton.ts
+++ b/src/hooks/simulationWorkerSingleton.ts
@@ -6,7 +6,7 @@
  * duration of the app. A listeners map enables multiplexed message routing.
  *
  * This module MUST live in src/hooks/ so the relative path to the worker file
- * resolves correctly at build time (webpack statically analyzes the URL pattern).
+ * resolves correctly at build time (webpack statically analyses the URL pattern).
  */
 
 import type {

--- a/src/hooks/useChartData.test.tsx
+++ b/src/hooks/useChartData.test.tsx
@@ -283,7 +283,7 @@ describe("useChartData hooks", () => {
     });
   });
 
-  describe("hook memoization", () => {
+  describe("hook memoisation", () => {
     it("useTotalRepaymentData returns equivalent data on rerender", async () => {
       const { result, rerender } = renderHook(() => useTotalRepaymentData(), {
         wrapper: createWrapper(),

--- a/src/hooks/useDebouncedFunction.ts
+++ b/src/hooks/useDebouncedFunction.ts
@@ -18,7 +18,7 @@ export function useDebouncedFunction<Args extends unknown[]>(
     };
   }, []);
 
-  // No manual memoization — React Compiler handles stable identity.
+  // No manual memoisation — React Compiler handles stable identity.
   return (...args: Args) => {
     if (timerRef.current !== null) {
       clearTimeout(timerRef.current);

--- a/src/hooks/useInputPanelMode.ts
+++ b/src/hooks/useInputPanelMode.ts
@@ -23,10 +23,10 @@ export function useInputPanelMode(options?: UseInputPanelModeOptions) {
   );
   const { applyPreset } = useLoanActions();
   const config = useLoanConfigState();
-  const hasPersonalized = !isPresetConfig(config.loans);
+  const hasPersonalised = !isPresetConfig(config.loans);
 
   function handlePersonalise() {
-    if (hasPersonalized) {
+    if (hasPersonalised) {
       trackWizardRestarted("loan");
     } else {
       trackWizardStarted("loan");
@@ -51,7 +51,7 @@ export function useInputPanelMode(options?: UseInputPanelModeOptions) {
 
   return {
     mode,
-    hasPersonalized,
+    hasPersonalised,
     handlePersonalise,
     handleWizardComplete,
     handlePresetApplied,

--- a/src/hooks/useSimulationWorker.ts
+++ b/src/hooks/useSimulationWorker.ts
@@ -23,10 +23,10 @@ type ResultFor<P extends WorkerPayload> = Extract<
  * Uses a shared singleton worker (created lazily on first message).
  * Handles request/response lifecycle and ignores stale responses.
  *
- * Two-pronged INP optimization:
+ * Two-pronged INP optimisation:
  * 1. Web Worker: Simulations run off the main thread
  * 2. useTransition: Result state updates are wrapped in startTransition,
- *    marking chart re-renders as non-urgent so React can prioritize
+ *    marking chart re-renders as non-urgent so React can prioritise
  *    user interactions (like slider drags) over rendering
  *
  * @param payload - The payload to send to the worker (changes trigger new computation)

--- a/src/hooks/useStoreSelectors.ts
+++ b/src/hooks/useStoreSelectors.ts
@@ -71,7 +71,7 @@ export function useRpiRate(): number {
   return rpiRate;
 }
 
-/** Select BOE base rate for simulation */
+/** Select BoE base rate for simulation */
 export function useBoeBaseRate(): number {
   const { boeBaseRate } = useLoanConfigState();
   return boeBaseRate;

--- a/src/lib/guides.ts
+++ b/src/lib/guides.ts
@@ -49,7 +49,7 @@ export const GUIDES: GuideEntry[] = [
     slug: "student-loan-vs-mortgage",
     title: "Student Loans & Mortgages",
     description:
-      "Does a student loan affect your mortgage? Affordability, income, your credit file, and whether to clear it first.",
+      "Does a student loan affect your mortgage? Affordability, income, your credit file, and whether to pay it off first.",
     topic: "Life & money",
   },
   {

--- a/src/lib/loans/engine.test.ts
+++ b/src/lib/loans/engine.test.ts
@@ -392,7 +392,7 @@ describe("simulate engine", () => {
 
       const firstSnapshot = result.snapshots[0];
 
-      // With 30k and 10k, Plan 2 gets 75% of overpayment, PG gets 25%
+      // With 30k and 10k, Plan 2 gets 75% of overpayment, Postgraduate gets 25%
       // But the exact distribution includes the base repayment too
       // Just verify both loans receive some payment
       expect(firstSnapshot.loans[0].repayment).toBeGreaterThan(0);

--- a/src/lib/loans/engine.ts
+++ b/src/lib/loans/engine.ts
@@ -47,7 +47,7 @@ export function simulate(config: SimulationConfig): SimulationTimeSeries {
     return createEmptyResult();
   }
 
-  // Initialize loan state tracking
+  // Initialise loan state tracking
   const loanStates = activeLoans.map((loan) => ({
     loan,
     balance: loan.balance,
@@ -57,7 +57,7 @@ export function simulate(config: SimulationConfig): SimulationTimeSeries {
     writeOffMonth: getWriteOffMonth(loan.planType, monthsElapsed),
   }));
 
-  // Initialize dynamic thresholds per plan type (for threshold growth)
+  // Initialise dynamic thresholds per plan type (for threshold growth)
   const planThresholds = new Map<string, number>();
   for (const loan of activeLoans) {
     if (!planThresholds.has(loan.planType)) {

--- a/src/lib/loans/overpaySimulate.test.ts
+++ b/src/lib/loans/overpaySimulate.test.ts
@@ -47,7 +47,7 @@ describe("simulateOverpayScenarios", () => {
       expect(result.recommendationReason).toContain(
         "Enter a lump sum or monthly amount",
       );
-      // Chart data should still be generated for baseline visualization
+      // Chart data should still be generated for baseline visualisation
       expect(result.balanceTimeSeries.length).toBeGreaterThan(0);
       expect(result.baseline.totalPaid).toBeGreaterThan(0);
     });
@@ -391,7 +391,7 @@ describe("simulateOverpayScenarios", () => {
       expect(result.baseline.monthsToPayoff).toBeGreaterThan(0);
     });
 
-    it("handles combined undergrad + postgrad loans", () => {
+    it("handles combined undergraduate + Postgraduate loans", () => {
       const result = simulateOverpayScenarios({
         ...defaultInput,
         loans: [

--- a/src/lib/loans/overpaySimulate.ts
+++ b/src/lib/loans/overpaySimulate.ts
@@ -366,7 +366,7 @@ function determineRecommendation(
 }
 
 /**
- * Creates an empty result for when there's nothing to analyze.
+ * Creates an empty result for when there's nothing to analyse.
  */
 function createEmptyResult(): OverpayAnalysisResult {
   return {

--- a/src/lib/loans/overpayTypes.ts
+++ b/src/lib/loans/overpayTypes.ts
@@ -63,7 +63,7 @@ export interface OverpayAnalysisResult {
   writeOffMonth: number | null;
   /** Payment difference: baseline.totalPaid - overpay.totalPaid
    * Positive = overpaying saves money (less interest paid)
-   * Negative = overpaying costs more (e.g., paying off debt that would be written off) */
+   * Negative = overpaying costs more (e.g., paying off a balance that would be written off) */
   paymentDifference: number;
   /** Extra amount paid when overpaying (overpayment contributions) */
   overpaymentContributions: number;

--- a/src/lib/loans/plans.test.ts
+++ b/src/lib/loans/plans.test.ts
@@ -41,7 +41,7 @@ describe("PLAN_CONFIGS", () => {
     );
   });
 
-  it("PLAN_2 has interest scale thresholds with upper > lower", () => {
+  it("PLAN_2 has sliding scale thresholds with upper > lower", () => {
     const { interestLowerThreshold, interestUpperThreshold } =
       PLAN_CONFIGS.PLAN_2;
     expect(interestLowerThreshold).toBeGreaterThan(0);

--- a/src/lib/loans/types.ts
+++ b/src/lib/loans/types.ts
@@ -69,7 +69,7 @@ export interface SimulationConfig {
   monthsElapsed?: number;
   /** Annual salary growth rate (default 0) */
   salaryGrowthRate?: number;
-  /** Extra payment per month distributed across loans (default 0) */
+  /** Overpayment per month distributed across loans (default 0) */
   monthlyOverpayment?: number;
   /** Annual threshold growth rate (default 0) */
   thresholdGrowthRate?: number;

--- a/src/lib/metadata.test.ts
+++ b/src/lib/metadata.test.ts
@@ -70,7 +70,7 @@ describe("parseMetadataParams", () => {
       expect(result.salary).toBe(65000);
     });
 
-    it("returns Postgraduate as plan name when only PG loans exist", () => {
+    it("returns Postgraduate as plan name when only Postgraduate loans exist", () => {
       const result = parseMetadataParams({
         loans: "POSTGRADUATE:15000",
         sal: "40000",
@@ -120,7 +120,7 @@ describe("parseMetadataParams", () => {
       expect(result.formattedSalary).toBe("£65,000");
     });
 
-    it("formats combined UG + PG balance in formattedBalance", () => {
+    it("formats combined Undergraduate + Postgraduate balance in formattedBalance", () => {
       const result = parseMetadataParams({
         loans: "PLAN_2:45000,POSTGRADUATE:12000",
       });

--- a/src/lib/planContent.ts
+++ b/src/lib/planContent.ts
@@ -192,7 +192,7 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
     heroIntro: `Plan 1 is the oldest UK student loan type still being repaid. It covers English and Welsh students who started before September 2012, and every Northern Irish student regardless of start year. You repay ${p1Rate} of everything you earn above ${p1YearGBP} a year, and any balance left after ${p1WriteOff} years is written off.`,
     whatItIs: [
       `A Plan 1 student loan is repaid at ${p1Rate} of your income above the ${p1YearGBP}-a-year (${p1MonthlyGBP} a month) repayment threshold. It has the lowest interest of any plan because the rate is capped at the lower of RPI or the Bank of England base rate plus 1%.`,
-      `Because Plan 1 is the oldest plan, many borrowers are now well into their ${p1WriteOff}-year term. Any remaining balance is cancelled once that write-off period is reached, with nothing left to pay.`,
+      `Because Plan 1 is the oldest plan, many borrowers are now well into their ${p1WriteOff}-year term. Any remaining balance is written off once that period is reached, with nothing left to pay.`,
     ],
     whoItIsFor: [
       "You are on Plan 1 if you are an English or Welsh student who started an undergraduate course before September 2012.",
@@ -203,7 +203,7 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
       `This cap keeps Plan 1 interest low and predictable — it never runs away the way a purely inflation-linked rate can, which makes Plan 1 the cheapest plan to carry pound for pound.`,
     ],
     compareParagraph: `Plan 1 has a lower threshold than Plan 2 (${p2YearGBP}) or Plan 4 (${p4YearGBP}), so you start repaying earlier, but its capped interest and shorter ${p1WriteOff}-year write-off make it far cheaper over a lifetime than the newer ${p5WriteOff}-year Plan 5.`,
-    middleEarner: `Plan 1's low, capped interest means the balance rarely balloons, so the middle-earner trap that hits Plan 2 and Plan 5 borrowers is much weaker here. The people most likely to clear a Plan 1 loan in full are steady middle earners — low earners often reach the ${p1WriteOff}-year write-off first, while high earners clear it quickly. Model your own salary to see where you land.`,
+    middleEarner: `Plan 1's low, capped interest means the balance rarely balloons, so the middle-earner trap that hits Plan 2 and Plan 5 borrowers is much weaker here. The people most likely to pay off a Plan 1 loan in full are steady middle earners — low earners often reach the ${p1WriteOff}-year write-off first, while high earners pay it off quickly. Model your own salary to see where you land.`,
     faqs: [
       {
         question: "What is a Plan 1 student loan?",
@@ -219,7 +219,7 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
       },
       {
         question: "When is a Plan 1 loan written off?",
-        answer: `A Plan 1 loan is written off ${p1WriteOff} years after the April you were first due to repay. Anything still outstanding at that point is cancelled and you stop paying.`,
+        answer: `A Plan 1 loan is written off ${p1WriteOff} years after the April you were first due to repay. Anything still outstanding at that point no longer has to be repaid, and you stop paying.`,
       },
     ],
   },
@@ -234,11 +234,11 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
     yearlyThreshold: p2.yearlyThreshold,
     repaymentRate: p2.repaymentRate,
     writeOffYears: p2.writeOffYears,
-    interestShort: "RPI to RPI + 3% (income-based)",
+    interestShort: "RPI to RPI + 3% (sliding scale)",
     interestCurrent: `${plan2LowPct}–${plan2HighPct}`,
     metaTitle:
       "What Is a Plan 2 Student Loan? Threshold, Interest & Write-Off (2026)",
-    metaDescription: `Plan 2 student loans: ${p2YearGBP} threshold, ${p1Rate} rate, income-based interest from ${plan2LowPct} to ${plan2HighPct}, and a ${p2WriteOff}-year write-off. Why middle earners repay the most.`,
+    metaDescription: `Plan 2 student loans: ${p2YearGBP} threshold, ${p1Rate} rate, a sliding scale from ${plan2LowPct} to ${plan2HighPct}, and a ${p2WriteOff}-year write-off. Why middle earners repay the most.`,
     keywords: [
       "what is plan 2 student loan",
       "plan 2 student loan",
@@ -249,7 +249,7 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
     ],
     heroIntro: `Plan 2 covers English and Welsh students who started university between September 2012 and July 2023 — the £9,000-plus tuition fee generation. You repay ${p1Rate} of income above ${p2YearGBP} a year, and interest runs on a sliding scale up to RPI + 3%, which is exactly why Plan 2 middle earners so often repay more than anyone else.`,
     whatItIs: [
-      `A Plan 2 student loan is repaid at ${p1Rate} of your income above ${p2YearGBP} a year (${p2MonthlyGBP} a month). Unlike Plan 1, interest is income-based: it climbs from RPI up to RPI + 3% as your salary rises.`,
+      `A Plan 2 student loan is repaid at ${p1Rate} of your income above ${p2YearGBP} a year (${p2MonthlyGBP} a month). Unlike Plan 1, interest follows a sliding scale: it climbs from RPI up to RPI + 3% as your salary rises.`,
       `Any balance still outstanding ${p2WriteOff} years after you were first due to repay is written off. But because of the high interest, most Plan 2 borrowers never reach a zero balance through minimum repayments alone.`,
     ],
     whoItIsFor: [
@@ -258,10 +258,10 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
     ],
     interestParagraphs: [
       `Plan 2 interest is charged on a sliding scale. While you are studying, and on income up to ${p2YearGBP}, you pay RPI (${rpiPct}). Between ${formatGBP(plan2InterestLower)} and ${formatGBP(plan2InterestUpper)} the rate rises linearly, reaching RPI + 3% (${plan2HighPct}) once you earn ${formatGBP(plan2InterestUpper)} or more.`,
-      `That RPI + 3% ceiling is the single biggest reason Plan 2 is so expensive: the balance can grow faster than a typical borrower repays it, so the debt keeps compounding for years.`,
+      `That RPI + 3% ceiling is the single biggest reason Plan 2 is so expensive: the balance can grow faster than a typical borrower repays it, so it keeps compounding for years.`,
     ],
     compareParagraph: `Plan 2 has a higher threshold than Plan 1 (${p1YearGBP}) or Plan 5 (${p5YearGBP}), so you repay less each month at the same salary — but its RPI + 3% interest ceiling makes it the most expensive plan for middle earners, more than offsetting the shorter ${p2WriteOff}-year term versus Plan 5's ${p5WriteOff} years.`,
-    middleEarner: `Plan 2 is the clearest example of the middle-earner trap. Low earners repay little and reach the ${p2WriteOff}-year write-off with plenty forgiven; high earners clear the balance fast before much interest builds. It is the middle — graduates earning enough to make real repayments, but not enough to outrun RPI + 3% interest — who repay the most in total, often far more than they originally borrowed.`,
+    middleEarner: `Plan 2 is the clearest example of the middle-earner trap. Low earners repay little and reach the ${p2WriteOff}-year write-off with plenty written off; high earners pay off the balance fast before much interest builds. It is the middle — graduates earning enough to make real repayments, but not enough to outrun RPI + 3% interest — who repay the most in total, often far more than they originally borrowed.`,
     faqs: [
       {
         question: "What is a Plan 2 student loan?",
@@ -273,11 +273,11 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
       },
       {
         question: "What is the Plan 2 interest rate?",
-        answer: `Plan 2 interest is income-based, from RPI (${rpiPct}) at or below ${formatGBP(plan2InterestLower)} up to RPI + 3% (${plan2HighPct}) at ${formatGBP(plan2InterestUpper)} or more, interpolated in between. A separate cap can lower the headline rate when market rates are low.`,
+        answer: `Plan 2 interest follows a sliding scale, from RPI (${rpiPct}) at or below ${formatGBP(plan2InterestLower)} up to RPI + 3% (${plan2HighPct}) at ${formatGBP(plan2InterestUpper)} or more, interpolated in between. A separate cap can lower the headline rate when market rates are low.`,
       },
       {
         question: "Why do Plan 2 middle earners repay the most?",
-        answer: `Because Plan 2 interest reaches RPI + 3%, middle earners repay steadily but not fast enough to stop the balance compounding, and they earn too much for the ${p2WriteOff}-year write-off to help. High earners clear the loan quickly; low earners have it written off — so the middle pays the most in total.`,
+        answer: `Because Plan 2 interest reaches RPI + 3%, middle earners repay steadily but not fast enough to stop the balance compounding, and they earn too much for the ${p2WriteOff}-year write-off to help. High earners pay off the loan quickly; low earners have it written off — so the middle pays the most in total.`,
       },
     ],
   },
@@ -365,7 +365,7 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
     ],
     heroIntro: `Plan 5 is the newest UK student loan, for English students who started university from September 2023 onwards. It has the lowest threshold of the current undergraduate plans — ${p5YearGBP} a year — the simplest interest (RPI only), but the longest write-off of any plan at ${p5WriteOff} years.`,
     whatItIs: [
-      `A Plan 5 student loan is repaid at ${p1Rate} of income above ${p5YearGBP} a year (${p5MonthlyGBP} a month). Interest is charged at RPI only — no income-based add-on — which makes the balance easier to predict than Plan 2.`,
+      `A Plan 5 student loan is repaid at ${p1Rate} of income above ${p5YearGBP} a year (${p5MonthlyGBP} a month). Interest is charged at RPI only — no sliding scale — which makes the balance easier to predict than Plan 2.`,
       `The catch is the term: Plan 5 balances are written off ${p5WriteOff} years after you become due to repay, ten years longer than Plan 2 and fifteen longer than Plan 1. That extra decade of repayments is where the real cost hides.`,
     ],
     whoItIsFor: [
@@ -373,11 +373,11 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
       "Welsh, Scottish and Northern Irish students are not on Plan 5 — Plan 5 is England-only. Students who started before August 2023 remain on Plan 2 (or Plan 1).",
     ],
     interestParagraphs: [
-      `Plan 5 interest is charged at RPI only — currently ${rpiPct} — with no income-based addition. That makes it the simplest interest of any plan to understand and forecast.`,
+      `Plan 5 interest is charged at RPI only — currently ${rpiPct} — with no sliding scale. That makes it the simplest interest of any plan to understand and forecast.`,
       `Lower, simpler interest sounds cheaper, but the ${p5WriteOff}-year write-off means most borrowers keep repaying for far longer, so many end up paying more in total than they would have on the shorter Plan 2.`,
     ],
     compareParagraph: `Plan 5's ${p5YearGBP} threshold is lower than Plan 2 (${p2YearGBP}), so you start repaying sooner and pay more each month at the same salary. Its RPI-only interest is gentler than Plan 2's RPI + 3%, but the ${p5WriteOff}-year term (versus ${p2WriteOff} for Plan 2) is longer than any other plan.`,
-    middleEarner: `Plan 5's ${p5WriteOff}-year term turns the middle-earner trap into a marathon. Lower earners can pay for four decades and still have a balance written off; high earners clear it early. Middle earners repay steadily for most of their working life — often paying back far more than they borrowed before the write-off ever arrives.`,
+    middleEarner: `Plan 5's ${p5WriteOff}-year term turns the middle-earner trap into a marathon. Lower earners can pay for four decades and still have a balance written off; high earners pay it off early. Middle earners repay steadily for most of their working life — often paying back far more than they borrowed before the write-off ever arrives.`,
     faqs: [
       {
         question: "What is a Plan 5 student loan?",
@@ -389,7 +389,7 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
       },
       {
         question: "What is the Plan 5 student loan interest rate?",
-        answer: `Plan 5 interest is charged at RPI only, currently ${rpiPct}, with no income-based add-on. That is simpler and lower than Plan 2's RPI + 3% ceiling, but the ${p5WriteOff}-year write-off can make Plan 5 more expensive overall.`,
+        answer: `Plan 5 interest is charged at RPI only, currently ${rpiPct}, with no sliding scale. That is simpler and lower than Plan 2's RPI + 3% ceiling, but the ${p5WriteOff}-year write-off can make Plan 5 more expensive overall.`,
       },
       {
         question: "When is a Plan 5 loan written off?",
@@ -431,7 +431,7 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
       "It sits on top of any undergraduate plan you already have. Your undergraduate loan keeps its own threshold, rate and write-off — the Postgraduate Loan is calculated separately.",
     ],
     interestParagraphs: [
-      `Postgraduate Loan interest is a flat RPI + 3% — currently ${postgradPct} — for everyone, whatever you earn. There is no income-based sliding scale like Plan 2 and no cap like Plan 1 or Plan 4.`,
+      `Postgraduate Loan interest is a flat RPI + 3% — currently ${postgradPct} — for everyone, whatever you earn. There is no sliding scale like Plan 2 and no cap like Plan 1 or Plan 4.`,
       `That makes it one of the higher interest rates in the system, so the balance grows quickly. Combined with the ${pgWriteOff}-year term, many postgraduate borrowers repay well beyond what they originally borrowed.`,
     ],
     compareParagraph: `The Postgraduate Loan has the lowest threshold (${pgYearGBP}) but the lowest repayment rate (${pgRatePct} versus 9%). Its flat RPI + 3% interest matches Plan 2's ceiling, and because it stacks on top of an undergraduate loan, the combined deductions can be heavier than any single plan.`,
@@ -447,7 +447,7 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
       },
       {
         question: "What is the Postgraduate Loan interest rate?",
-        answer: `Postgraduate Loan interest is a flat RPI + 3% for everyone, currently ${postgradPct}. Unlike Plan 2 there is no income-based sliding scale, and unlike Plan 1 and Plan 4 there is no low-rate cap.`,
+        answer: `Postgraduate Loan interest is a flat RPI + 3% for everyone, currently ${postgradPct}. Unlike Plan 2 there is no sliding scale, and unlike Plan 1 and Plan 4 there is no low-rate cap.`,
       },
       {
         question:

--- a/src/lib/presets.test.ts
+++ b/src/lib/presets.test.ts
@@ -9,7 +9,7 @@ describe("isPresetConfig", () => {
     }
   });
 
-  it("returns false for a custom loan config", () => {
+  it("returns false for a personalised loan config", () => {
     const customLoans: Loan[] = [{ planType: "PLAN_2", balance: 30_000 }];
     expect(isPresetConfig(customLoans)).toBe(false);
   });

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -32,8 +32,8 @@ export const PRESETS: Preset[] = [
   },
   {
     id: "ug-pg-combo",
-    label: "UG + Masters",
-    description: "Plan 2 \u00b7 \u00a345k + \u00a312k postgrad",
+    label: "Undergraduate + Masters",
+    description: "Plan 2 \u00b7 \u00a345k + \u00a312k Postgraduate",
     loans: [
       { planType: "PLAN_2", balance: 45_000 },
       { planType: "POSTGRADUATE", balance: 12_000 },

--- a/src/lib/quiz/determinePlan.test.ts
+++ b/src/lib/quiz/determinePlan.test.ts
@@ -200,7 +200,7 @@ describe("determineAllLoans", () => {
     direction: "forward",
   };
 
-  it("returns single plan for Scotland without postgrad", () => {
+  it("returns single plan for Scotland without Postgraduate", () => {
     const state: QuizState = {
       ...baseState,
       region: "scotland",
@@ -209,7 +209,7 @@ describe("determineAllLoans", () => {
     expect(determineAllLoans(state)).toEqual(["PLAN_4"]);
   });
 
-  it("returns single plan for Northern Ireland without postgrad", () => {
+  it("returns single plan for Northern Ireland without Postgraduate", () => {
     const state: QuizState = {
       ...baseState,
       region: "northern-ireland",
@@ -298,7 +298,7 @@ describe("determineAllLoans", () => {
     ]);
   });
 
-  it("handles Scotland with postgrad loan", () => {
+  it("handles Scotland with Postgraduate loan", () => {
     const state: QuizState = {
       ...baseState,
       region: "scotland",

--- a/src/lib/shareUrl.test.ts
+++ b/src/lib/shareUrl.test.ts
@@ -130,7 +130,7 @@ describe("decodeParamsToState", () => {
     expect(state.salary).toBe(65000);
   });
 
-  it("decodes legacy format without postgrad", () => {
+  it("decodes legacy format without Postgraduate", () => {
     const params = new URLSearchParams("plan=PLAN_5&ug=50000&sal=40000");
     const state = decodeParamsToState(params);
 
@@ -138,7 +138,7 @@ describe("decodeParamsToState", () => {
     expect(state.salary).toBe(40000);
   });
 
-  it("decodes legacy format with zero postgrad balance", () => {
+  it("decodes legacy format with zero Postgraduate balance", () => {
     const params = new URLSearchParams("plan=PLAN_2&ug=45000&pg=0&sal=40000");
     const state = decodeParamsToState(params);
 

--- a/src/types/insightCards.ts
+++ b/src/types/insightCards.ts
@@ -24,7 +24,7 @@ export interface InterestCardData {
 export interface EffectiveRateCardData {
   stat: string;
   label: string;
-  /** Effective annualized cost of the loan (0.035 = 3.5%) */
+  /** Effective annualised cost of the loan (0.035 = 3.5%) */
   effectiveRate: number;
   /** Bank of England base rate for comparison (0.045 = 4.5%) */
   boeRate: number;

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -20,7 +20,7 @@ export interface LoanState {
   applyPlan2Freeze: boolean;
   /** RPI rate as percentage (e.g., 3.2 = 3.2%), matching CURRENT_RATES format */
   rpiRate: number;
-  /** BOE base rate as percentage (e.g., 3.75 = 3.75%), matching CURRENT_RATES format */
+  /** BoE base rate as percentage (e.g., 3.75 = 3.75%), matching CURRENT_RATES format */
   boeBaseRate: number;
   /** One-off lump sum payment in GBP */
   lumpSumPayment: number;

--- a/src/utils/insights.test.ts
+++ b/src/utils/insights.test.ts
@@ -49,7 +49,7 @@ describe("generateInsight", () => {
     expect(result?.title).toContain("pay off quickly");
   });
 
-  it("uses custom rpiRate and boeBaseRate when provided", () => {
+  it("uses personalised rpiRate and boeBaseRate when provided", () => {
     const withDefaults = generateInsight(60_000, { loans: [plan2Loan] });
     const withCustomRates = generateInsight(60_000, {
       loans: [plan2Loan],

--- a/src/utils/insights.ts
+++ b/src/utils/insights.ts
@@ -32,7 +32,7 @@ interface InsightConfig {
 
 /**
  * Gets the write-off years for a loan configuration.
- * Uses the undergraduate loan's write-off period, or postgraduate if no undergrad.
+ * Uses the undergraduate loan's write-off period, or Postgraduate if no undergraduate loan.
  */
 function getWriteOffYears(loans: Loan[]): number {
   const undergradLoan = loans.find((l) => l.planType !== "POSTGRADUATE");
@@ -50,9 +50,9 @@ function willBeWrittenOff(result: SimulationTimeSeries): boolean {
 }
 
 /**
- * Generates a personalized insight based on salary and loan configuration.
+ * Generates a personalised insight based on salary and loan configuration.
  *
- * Categorizes the user into one of three zones:
+ * Categorises the user into one of three zones:
  * - Peak zone: total repayment exceeds 1.7x the principal
  * - Low earner: loan gets written off before paying too much
  * - High earner: pays off quickly without excessive interest
@@ -175,7 +175,7 @@ export function generateInsight(
   return {
     type: "high-earner",
     title: "You'll pay off quickly",
-    description: `You'll clear your loan in about ${yearsToPayoff} years, ${interestDescription}.`,
+    description: `You'll pay off your loan in about ${yearsToPayoff} years, ${interestDescription}.`,
     cta: {
       text: "See how overpaying saves you time",
       href: "/overpay",

--- a/src/utils/loanCalculations.test.ts
+++ b/src/utils/loanCalculations.test.ts
@@ -98,7 +98,7 @@ describe("generateSalaryDataSeries: rpiRate and boeBaseRate", () => {
     expect(dataLowRpi[midIndex].value).not.toBe(dataHighRpi[midIndex].value);
   });
 
-  it("different BOE base rates produce different results for Plan 1", () => {
+  it("different BoE base rates produce different results for Plan 1", () => {
     const loans: Loan[] = [{ planType: "PLAN_1", balance: 30000 }];
 
     const dataLowBoe = generateSalaryDataSeries(loans, undefined, 0, 0, 2);

--- a/src/utils/loanCalculations.ts
+++ b/src/utils/loanCalculations.ts
@@ -59,7 +59,7 @@ export function generateSalaryDataSeries(
  * @param rpiRate - Optional RPI rate override
  * @param salaryGrowthRate - Annual salary growth rate (default 0)
  * @param thresholdGrowthRate - Annual threshold growth rate (default 0)
- * @param boeBaseRate - BOE base rate override
+ * @param boeBaseRate - BoE base rate override
  * @returns Array of [salary, value] data points with PV-adjusted values
  */
 export function generateSalaryDataSeriesPV(

--- a/src/workers/simulation.worker.ts
+++ b/src/workers/simulation.worker.ts
@@ -6,7 +6,7 @@
  * - SALARY_SERIES: 126 simulations across salary range
  * - BALANCE_SERIES: 1 simulation for balance over time
  * - OVERPAY_ANALYSIS: 2 simulations for overpay comparison
- * - INSIGHT: 1 simulation for personalized insight text
+ * - INSIGHT: 1 simulation for personalised insight text
  * - DETAIL_SERIES: 1 simulation extracting all time-series for detail pages
  * - EFFECTIVE_RATE_SALARY: 126 simulations computing effective rate by salary
  */
@@ -276,7 +276,7 @@ function handleInsight(payload: InsightPayload): {
       effectiveRate: 0,
       boeRate: payload.boeBaseRate / 100,
     },
-    cumulative: { data: [], stat: "\u2014", label: "Total Cost" },
+    cumulative: { data: [], stat: "\u2014", label: "Total Repayments" },
   };
 
   if (totalBalance <= 0) {
@@ -402,7 +402,7 @@ function handleInsight(payload: InsightPayload): {
     cumulative: {
       data: cumulativeData,
       stat: cumulativeStat,
-      label: "Total Cost",
+      label: "Total Repayments",
     },
   };
 


### PR DESCRIPTION
## Why

`CONTEXT.md` is the arbitration for our domain language, but drift had accumulated: the same concepts were being named with the glossary's `_Avoid_` synonyms across code identifiers, comments, docs, and user-facing copy. This sweep converges every concept back to its one canonical name so human readers — and future AI sessions — don't have to re-derive whether competing terms mean the same thing.

**Behaviour-preserving only.** Renames of identifiers, comments, docs, and product copy. No logic changes (the diff is a balanced 301/301 line swap; the full gate — typecheck, lint, 507 unit tests, build, format, and the two affected e2e specs' string alignment — is green).

## What converged

- **UK spelling in identifiers and copy** (the glossary mandates it): the personalised-results React context/hook/provider and its file, plus a repo-wide `-ize`→`-ise` sweep.
- **Write-off vs Paid-off kept genuinely distinct** (the glossary calls them opposite): the "pay down to zero" sense now always reads *pay off*; the "balance cancelled at term end" sense always reads *written off*; result labels aligned.
- **Concept → canonical term:** Income (not earnings/salary) as the assessed figure in the repayment rule; Overpayment (not voluntary/extra payment); mandatory Repayment (not payment); Balance/Principal (not debt/outstanding balance/original loan amount); Sliding scale (not income-based interest); Effective rate (not effective interest rate/true cost); Present value (not inflation-adjusted/in real terms, including chart aria-labels for accessibility parity); Total repaid (not total cost/lifetime total).
- **Plan language:** "scheme"→Plan; UG/PG/postgrad/PGL abbreviations→full title-case Undergraduate/Postgraduate in copy; BoE casing.
- **UI labels** aligned to the glossary's chosen wording (Tailor to you / Edit details).
- e2e specs and the auto-generated `llms.txt` updated to stay in sync with renamed copy.

## Glossary change in this PR (please review)

`CONTEXT.md`'s **Write-off** entry now records a deliberate exception: the moving-abroad myth FAQ and its SEO keyword intentionally keep "wiped"/"wipe"/"cancel" — the words users actually search — to debunk the "moving abroad wipes your loan" myth. Factual statements there still use "written off". You can see both halves in the same `overseas-data.ts` FAQ: the *question* keeps "wiped", the *answer* now reads "written off at the end of your plan's term".

## Left intact deliberately (considered, not missed)

- Share-URL params `ug`/`pg` and the preset id `ug-pg-combo` — external contracts; renaming breaks old shared links.
- Genuinely-different senses kept: pay-upfront "Total cost" (cost of the loan-vs-upfront-tuition strategy), "income-based repayments" (overseas income-contingent repayment), mortgage/collections "debt", the effective-rate FAQ "true annualised cost" (the glossary's own definitional wording), explanatory "today's money"/"in real terms" prose (the avoid is scoped to the toggle/state label only), and "PhD" in the quiz question (voice-of-customer).
- The "Fig. 1 — Lifetime repaid by salary" chart-caption system was left as a documented distinction from the "Total repaid" scalar — recommend recording it in the glossary or renaming captions in a follow-up.

## Recommended follow-up (not in this PR)

A pre-existing factual error at `src/lib/planContent.ts:260` states Plan 2 *in-study* interest as RPI, but per GOV.UK and the repo's own research doc (`docs/uk-student-loans-research.md:100-102`) it should be RPI + 3% — the sliding scale applies only after study, and the same paragraph appears to use the repayment threshold where the interest thresholds belong. It's outside the changed lines and is a financial-accuracy fix deserving its own focused PR.