### PR TITLE
feat: show a live "verified Xh ago" data-freshness signal

### DIFF
--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { VerifiedAgo } from "@/components/instrument/VerifiedAgo";
 import { WideLayout } from "@/components/layout/WideLayout";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { Heading } from "@/components/typography/Heading";
@@ -12,14 +13,6 @@ import {
 } from "@/components/ui/breadcrumb";
 import { GUIDES } from "@/lib/guides";
 import { SHELL_GUTTER } from "@/lib/layout";
-import { LAST_UPDATED } from "@/lib/loans/plans";
-
-// "Updated May 2026" — derived from the automation's LAST_UPDATED so the guides
-// masthead carries the same freshness signal as the homepage hero.
-const UPDATED_LABEL = new Intl.DateTimeFormat("en-GB", {
-  month: "long",
-  year: "numeric",
-}).format(new Date(LAST_UPDATED));
 
 // Aggregate the honest topic taxonomy into counts for the orientation rail's
 // "by topic" ledger — derived from the data (unique topics in first-appearance
@@ -109,7 +102,7 @@ export default function GuidesPage() {
           <p className="flex flex-wrap items-center gap-x-[0.65rem] gap-y-[0.4rem] pt-6 font-sans text-meta text-muted-foreground work:mt-auto">
             <span className="font-bold text-primary">✓</span> Independent{" "}
             <span className="text-faint">·</span> GOV.UK sourced{" "}
-            <span className="text-faint">·</span> Updated {UPDATED_LABEL}
+            <span className="text-faint">·</span> <VerifiedAgo />
           </p>
         </div>
 

--- a/src/components/home/instrument/Hero.tsx
+++ b/src/components/home/instrument/Hero.tsx
@@ -1,12 +1,5 @@
+import { VerifiedAgo } from "@/components/instrument/VerifiedAgo";
 import { Heading } from "@/components/typography/Heading";
-import { LAST_UPDATED } from "@/lib/loans/plans";
-
-// "Updated May 2026" — derived from the automation's LAST_UPDATED so it stays
-// current without hardcoding.
-const UPDATED_LABEL = new Intl.DateTimeFormat("en-GB", {
-  month: "long",
-  year: "numeric",
-}).format(new Date(LAST_UPDATED));
 
 export function Hero() {
   return (
@@ -26,7 +19,7 @@ export function Hero() {
       <p className="flex flex-wrap items-center gap-x-[0.65rem] gap-y-[0.4rem] font-sans text-meta text-muted-foreground">
         <span className="font-bold text-primary">✓</span> Independent{" "}
         <span className="text-faint">·</span> GOV.UK sourced{" "}
-        <span className="text-faint">·</span> Updated {UPDATED_LABEL}
+        <span className="text-faint">·</span> <VerifiedAgo />
       </p>
     </div>
   );

--- a/src/components/home/instrument/RulesSection.tsx
+++ b/src/components/home/instrument/RulesSection.tsx
@@ -80,7 +80,8 @@ export function RulesSection() {
           </h3>
           <p className="col-start-2 text-body leading-[1.55] text-pretty text-muted-foreground">
             Thresholds, repayment rates and the RPI figure come straight from
-            GOV.UK and the Bank of England, and are refreshed when they change.
+            GOV.UK and the Bank of England, checked daily by an automated job
+            and refreshed whenever they change.
           </p>
           <span className="col-start-2 mt-[0.55rem] font-sans text-meta text-muted-foreground">
             {TAX_YEAR} tax year

--- a/src/components/instrument/VerifiedAgo.tsx
+++ b/src/components/instrument/VerifiedAgo.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { formatAgo, hoursSinceLastCheck } from "@/lib/dataFreshness";
+
+// The label is hour-bucketed, so every instance shares a single timer that
+// fires on the next UTC hour boundary — when the value can actually change —
+// rather than each polling every minute. useSyncExternalStore skips the
+// re-render when the recomputed string is unchanged, so a boundary wake is
+// cheap even in the rare case nothing moved.
+const listeners = new Set<() => void>();
+let timer: ReturnType<typeof setTimeout> | undefined;
+
+function schedule(): void {
+  // +1s past the boundary so the recompute lands in the new hour bucket.
+  timer = setTimeout(tick, 3_600_000 - (Date.now() % 3_600_000) + 1_000);
+}
+
+function tick(): void {
+  for (const notify of listeners) {
+    notify();
+  }
+  schedule();
+}
+
+function subscribe(onChange: () => void): () => void {
+  listeners.add(onChange);
+  if (listeners.size === 1) {
+    schedule();
+  }
+  return () => {
+    listeners.delete(onChange);
+    if (listeners.size === 0 && timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+}
+
+/**
+ * Live "Verified X ago" freshness label, derived client-side from the daily
+ * 07:00 UTC check schedule (see `@/lib/dataFreshness`).
+ *
+ * `useSyncExternalStore` renders the durable "Verified recently" fallback during
+ * SSR and hydration, then swaps to the relative label on the client. That keeps
+ * the SSR'd HTML and the no-JS experience truthful and sidesteps a hydration
+ * mismatch by design. "recently" (not "daily") is deliberate: it reads on its
+ * own when the verb is hidden (see `narrow`), it stays consistent with the live
+ * "X ago" recency signal, and every surface shows the same fallback word on a
+ * page. The whole label is one inline span, so it stays a single flex item.
+ *
+ * `narrow` is for tight chrome (the header badge): it hides the "Verified" verb
+ * below `sm`, dropping to just "14h ago" / "recently".
+ */
+export function VerifiedAgo({ narrow = false }: { narrow?: boolean }) {
+  const ago = useSyncExternalStore(
+    subscribe,
+    () => formatAgo(hoursSinceLastCheck(new Date())),
+    () => "recently",
+  );
+
+  return (
+    <span>
+      <span className={narrow ? "hidden sm:inline" : undefined}>
+        {"Verified "}
+      </span>
+      {ago}
+    </span>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -18,7 +18,7 @@ export function Footer() {
             <BrandLogo size="sm" />
             <p className="max-w-sm text-sm text-muted-foreground">
               Independent UK student loan calculator. Figures sourced from
-              GOV.UK and the Bank of England.
+              GOV.UK and the Bank of England, and verified daily.
             </p>
           </div>
           <Eyebrow marker={false}>studentloanstudy.uk</Eyebrow>

--- a/src/components/layout/GovUkBadge.tsx
+++ b/src/components/layout/GovUkBadge.tsx
@@ -1,6 +1,7 @@
 import { Tick02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
+import { VerifiedAgo } from "@/components/instrument/VerifiedAgo";
 import { badgeVariants } from "@/components/ui/badge";
 import {
   Popover,
@@ -29,17 +30,30 @@ export function GovUkBadge({ className }: { className?: string }) {
           // mismatch on every page. One element → one stable data-slot.
           <button type="button" className={cn(badgeVariants(), className)}>
             <HugeiconsIcon icon={Tick02Icon} className="size-3" />
-            GOV.UK <time dateTime={LAST_UPDATED}>{formattedDate}</time>
+            GOV.UK{" "}
+            <span className="text-faint" aria-hidden="true">
+              ·
+            </span>{" "}
+            {/* narrow: hides the "Verified" verb below sm to keep the chip
+                compact (the component pairs that with a standalone fallback). */}
+            <VerifiedAgo narrow />
+            {/* Keep a machine-readable "as of" date in the always-rendered chip
+                for crawlers and assistive tech; the popover's date only mounts
+                when it opens. */}
+            <time dateTime={LAST_UPDATED} className="sr-only">
+              {" "}
+              — figures last changed {formattedDate}
+            </time>
           </button>
         }
       />
       <PopoverContent className="w-auto max-w-64 space-y-1.5">
         <p className="text-sm font-medium">
-          Rates &amp; thresholds as of{" "}
-          <time dateTime={LAST_UPDATED}>{formattedDate}</time>
+          Checked against GOV.UK and the Bank of England every morning.
         </p>
         <p className="text-sm text-muted-foreground">
-          Verified daily against GOV.UK and the Bank of England.
+          Figures last changed{" "}
+          <time dateTime={LAST_UPDATED}>{formattedDate}</time>.
         </p>
         <Link
           href="/our-data"

--- a/src/components/our-data/OurDataPage.tsx
+++ b/src/components/our-data/OurDataPage.tsx
@@ -11,6 +11,7 @@ import {
   MetricReadout,
 } from "@/components/instrument/MetricReadout";
 import { Panel, PanelHeader } from "@/components/instrument/Panel";
+import { VerifiedAgo } from "@/components/instrument/VerifiedAgo";
 import { PageLayout } from "@/components/layout/PageLayout";
 import { Heading } from "@/components/typography/Heading";
 import {
@@ -171,22 +172,37 @@ export function OurDataPage() {
             <p className="max-w-[68ch] text-lead text-muted-foreground">
               Our calculators run on the official figures published by GOV.UK,
               the Bank of England, and the ONS. An automated job re-checks them
-              every day&nbsp;&mdash; if a number moves, the model updates within
-              24 hours.
+              every day and refreshes the model whenever a figure changes.
             </p>
           </div>
-          <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 border-t border-border pt-4">
-            <span className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
-              Last verified
+          <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5 border-t border-border pt-4 text-meta text-muted-foreground">
+            <span className="inline-flex items-center gap-2 font-medium text-foreground">
+              <span
+                className="size-1.5 shrink-0 rounded-full bg-primary"
+                aria-hidden="true"
+              />
+              <VerifiedAgo />
             </span>
-            <time
-              dateTime={LAST_UPDATED}
-              className="font-mono text-sm font-semibold tracking-tight text-cta tabular-nums"
-            >
-              {formattedLastUpdated}
-            </time>
-            <span className="text-sm text-muted-foreground">
-              · {TAX_YEAR} tax year
+            <span className="text-faint" aria-hidden="true">
+              ·
+            </span>
+            <span>
+              Last changed{" "}
+              <time
+                dateTime={LAST_UPDATED}
+                className="font-medium text-foreground tabular-nums"
+              >
+                {formattedLastUpdated}
+              </time>
+            </span>
+            <span className="text-faint" aria-hidden="true">
+              ·
+            </span>
+            <span>
+              <span className="font-medium text-foreground tabular-nums">
+                {TAX_YEAR}
+              </span>{" "}
+              tax year
             </span>
           </div>
         </header>

--- a/src/lib/dataFreshness.test.ts
+++ b/src/lib/dataFreshness.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CHECK_HOUR_UTC,
+  formatAgo,
+  hoursSinceLastCheck,
+} from "./dataFreshness";
+
+describe("hoursSinceLastCheck", () => {
+  it("counts from today's 07:00 UTC once it has passed", () => {
+    // 13:00 UTC, same day → 6h since the 07:00 run.
+    expect(hoursSinceLastCheck(new Date("2026-07-22T13:00:00Z"))).toBe(6);
+  });
+
+  it("is 0 exactly at the scheduled run time", () => {
+    expect(hoursSinceLastCheck(new Date("2026-07-22T07:00:00Z"))).toBe(0);
+  });
+
+  it("floors partial hours", () => {
+    // 1h30m after the run → floored to 1.
+    expect(hoursSinceLastCheck(new Date("2026-07-22T08:30:00Z"))).toBe(1);
+  });
+
+  it("falls back to yesterday's run before today's 07:00", () => {
+    // 06:59 UTC → last run was yesterday 07:00, i.e. 23h ago.
+    expect(hoursSinceLastCheck(new Date("2026-07-22T06:59:00Z"))).toBe(23);
+  });
+
+  it("never exceeds 23 hours (daily cadence)", () => {
+    for (let h = 0; h < 24; h++) {
+      const now = new Date(Date.UTC(2026, 6, 22, h, 30));
+      const result = hoursSinceLastCheck(now);
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThanOrEqual(23);
+    }
+  });
+
+  it("is timezone-independent (duration, not wall-clock)", () => {
+    // Same instant, expressed with an offset, yields the same elapsed hours.
+    const utc = hoursSinceLastCheck(new Date("2026-07-22T13:00:00Z"));
+    const withOffset = hoursSinceLastCheck(
+      new Date("2026-07-22T14:00:00+01:00"),
+    );
+    expect(withOffset).toBe(utc);
+  });
+
+  it("uses the documented 07:00 UTC schedule", () => {
+    expect(CHECK_HOUR_UTC).toBe(7);
+  });
+});
+
+describe("formatAgo", () => {
+  it("formats hours compactly", () => {
+    expect(formatAgo(6)).toBe("6h ago");
+    expect(formatAgo(1)).toBe("1h ago");
+    expect(formatAgo(23)).toBe("23h ago");
+  });
+
+  it("handles the first hour after a check", () => {
+    expect(formatAgo(0)).toBe("<1h ago");
+  });
+});

--- a/src/lib/dataFreshness.ts
+++ b/src/lib/dataFreshness.ts
@@ -1,0 +1,60 @@
+/**
+ * Data-freshness signal derived from the daily GOV.UK figure check.
+ *
+ * The check runs on a GitHub Actions cron at 07:00 UTC every day
+ * (`.github/workflows/check-govuk-figures.yml`). We do not commit a real
+ * "last checked" timestamp — the automation only commits when a figure
+ * *changes* — so we derive "verified X ago" from the known schedule instead:
+ * the most recent 07:00 UTC that has already passed.
+ *
+ * Accepted trade-off: this asserts the *scheduled* run time, not a confirmed
+ * completion. On a day the scrape fails, or GitHub delays/skips the run, the
+ * derived time is optimistic. The workflow opens a tracking issue on failure,
+ * so those days are caught in the repo even though the UI cannot know.
+ */
+
+/**
+ * Hour of day (UTC) the daily figure check is scheduled to run. Must stay in
+ * sync with the cron in `.github/workflows/check-govuk-figures.yml` (`0 7 * * *`)
+ * — the two are not linked, so change both together if the schedule moves.
+ */
+export const CHECK_HOUR_UTC = 7;
+
+/** The most recent scheduled check time (07:00 UTC) at or before `now`. */
+function lastScheduledCheck(now: Date): Date {
+  const candidate = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      CHECK_HOUR_UTC,
+    ),
+  );
+  if (candidate.getTime() > now.getTime()) {
+    // Today's run has not happened yet — the last one was yesterday.
+    candidate.setUTCDate(candidate.getUTCDate() - 1);
+  }
+  return candidate;
+}
+
+/**
+ * Whole hours since the last scheduled check. Always 0–23, because the check
+ * runs daily — so the signal never reads "days ago", reinforcing the cadence.
+ */
+export function hoursSinceLastCheck(now: Date): number {
+  const diffMs = now.getTime() - lastScheduledCheck(now).getTime();
+  return Math.floor(diffMs / 3_600_000);
+}
+
+/**
+ * Relative "X ago" tail for the last check, without a verb — callers prepend
+ * "Verified " in a separate element so it can be hidden on narrow chrome. The
+ * value is always 0–23 hours (daily cadence), so the compact "6h ago" form is
+ * all that is ever rendered.
+ */
+export function formatAgo(hours: number): string {
+  if (hours <= 0) {
+    return "<1h ago";
+  }
+  return `${String(hours)}h ago`;
+}


### PR DESCRIPTION
## Why

The factual student-loan figures are re-checked **every day** by a GitHub Actions cron (07:00 UTC) that scrapes GOV.UK, the Bank of England, and the ONS — but the committed `LAST_UPDATED` constant only advances when a figure actually *changes*. So the glanceable freshness signals were stamping "Updated {Month Year}" / "GOV.UK {Month Year}", which read as months-stale even though the data is verified daily.

This reframes that glanceable signal from a last-*changed* date to a live **"Verified Xh ago"** recency signal, so the everyday-verification story is visible everywhere it matters.

## What changed

The live "Verified Xh ago" label is derived client-side from the known daily 07:00 UTC schedule (the most recent scheduled run). It now appears on the glanceable chrome: the header GOV.UK badge (every page), the homepage hero trust strip, the guides index masthead, and the Our Data freshness row. The last-*changed* date is kept as secondary detail only where it still helps — the badge popover (plus a machine-readable sr-only `<time>`) and Our Data. Prose surfaces (footer, homepage "GOV.UK figures, kept current" rule, Our Data lede) move to durable "checked daily" language.

| Surface | Freshness signal | Last-changed date |
| --- | --- | --- |
| Header GOV.UK badge (all pages) | ✅ live, narrow ("GOV.UK · 14h ago") | popover + sr-only `<time>` |
| Homepage hero trust strip | ✅ live | — |
| Guides index masthead | ✅ live | — |
| Our Data stat row | ✅ live | ✅ shown |
| Footer / homepage rule / Our Data lede | prose "checked daily" | — |

The Our Data freshness row was also rebuilt to fit the house design system: the old row rendered a metadata date in green monospace (violating the "figures-are-mono" rule) under an uppercase eyebrow; it's now a single quiet sans meta-line with a small spruce status dot — freshness primary, last-changed date and tax year secondary.

Implementation notes for accuracy: the relative label renders via `useSyncExternalStore`, so SSR / no-JS show a durable "Verified recently" fallback and the client swaps to the live value with no hydration mismatch; the value is hour-bucketed, and every instance shares a single timer that wakes on the UTC hour boundary. The header badge hides the word "Verified" below `sm` (showing just "GOV.UK · 14h ago") to avoid horizontal page overflow on narrow (~485px) screens.

## Deliberate trade-offs (please don't flag)

1. **Freshness is schedule-derived (client-side), not backed by a confirmed check timestamp.** This asserts the *scheduled* run, not a completed one, so on a day the scrape fails or GitHub delays/skips the cron it is optimistic — documented in `dataFreshness.ts`. The workflow opens a tracking issue on failure. The heavier "persist a real last-checked timestamp + deploy daily" option was explicitly considered and declined as too much.
2. **The relative time depends on the viewer's device clock** — inherent to any client-side "X ago" label.
3. **The hero and guides trust strips intentionally show only "Verified Xh ago"** with no companion last-changed date. That date stays available on the omnipresent header badge (popover + sr-only `<time>`) and on Our Data.

## Follow-up

A separate PR will add **guarded auto-merge** to the daily figures workflow (sanity-bounded checks so routine changes auto-merge and deploy, while suspicious/large ones fall back to human review). That will let the homepage copy return to a stronger "refreshed within 24 hours" claim. This PR deliberately keeps that copy softened ("checked daily … refreshed whenever they change") so it stays accurate until the enforcement lands.