### PR TITLE
fix: detect orca worktrees for session install

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c '[[ \"$CLAUDE_PROJECT_DIR\" == *\".claude/worktrees/\"* ]] || exit 0; [ -L \"$CLAUDE_PROJECT_DIR/node_modules/typescript\" ] && exit 0; cd \"$CLAUDE_PROJECT_DIR\" && pnpm install --prefer-offline'"
+            "command": "bash -c '[[ \"$CLAUDE_PROJECT_DIR\" == *\".claude/worktrees/\"* || -n \"$ORCA_WORKTREE_ID\" ]] || exit 0; [ -L \"$CLAUDE_PROJECT_DIR/node_modules/typescript\" ] && exit 0; cd \"$CLAUDE_PROJECT_DIR\" && pnpm install --prefer-offline'"
           }
         ]
       }


### PR DESCRIPTION
## Why

The `SessionStart` hook in `.claude/settings.json` runs `pnpm install --prefer-offline` so a worktree's dependencies stay in sync when a session starts. It decided whether it was inside a worktree solely by looking for the `.claude/worktrees/<name>` path segment — Claude Code's native worktree layout.

Orca worktrees don't live under that path. They live under `orca/workspaces/...` and are surfaced through the `$ORCA_WORKTREE_ID` environment variable. So inside an Orca worktree the detection fell through, the hook exited early, and the dependency-sync install was silently skipped — leaving the worktree with stale or missing dependencies.

## What changed

The hook now also treats a session as being inside a worktree when `$ORCA_WORKTREE_ID` is set, so the install runs in Orca worktrees too. The existing `.claude/worktrees/` detection and the typescript-symlink short-circuit are unchanged.

## Context

This ports the applicable half of shiqingqi.com PR [#2556](https://github.com/QingqiShi/shiqingqi.com/pull/2556). That PR had two consumers of worktree detection — a dev-server port helper (`scripts/worktree-port.mjs`) and this `SessionStart` install hook. This repo is a single-app project with the dev server and Playwright hardcoded to port 3000 and has no `worktree-port.mjs`, so only the hook change applies here.