### PR TITLE
feat: redesign the which-plan quiz around a single instrument card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ scripts/check-govuk-figures/results/
 # Claude Code worktrees
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+
+# impeccable design-review snapshots (local tooling artifacts)
+.impeccable/

--- a/e2e/quiz-calculator.spec.ts
+++ b/e2e/quiz-calculator.spec.ts
@@ -28,7 +28,7 @@ test.describe("Quiz flow at /which-plan", () => {
     // Answer "No" to postgrad question
     await page.getByRole("radio", { name: /No postgraduate study/ }).click();
     await expect(
-      page.getByRole("heading", { name: "Plan 2", level: 1 }),
+      page.getByRole("heading", { name: "Plan 2", level: 2 }),
     ).toBeVisible();
   });
 
@@ -44,7 +44,7 @@ test.describe("Quiz flow at /which-plan", () => {
 
     await page.getByRole("radio", { name: /No postgraduate study/ }).click();
     await expect(
-      page.getByRole("heading", { name: "Plan 4", level: 1 }),
+      page.getByRole("heading", { name: "Plan 4", level: 2 }),
     ).toBeVisible();
   });
 
@@ -62,7 +62,7 @@ test.describe("Quiz flow at /which-plan", () => {
 
     await page.getByRole("radio", { name: /No postgraduate study/ }).click();
     await expect(
-      page.getByRole("heading", { name: "Plan 5", level: 1 }),
+      page.getByRole("heading", { name: "Plan 5", level: 2 }),
     ).toBeVisible();
   });
 
@@ -84,7 +84,7 @@ test.describe("Quiz flow at /which-plan", () => {
     await page.getByRole("radio", { name: /No postgraduate study/ }).click();
 
     await expect(
-      page.getByRole("heading", { name: "Plan 4", level: 1 }),
+      page.getByRole("heading", { name: "Plan 4", level: 2 }),
     ).toBeVisible();
 
     // Click "Enter your balances" which navigates to home

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -331,14 +331,46 @@ body {
   }
 }
 
-@keyframes quiz-result-enter {
+/* Staggered reveal for the result payoff — each block rises in turn so the
+   answer lands as a considered moment. Drive the cascade with a per-element
+   inline `animation-delay`. Reduced motion collapses to an instant reveal. */
+@keyframes quiz-result-item {
   from {
-    transform: scale(0.95);
+    transform: translateY(12px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@utility animate-quiz-result-item {
+  animation: quiz-result-item 550ms cubic-bezier(0.16, 1, 0.3, 1) both;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+/* The confidence beat: the filled spruce plan badge scales and fades up as the
+   result lands. */
+@keyframes quiz-result-badge {
+  from {
+    transform: scale(0.8);
     opacity: 0;
   }
   to {
     transform: scale(1);
     opacity: 1;
+  }
+}
+
+@utility animate-quiz-result-badge {
+  animation: quiz-result-badge 500ms cubic-bezier(0.16, 1, 0.3, 1) both;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
   }
 }
 
@@ -352,14 +384,6 @@ body {
 
 @utility animate-quiz-slide-in-reverse {
   animation: quiz-slide-in-reverse 200ms ease-out;
-
-  @media (prefers-reduced-motion: reduce) {
-    animation: none;
-  }
-}
-
-@utility animate-quiz-result-enter {
-  animation: quiz-result-enter 300ms ease-out;
 
   @media (prefers-reduced-motion: reduce) {
     animation: none;

--- a/src/app/which-plan/page.tsx
+++ b/src/app/which-plan/page.tsx
@@ -3,107 +3,58 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { Footer } from "@/components/layout/Footer";
 import { Header } from "@/components/layout/Header";
+import { AllPlansTable } from "@/components/plans/AllPlansTable";
 import { QuizContainer } from "@/components/quiz/QuizContainer";
 import { Heading } from "@/components/typography/Heading";
-import { currencyFormatter } from "@/constants";
-import {
-  PLAN_DISPLAY_INFO,
-  POSTGRADUATE_DISPLAY_INFO,
-} from "@/lib/loans/plans";
-import { PLAN_PAGE_ORDER, PLAN_PAGES } from "@/lib/planContent";
-import { surfaceCardInteractive } from "@/lib/surfaces";
+import { PROSE_LINK } from "@/lib/layout";
 import { cn } from "@/lib/utils";
-
-const DISPLAY_BY_KEY = {
-  PLAN_1: PLAN_DISPLAY_INFO.PLAN_1,
-  PLAN_2: PLAN_DISPLAY_INFO.PLAN_2,
-  PLAN_4: PLAN_DISPLAY_INFO.PLAN_4,
-  PLAN_5: PLAN_DISPLAY_INFO.PLAN_5,
-  POSTGRADUATE: POSTGRADUATE_DISPLAY_INFO,
-} as const;
 
 export default function WhichPlanPage() {
   return (
     <div className="flex min-h-screen flex-col">
       <Header />
       <main id="main-content" className="flex-1">
-        <QuizContainer standalone />
-        <section className="border-t border-border">
-          <div className="mx-auto max-w-4xl px-3 py-12">
-            <div className="mb-8 text-center">
-              <Heading as="h2" size="section">
-                All UK Student Loan Plans
+        {/* Primary task. A dominant hero names the job, then the quiz sits
+            directly beneath as one anchored instrument card — the single focal
+            object on the page. */}
+        <section className="mx-auto w-full max-w-lg px-4 pt-12 pb-16 sm:pt-16 sm:pb-24">
+          <div className="text-center">
+            <Heading as="h1" size="page-hero">
+              Which student loan plan am I on?
+            </Heading>
+            <p className="mx-auto mt-4 max-w-md text-pretty text-muted-foreground">
+              Answer a few quick questions — we&apos;ll match you to Plan 1, 2,
+              4, 5 or Postgraduate and show this year&apos;s repayment figures.
+            </p>
+          </div>
+          <div className="mt-8 sm:mt-10">
+            <QuizContainer standalone />
+          </div>
+        </section>
+
+        {/* Secondary. A quiet at-a-glance reference, clearly subordinate to the
+            finder: sunk band, a small left-aligned heading (not another centered
+            hero), and the compact comparison table instead of five data cards
+            that each read like a mini result screen. */}
+        <section className="border-t border-border bg-muted/30">
+          <div className="mx-auto max-w-4xl px-4 py-14">
+            <div className="mb-6 max-w-prose">
+              <Heading as="h2" size="subsection">
+                All UK student loan plans at a glance
               </Heading>
-              <p className="mt-2 text-muted-foreground">
-                A quick reference for every UK student loan plan type —
-                thresholds, repayment rates, and write-off periods at a glance.
-                Tap any plan for the full breakdown.
+              <p className="mt-1 text-sm text-muted-foreground">
+                Prefer to browse? Thresholds, repayment rates and write-off
+                periods for every plan. Select a plan for the full breakdown.
               </p>
             </div>
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {PLAN_PAGE_ORDER.map((key) => {
-                const plan = DISPLAY_BY_KEY[key];
-                const slug = PLAN_PAGES[key].slug;
-                return (
-                  <Link
-                    key={key}
-                    href={`/plans/${slug}`}
-                    className="group block h-full"
-                  >
-                    <div
-                      className={cn(
-                        surfaceCardInteractive,
-                        "flex h-full flex-col p-5",
-                      )}
-                    >
-                      <Heading as="h3" size="subsection">
-                        {plan.name}
-                      </Heading>
-                      <p className="mt-1 text-sm text-muted-foreground">
-                        {plan.description}
-                      </p>
-                      <dl className="mt-4 space-y-2 text-sm">
-                        <div className="flex items-baseline justify-between gap-2">
-                          <dt className="text-muted-foreground">Threshold</dt>
-                          <dd className="font-mono font-semibold tabular-nums">
-                            {currencyFormatter.format(plan.yearlyThreshold)}
-                            <span className="font-sans text-xs font-normal text-muted-foreground">
-                              /yr
-                            </span>
-                          </dd>
-                        </div>
-                        <div className="flex items-baseline justify-between gap-2">
-                          <dt className="text-muted-foreground">Rate</dt>
-                          <dd className="font-mono font-semibold tabular-nums">
-                            {String(plan.repaymentRate * 100)}%
-                          </dd>
-                        </div>
-                        <div className="flex items-baseline justify-between gap-2">
-                          <dt className="text-muted-foreground">Write-off</dt>
-                          <dd className="font-mono font-semibold tabular-nums">
-                            {String(plan.writeOffYears)}
-                            <span className="ml-1 font-sans text-xs font-normal text-muted-foreground">
-                              years
-                            </span>
-                          </dd>
-                        </div>
-                      </dl>
-                      <div className="mt-4 flex items-center gap-1.5 border-t border-border pt-3 text-xs font-semibold tracking-wider text-cta uppercase">
-                        {plan.name} explained
-                        <HugeiconsIcon
-                          icon={ArrowRight01Icon}
-                          className="size-3.5 transition-transform group-hover:translate-x-0.5"
-                        />
-                      </div>
-                    </div>
-                  </Link>
-                );
-              })}
-            </div>
-            <div className="mt-8 text-center">
+            <p className="mb-2 text-xs text-muted-foreground sm:hidden">
+              Swipe the table sideways to see rate and write-off →
+            </p>
+            <AllPlansTable />
+            <div className="mt-6">
               <Link
                 href="/plans"
-                className="inline-flex items-center gap-1 text-sm font-medium text-cta underline underline-offset-4 hover:text-cta/80"
+                className={cn(PROSE_LINK, "inline-flex items-center gap-1")}
               >
                 Compare all UK student loan plans
                 <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />

--- a/src/components/quiz/AdditionalCourseQuestion.tsx
+++ b/src/components/quiz/AdditionalCourseQuestion.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
-import type { Region, StartYearGroup } from "@/lib/quiz/determinePlan";
-import { getAdditionalCoursePlan } from "@/lib/quiz/determinePlan";
+import type { StartYearGroup } from "@/lib/quiz/determinePlan";
 import { OptionCard } from "./OptionCard";
+import { OptionGroup } from "./OptionGroup";
 import { QuestionStep } from "./QuestionStep";
 
 interface AdditionalCourseQuestionProps {
@@ -11,7 +10,6 @@ interface AdditionalCourseQuestionProps {
   selectedValue: boolean | null;
   direction: "forward" | "backward";
   yearGroup: StartYearGroup;
-  region: Region;
 }
 
 export function AdditionalCourseQuestion({
@@ -19,23 +17,19 @@ export function AdditionalCourseQuestion({
   selectedValue,
   direction,
   yearGroup,
-  region,
 }: AdditionalCourseQuestionProps) {
   const dateLabel =
     yearGroup === "before-2012" ? "September 2012" : "August 2023";
-  const additionalPlanType = getAdditionalCoursePlan(yearGroup, region);
-  const planLabel = PLAN_DISPLAY_INFO[additionalPlanType].name;
 
   return (
     <QuestionStep
       title={`Did you start another course after ${dateLabel}?`}
-      subtitle={`Starting another course after this date means an additional ${planLabel} loan`}
+      subtitle="Only if you began a second, separate course. Most people answer No."
       direction={direction}
     >
-      <div
+      <OptionGroup
+        label="Did you start another course?"
         className="flex flex-col gap-3"
-        role="radiogroup"
-        aria-label="Did you start another course?"
       >
         <OptionCard
           label="Yes"
@@ -53,7 +47,7 @@ export function AdditionalCourseQuestion({
             onSelect(false);
           }}
         />
-      </div>
+      </OptionGroup>
     </QuestionStep>
   );
 }

--- a/src/components/quiz/OptionCard.tsx
+++ b/src/components/quiz/OptionCard.tsx
@@ -25,17 +25,19 @@ export function OptionCard({
       type="button"
       role={variant}
       aria-checked={isSelected}
+      aria-label={sublabel ? `${label}, ${sublabel}` : label}
       onClick={onClick}
       className={cn(
         "group relative flex size-full min-h-18 items-center gap-4 rounded-xl px-5 py-4 text-left ring-1 transition-colors duration-150",
         "focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none focus-visible:ring-inset",
         isSelected
           ? "bg-accent-wash ring-primary"
-          : "bg-card ring-border hover:bg-muted",
+          : "bg-card ring-input hover:bg-muted",
       )}
     >
       {icon && (
         <div
+          aria-hidden="true"
           className={cn(
             "flex size-10 shrink-0 items-center justify-center rounded-lg text-lg ring-1 transition-colors",
             isSelected
@@ -67,7 +69,7 @@ export function OptionCard({
         <div
           className={cn(
             "size-5 shrink-0 rounded-full ring-2 transition-colors",
-            isSelected ? "bg-primary ring-primary" : "ring-border",
+            isSelected ? "bg-primary ring-primary" : "ring-input",
           )}
         >
           {isSelected && (
@@ -89,7 +91,7 @@ export function OptionCard({
         <div
           className={cn(
             "flex size-5 shrink-0 items-center justify-center rounded-md ring-2 transition-colors",
-            isSelected ? "bg-primary ring-primary" : "ring-border",
+            isSelected ? "bg-primary ring-primary" : "ring-input",
           )}
         >
           {isSelected && (

--- a/src/components/quiz/OptionGroup.tsx
+++ b/src/components/quiz/OptionGroup.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+interface OptionGroupProps {
+  /** Accessible name for the group of options. */
+  label: string;
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * A `role="radiogroup"` wrapper that gives a set of `OptionCard` radios a single
+ * accessible name — the same grouping the wizard steps apply inline. Choosing an
+ * option immediately advances the quiz, so the options are plain Tab stops like
+ * every other radiogroup in the app; we deliberately don't add roving tabindex or
+ * arrow-to-select, which assume a review-then-submit group and would fight the
+ * auto-advance (arrowing onto an option would commit it and jump to the next step).
+ */
+export function OptionGroup({ label, children, className }: OptionGroupProps) {
+  return (
+    <div role="radiogroup" aria-label={label} className={className}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/quiz/PostgradQuestion.tsx
+++ b/src/components/quiz/PostgradQuestion.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { OptionCard } from "./OptionCard";
+import { OptionGroup } from "./OptionGroup";
 import { QuestionStep } from "./QuestionStep";
 
 type PostgradAnswer = "loan" | "self-funded" | "no";
@@ -43,11 +44,7 @@ export function PostgradQuestion({
       title="Did you go on to study a Master's or PhD?"
       direction={direction}
     >
-      <div
-        className="flex flex-col gap-3"
-        role="radiogroup"
-        aria-label="Postgraduate study"
-      >
+      <OptionGroup label="Postgraduate study" className="flex flex-col gap-3">
         {OPTIONS.map((option) => (
           <OptionCard
             key={option.value}
@@ -59,7 +56,7 @@ export function PostgradQuestion({
             }}
           />
         ))}
-      </div>
+      </OptionGroup>
     </QuestionStep>
   );
 }

--- a/src/components/quiz/QuestionStep.tsx
+++ b/src/components/quiz/QuestionStep.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { useId } from "react";
 import { Heading } from "@/components/typography/Heading";
 
 interface QuestionStepProps {
@@ -16,6 +17,7 @@ export function QuestionStep({
   children,
   direction,
 }: QuestionStepProps) {
+  const subtitleId = useId();
   return (
     <div
       className={
@@ -23,14 +25,29 @@ export function QuestionStep({
           ? "animate-quiz-slide-in-reverse"
           : "animate-quiz-slide-in"
       }
-      aria-live="polite"
     >
       <div className="mb-8 text-center">
-        <Heading as="h1" size="section">
+        {/* `data-step-heading` + tabIndex let QuizContainer move focus here on
+            each step change, so keyboard/SR users land on the new question
+            instead of being dropped back to <body>. `aria-describedby` ties the
+            subtitle to the heading so the screen reader also reads the
+            disambiguating hint (e.g. "the year you began, not graduated") when
+            focus lands — it's no longer inside a live region. */}
+        <Heading
+          as="h2"
+          size="section"
+          data-step-heading
+          tabIndex={-1}
+          aria-describedby={subtitle ? subtitleId : undefined}
+          className="outline-none"
+        >
           {title}
         </Heading>
         {subtitle && (
-          <p className="mt-2 text-sm text-muted-foreground md:text-base">
+          <p
+            id={subtitleId}
+            className="mt-2 text-sm text-muted-foreground md:text-base"
+          >
             {subtitle}
           </p>
         )}

--- a/src/components/quiz/QuizContainer.tsx
+++ b/src/components/quiz/QuizContainer.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useReducer, useRef } from "react";
+import { useEffect, useReducer, useRef } from "react";
 import {
   trackQuizStarted,
   trackQuizRegionSelected,
   trackQuizYearSelected,
   trackQuizBackClicked,
+  trackQuizCompleted,
 } from "@/lib/analytics";
 import type { PlanType } from "@/lib/loans/types";
 import type {
@@ -18,7 +19,10 @@ import {
   canSkipStartYear,
   determineAllLoans,
   shouldAskAboutAdditionalCourse,
+  summariseQuizAnswers,
 } from "@/lib/quiz/determinePlan";
+import { surfaceCard } from "@/lib/surfaces";
+import { cn } from "@/lib/utils";
 import { AdditionalCourseQuestion } from "./AdditionalCourseQuestion";
 import { PostgradQuestion } from "./PostgradQuestion";
 import { QuizProgress } from "./QuizProgress";
@@ -32,6 +36,7 @@ type QuizAction =
   | { type: "SET_ADDITIONAL_COURSE"; payload: boolean }
   | { type: "SET_POSTGRAD"; payload: "loan" | "self-funded" | "no" }
   | { type: "GO_BACK" }
+  | { type: "EDIT_ANSWERS" }
   | { type: "RESTART" };
 
 const initialState: QuizState = {
@@ -81,6 +86,12 @@ function quizReducer(state: QuizState, action: QuizAction): QuizState {
       const nextStep = state.region
         ? getNextStepAfterYear(state.region, yearGroup)
         : ("postgrad" as QuizStep);
+      // Preserve hasAdditionalCourse even when the new path skips that step:
+      // determineAllLoans/summariseQuizAnswers already gate it behind
+      // shouldAskAboutAdditionalCourse (via includesAdditionalCourseLoan), so a
+      // stale "yes" can't leak a phantom loan into the result — and keeping it
+      // means editing the year back restores the earlier answer, as the edit
+      // flow promises.
       return {
         ...state,
         startYearGroup: yearGroup,
@@ -138,6 +149,11 @@ function quizReducer(state: QuizState, action: QuizAction): QuizState {
           return state;
       }
     }
+    case "EDIT_ANSWERS":
+      // Re-enter the quiz from the first question with every answer preserved,
+      // so the result's "Change your answers" honestly lets the user revise any
+      // of them (the flow has no per-answer jump). Reverse-slide like a back step.
+      return { ...state, currentStep: "region", direction: "backward" };
     case "RESTART":
       return initialState;
     default:
@@ -176,10 +192,10 @@ interface QuizContainerProps {
   /** When provided, shows a close button to exit the quiz from any step */
   onClose?: () => void;
   /**
-   * Rendered inline on the /which-plan page (below the site masthead) rather
-   * than filling a modal: caps the question stage well under the viewport so
-   * the card is not stranded in a full-height void, and lets the masthead be
-   * the sticky element instead of the progress bar.
+   * Rendered inline on the /which-plan page (below the page hero) rather than
+   * filling a modal: the quiz flows in its parent column with no full-height
+   * centering void, the progress rail renders flush to that column instead of
+   * as full-width chrome, and the masthead is the sticky element.
    */
   standalone?: boolean;
 }
@@ -192,6 +208,47 @@ export function QuizContainer({
 }: QuizContainerProps) {
   const [state, dispatch] = useReducer(quizReducer, initialState);
   const hasStartedRef = useRef(false);
+
+  // The loans the current answers resolve to — derived once and shared by the
+  // completion effect, the result render, and the "use these loans" handler.
+  const currentLoans = determineAllLoans(state);
+
+  // Accessibility: on every step change (but not the initial mount), move focus
+  // to the new step's heading. Without this, selecting an option unmounts the
+  // current step and focus falls back to <body>, stranding keyboard/SR users at
+  // the top of the document; landing on the heading also makes the screen reader
+  // announce the new question or result. Plain focus() (no preventScroll) lets
+  // the browser bring the heading into view when it's scrolled off — important on
+  // the standalone page, where the card can sit below the fold.
+  const stepRegionRef = useRef<HTMLDivElement>(null);
+  const prevStepRef = useRef<QuizStep | null>(null);
+  useEffect(() => {
+    const prev = prevStepRef.current;
+    prevStepRef.current = state.currentStep;
+    // Focus only on a real step transition — not the initial mount, and not
+    // StrictMode's dev-only setup→cleanup→setup remount (same step both times),
+    // which would otherwise focus and scroll to the first question on load.
+    if (prev === null || prev === state.currentStep) return;
+    stepRegionRef.current
+      ?.querySelector<HTMLElement>("[data-step-heading]")
+      ?.focus();
+  }, [state.currentStep]);
+
+  // Record a completion whenever the reached result differs from the one last
+  // recorded. A no-op "Change your answers" round-trip that lands on the same
+  // plans doesn't re-count; an edit that changes the outcome records the
+  // corrected plans, so the latest event is always the user's final result.
+  // Toggling between two outcomes re-reports each change — deliberately keeping
+  // attribution correct at the cost of a little over-counting; restart re-arms.
+  const lastCompletedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (state.currentStep !== "result") return;
+    const result = currentLoans.join(",");
+    if (lastCompletedRef.current !== result) {
+      lastCompletedRef.current = result;
+      trackQuizCompleted(result);
+    }
+  }, [state.currentStep, currentLoans]);
 
   const handleRegionSelect = (region: Region) => {
     if (!hasStartedRef.current) {
@@ -222,13 +279,20 @@ export function QuizContainer({
 
   const handleRestart = () => {
     hasStartedRef.current = false;
+    lastCompletedRef.current = null;
     dispatch({ type: "RESTART" });
+  };
+
+  // Distinct from the progress back-arrow: this rewinds all the way to the first
+  // question (keeping answers) rather than one step, and it must not emit the
+  // step-scoped quiz_back_clicked event (the result has no valid step index).
+  const handleEditAnswers = () => {
+    dispatch({ type: "EDIT_ANSWERS" });
   };
 
   const handleUseLoans = () => {
     if (onLoansDiscovered) {
-      const planTypes = determineAllLoans(state);
-      onLoansDiscovered(planTypes);
+      onLoansDiscovered(currentLoans);
     }
   };
 
@@ -238,76 +302,87 @@ export function QuizContainer({
 
   const backHandler = canGoBack ? handleBack : onBack;
 
-  return (
-    <div
-      className={
-        standalone
-          ? "flex flex-col bg-background"
-          : "flex min-h-dvh flex-col bg-background"
-      }
-    >
-      {showProgress && (
-        <QuizProgress
-          currentStep={currentStepIndex}
-          totalSteps={TOTAL_STEPS}
-          onBack={backHandler}
-          onClose={onClose}
-          sticky={!standalone}
+  const progress = showProgress ? (
+    <QuizProgress
+      currentStep={currentStepIndex}
+      totalSteps={TOTAL_STEPS}
+      onBack={backHandler}
+      onClose={onClose}
+      sticky={!standalone}
+      flush={standalone}
+    />
+  ) : null;
+
+  const stepContent = (
+    <>
+      {state.currentStep === "region" && (
+        <RegionQuestion
+          onSelect={handleRegionSelect}
+          selectedValue={state.region}
+          direction={state.direction}
         />
       )}
 
-      <div
-        className={
-          standalone
-            ? "flex min-h-96 flex-col items-center justify-center px-4 py-12"
-            : "flex flex-1 flex-col items-center justify-center px-4 py-8"
-        }
-      >
-        <div className="w-full max-w-lg">
-          {state.currentStep === "region" && (
-            <RegionQuestion
-              onSelect={handleRegionSelect}
-              selectedValue={state.region}
-              direction={state.direction}
-            />
-          )}
+      {state.currentStep === "start-year" && (
+        <StartYearQuestion
+          onSelect={handleStartYearSelect}
+          selectedValue={state.startYearGroup}
+          direction={state.direction}
+        />
+      )}
 
-          {state.currentStep === "start-year" && (
-            <StartYearQuestion
-              onSelect={handleStartYearSelect}
-              selectedValue={state.startYearGroup}
-              direction={state.direction}
-            />
-          )}
+      {state.currentStep === "additional-course" && state.startYearGroup && (
+        <AdditionalCourseQuestion
+          onSelect={handleAdditionalCourseSelect}
+          selectedValue={state.hasAdditionalCourse}
+          direction={state.direction}
+          yearGroup={state.startYearGroup}
+        />
+      )}
 
-          {state.currentStep === "additional-course" &&
-            state.startYearGroup &&
-            state.region && (
-              <AdditionalCourseQuestion
-                onSelect={handleAdditionalCourseSelect}
-                selectedValue={state.hasAdditionalCourse}
-                direction={state.direction}
-                yearGroup={state.startYearGroup}
-                region={state.region}
-              />
-            )}
+      {state.currentStep === "postgrad" && (
+        <PostgradQuestion
+          onSelect={handlePostgradSelect}
+          selectedValue={state.postgradAnswer}
+          direction={state.direction}
+        />
+      )}
 
-          {state.currentStep === "postgrad" && (
-            <PostgradQuestion
-              onSelect={handlePostgradSelect}
-              selectedValue={state.postgradAnswer}
-              direction={state.direction}
-            />
-          )}
+      {state.currentStep === "result" && state.region && (
+        <ResultScreen
+          planTypes={currentLoans}
+          recap={summariseQuizAnswers(state)}
+          onRestart={handleRestart}
+          onEditAnswers={handleEditAnswers}
+          onUseLoans={onLoansDiscovered ? handleUseLoans : undefined}
+        />
+      )}
+    </>
+  );
 
-          {state.currentStep === "result" && state.region && (
-            <ResultScreen
-              planTypes={determineAllLoans(state)}
-              onRestart={handleRestart}
-              direction={state.direction}
-              onUseLoans={onLoansDiscovered ? handleUseLoans : undefined}
-            />
-          )}
+  // Standalone: the quiz is a single anchored instrument — one card holds the
+  // progress rail (a header seam) and the active step, so the whole thing reads
+  // as one focal object with clear internal hierarchy instead of a stack of
+  // free-floating elements.
+  if (standalone) {
+    return (
+      <div className={cn(surfaceCard, "overflow-hidden")}>
+        {progress && (
+          <div className="border-b border-border px-5 sm:px-7">{progress}</div>
+        )}
+        <div ref={stepRegionRef} className="px-5 py-8 sm:px-7 sm:py-10">
+          {stepContent}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-dvh flex-col bg-background">
+      {progress}
+      <div className="flex flex-1 flex-col items-center justify-center px-4 py-8">
+        <div ref={stepRegionRef} className="w-full max-w-lg">
+          {stepContent}
         </div>
       </div>
     </div>

--- a/src/components/quiz/QuizProgress.tsx
+++ b/src/components/quiz/QuizProgress.tsx
@@ -16,6 +16,10 @@ interface QuizProgressProps {
   /** Stick to the top of the scroll container (modal). Off on the standalone
    * page, where the site masthead is the sticky element instead. */
   sticky?: boolean;
+  /** Render as an in-column rail rather than full-width page chrome: drops the
+   * full-bleed divider, background and inner measure so the bar aligns to the
+   * quiz column it sits inside. Used on the standalone /which-plan page. */
+  flush?: boolean;
 }
 
 export function QuizProgress({
@@ -26,6 +30,7 @@ export function QuizProgress({
   closeIcon = Cancel01Icon,
   closeLabel = "Exit quiz",
   sticky = true,
+  flush = false,
 }: QuizProgressProps) {
   const stepNumber = Math.min(currentStep + 1, totalSteps);
   const fillPercent = (stepNumber / totalSteps) * 100;
@@ -33,11 +38,16 @@ export function QuizProgress({
   return (
     <div
       className={cn(
-        "z-10 border-b border-border bg-background",
+        !flush && "z-10 border-b border-border bg-background",
         sticky && "sticky top-0",
       )}
     >
-      <div className="mx-auto flex max-w-lg items-center gap-3 px-4 py-3">
+      <div
+        className={cn(
+          "flex items-center gap-3 py-3",
+          flush ? "w-full" : "mx-auto max-w-lg px-4",
+        )}
+      >
         <div className="w-10 shrink-0">
           {onBack && (
             <Button

--- a/src/components/quiz/RegionQuestion.tsx
+++ b/src/components/quiz/RegionQuestion.tsx
@@ -2,6 +2,7 @@
 
 import type { Region } from "@/lib/quiz/determinePlan";
 import { OptionCard } from "./OptionCard";
+import { OptionGroup } from "./OptionGroup";
 import { QuestionStep } from "./QuestionStep";
 
 interface RegionQuestionProps {
@@ -51,10 +52,9 @@ export function RegionQuestion({
       subtitle="The UK nation where your university was located"
       direction={direction}
     >
-      <div
+      <OptionGroup
+        label="Select where you studied"
         className="grid grid-cols-1 gap-3 xs:grid-cols-2"
-        role="radiogroup"
-        aria-label="Select where you studied"
       >
         {REGION_OPTIONS.map((option) => (
           <OptionCard
@@ -71,7 +71,7 @@ export function RegionQuestion({
             }}
           />
         ))}
-      </div>
+      </OptionGroup>
     </QuestionStep>
   );
 }

--- a/src/components/quiz/ResultScreen.tsx
+++ b/src/components/quiz/ResultScreen.tsx
@@ -1,17 +1,17 @@
 "use client";
 
+import { ArrowLeft01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
-import { useEffect } from "react";
-import {
-  MetricCell,
-  MetricReadout,
-} from "@/components/instrument/MetricReadout";
+import { useId } from "react";
+import { MetricReadout } from "@/components/instrument/MetricReadout";
 import { Eyebrow } from "@/components/typography/Eyebrow";
+import { Figure } from "@/components/typography/Figure";
 import { Heading } from "@/components/typography/Heading";
 import { Button } from "@/components/ui/button";
 import { currencyFormatter } from "@/constants";
 import { useLoanActions } from "@/context/LoanContext";
-import { trackQuizCompleted, trackQuizRestarted } from "@/lib/analytics";
+import { trackQuizRestarted } from "@/lib/analytics";
 import {
   PLAN_DISPLAY_INFO,
   POSTGRADUATE_DISPLAY_INFO,
@@ -25,24 +25,45 @@ function getPlanDisplayInfo(planType: PlanType) {
   return PLAN_DISPLAY_INFO[planType];
 }
 
+/**
+ * One cell of the result's {@link MetricReadout}. Kept local rather than using
+ * `MetricCell` because of the phone layout: the three cells stack as a
+ * label-left / value-right spec list (a 7-glyph mono figure like "£26,892" can't
+ * survive a ~100px column), then revert to a stacked 3-up grid at `sm`. The label
+ * and figure treatment mirrors `MetricCell`'s.
+ */
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3 bg-card px-4 py-3.5 sm:block">
+      <span className="block font-sans text-xs font-semibold tracking-label text-muted-foreground uppercase">
+        {label}
+      </span>
+      <span className="block font-mono text-xl font-semibold tracking-tight text-foreground tabular-nums sm:mt-1.5">
+        <Figure value={value} />
+      </span>
+    </div>
+  );
+}
+
 interface ResultScreenProps {
   planTypes: PlanType[];
+  /** Human-readable recap of the answers that led here, e.g. ["England", …]. */
+  recap: string[];
   onRestart: () => void;
-  direction: "forward" | "backward";
+  /** Re-enter the quiz from the first question (answers preserved) to revise. */
+  onEditAnswers: () => void;
   onUseLoans?: () => void;
 }
 
 export function ResultScreen({
   planTypes,
+  recap,
   onRestart,
-  direction,
+  onEditAnswers,
   onUseLoans,
 }: ResultScreenProps) {
   const { updateField } = useLoanActions();
-
-  useEffect(() => {
-    trackQuizCompleted(planTypes.join(","));
-  }, [planTypes]);
+  const recapId = useId();
 
   const handleRestart = () => {
     trackQuizRestarted();
@@ -53,43 +74,94 @@ export function ResultScreen({
     updateField("pendingQuizPlanTypes", planTypes);
   }
 
+  const names = planTypes.map((p) => getPlanDisplayInfo(p).name);
+  const isMulti = names.length > 1;
+  // Natural-language join so a combined result reads as prose, not arithmetic:
+  // "Plan 2, Plan 5 & Postgraduate" rather than "Plan 2 + Plan 5 + Postgraduate".
+  const joinedNames = isMulti
+    ? `${names.slice(0, -1).join(", ")} & ${names[names.length - 1]}`
+    : names[0];
+
+  // Staggered reveal: each block rises in turn (see globals.css). Delays step
+  // through the badge → eyebrow → answer → recap → readouts → actions.
+  const delay = (ms: number) => ({ animationDelay: `${String(ms)}ms` });
+  const readoutStart = 260;
+  const actionsDelay = readoutStart + planTypes.length * 80 + 40;
+
   return (
-    <div
-      className={
-        direction === "backward"
-          ? "animate-quiz-slide-in-reverse"
-          : "animate-quiz-result-enter"
-      }
-      aria-live="polite"
-    >
+    <>
       <div className="text-center">
-        <Eyebrow as="p" marker={false} className="mb-3 justify-center">
-          {planTypes.length === 1 ? "Your plan type" : "Your plan types"}
+        <div
+          className="mx-auto mb-5 flex size-14 animate-quiz-result-badge items-center justify-center rounded-full bg-primary text-primary-foreground"
+          aria-hidden="true"
+        >
+          <HugeiconsIcon
+            icon={Tick02Icon}
+            className="size-7"
+            strokeWidth={2.5}
+          />
+        </div>
+
+        <Eyebrow
+          as="p"
+          marker={false}
+          className="animate-quiz-result-item justify-center"
+          style={delay(60)}
+        >
+          {isMulti ? "Your plan types" : "Your plan type"}
         </Eyebrow>
 
-        <Heading as="h1" size="page-hero" className="mb-2">
-          {planTypes.map((p) => getPlanDisplayInfo(p).name).join(" + ")}
+        <Heading
+          as="h2"
+          size="page"
+          data-step-heading
+          tabIndex={-1}
+          aria-describedby={recap.length > 0 ? recapId : undefined}
+          className="mt-2 animate-quiz-result-item outline-none"
+          style={delay(130)}
+        >
+          {joinedNames}
         </Heading>
+
+        {recap.length > 0 && (
+          <p
+            id={recapId}
+            className="mx-auto mt-3 max-w-sm animate-quiz-result-item text-sm text-muted-foreground"
+            style={delay(200)}
+          >
+            Matched from your answers: {recap.join(" · ")}
+          </p>
+        )}
       </div>
 
-      <div className="mt-8 space-y-6">
-        {planTypes.map((planType) => {
+      <div className="mt-7 space-y-4">
+        {planTypes.map((planType, idx) => {
           const info = getPlanDisplayInfo(planType);
           return (
-            <div key={planType} className="space-y-3">
-              <Heading as="h2" size="subsection">
-                {info.name}
-              </Heading>
+            <div
+              key={planType}
+              className="animate-quiz-result-item"
+              style={delay(readoutStart + idx * 80)}
+            >
+              {/* Only label each block when there are several loans to tell
+                  apart — for a single plan the heading above already names it.
+                  An h3 (under the result's h2) keeps each loan reachable by
+                  screen-reader heading navigation. */}
+              {isMulti && (
+                <Heading as="h3" size="subsection" className="mb-2">
+                  {info.name}
+                </Heading>
+              )}
               <MetricReadout columns={3}>
-                <MetricCell
+                <Stat
                   label="Threshold / yr"
                   value={currencyFormatter.format(info.yearlyThreshold)}
                 />
-                <MetricCell
+                <Stat
                   label="Repayment rate"
                   value={`${String(info.repaymentRate * 100)}%`}
                 />
-                <MetricCell
+                <Stat
                   label="Write-off / yrs"
                   value={String(info.writeOffYears)}
                 />
@@ -99,15 +171,18 @@ export function ResultScreen({
         })}
       </div>
 
-      <div className="mt-8 space-y-3">
+      <div
+        className="mt-8 animate-quiz-result-item space-y-4"
+        style={delay(actionsDelay)}
+      >
         {onUseLoans ? (
-          <Button size="lg" className="w-full" onClick={onUseLoans}>
+          <Button size="lg" className="min-h-11 w-full" onClick={onUseLoans}>
             Use these loans →
           </Button>
         ) : (
           <Button
             size="lg"
-            className="w-full"
+            className="min-h-11 w-full"
             render={<Link href="/" />}
             nativeButton={false}
             onClick={handleStandaloneClick}
@@ -116,14 +191,27 @@ export function ResultScreen({
           </Button>
         )}
 
-        <button
-          type="button"
-          onClick={handleRestart}
-          className="w-full py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-        >
-          Not sure? Take the quiz again
-        </button>
+        <div className="flex items-center justify-center gap-2 text-sm">
+          <button
+            type="button"
+            onClick={onEditAnswers}
+            className="inline-flex items-center gap-1 p-2 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+            Change your answers
+          </button>
+          <span aria-hidden="true" className="text-faint">
+            ·
+          </span>
+          <button
+            type="button"
+            onClick={handleRestart}
+            className="p-2 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Start over
+          </button>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/quiz/StartYearQuestion.tsx
+++ b/src/components/quiz/StartYearQuestion.tsx
@@ -2,6 +2,7 @@
 
 import type { StartYearGroup } from "@/lib/quiz/determinePlan";
 import { OptionCard } from "./OptionCard";
+import { OptionGroup } from "./OptionGroup";
 import { QuestionStep } from "./QuestionStep";
 
 interface StartYearQuestionProps {
@@ -43,10 +44,9 @@ export function StartYearQuestion({
       subtitle="The academic year you began, not graduated"
       direction={direction}
     >
-      <div
+      <OptionGroup
+        label="Select when you started your course"
         className="flex flex-col gap-3"
-        role="radiogroup"
-        aria-label="Select when you started your course"
       >
         {YEAR_OPTIONS.map((option) => (
           <OptionCard
@@ -59,7 +59,7 @@ export function StartYearQuestion({
             }}
           />
         ))}
-      </div>
+      </OptionGroup>
     </QuestionStep>
   );
 }

--- a/src/lib/quiz/determinePlan.test.ts
+++ b/src/lib/quiz/determinePlan.test.ts
@@ -5,6 +5,7 @@ import {
   shouldAskAboutAdditionalCourse,
   getAdditionalCoursePlan,
   determineAllLoans,
+  summariseQuizAnswers,
   type QuizAnswers,
   type QuizState,
 } from "./determinePlan";
@@ -318,11 +319,112 @@ describe("determineAllLoans", () => {
     expect(determineAllLoans(state)).toEqual(["PLAN_4"]);
   });
 
+  it("ignores a stale additional-course answer when the current path skips it (edit-answer regression)", () => {
+    // Reachable by editing 2012–2022 + "another course: yes" down to 2023+:
+    // the current path never asks about a second course, so a carried-over
+    // "yes" must not add a duplicate PLAN_5.
+    const state: QuizState = {
+      ...baseState,
+      region: "england",
+      startYearGroup: "2023-or-later",
+      hasAdditionalCourse: true,
+      postgradAnswer: "no",
+    };
+    expect(determineAllLoans(state)).toEqual(["PLAN_5"]);
+  });
+
+  it("collapses duplicate plan types when the additional course maps to the primary plan (Wales 2012-2022)", () => {
+    // Both the primary and the later Welsh course are Plan 2 (Plan 5 is
+    // England-only), so the result must be a single PLAN_2, not a duplicate.
+    const state: QuizState = {
+      ...baseState,
+      region: "wales",
+      startYearGroup: "2012-2022",
+      hasAdditionalCourse: true,
+      postgradAnswer: "no",
+    };
+    expect(determineAllLoans(state)).toEqual(["PLAN_2"]);
+  });
+
   it("returns empty array when region is null", () => {
     const state: QuizState = {
       ...baseState,
       region: null,
     };
     expect(determineAllLoans(state)).toEqual([]);
+  });
+});
+
+describe("summariseQuizAnswers", () => {
+  const baseState: QuizState = {
+    currentStep: "result",
+    region: null,
+    startYearGroup: null,
+    hasAdditionalCourse: null,
+    postgradAnswer: null,
+    direction: "forward",
+  };
+
+  it("summarises region and start year", () => {
+    expect(
+      summariseQuizAnswers({
+        ...baseState,
+        region: "england",
+        startYearGroup: "before-2012",
+      }),
+    ).toEqual(["England", "Started before 2012"]);
+  });
+
+  it("omits the start year for Scotland/NI (skipped) and includes only answered steps", () => {
+    expect(
+      summariseQuizAnswers({
+        ...baseState,
+        region: "scotland",
+        postgradAnswer: "no",
+      }),
+    ).toEqual(["Scotland"]);
+  });
+
+  it("includes a later course and a postgraduate loan when present", () => {
+    expect(
+      summariseQuizAnswers({
+        ...baseState,
+        region: "england",
+        startYearGroup: "2012-2022",
+        hasAdditionalCourse: true,
+        postgradAnswer: "loan",
+      }),
+    ).toEqual([
+      "England",
+      "Started 2012–2022",
+      "Plus a later course",
+      "Postgraduate loan",
+    ]);
+  });
+
+  it("omits 'Plus a later course' when the current path skips that question (edit-answer regression)", () => {
+    expect(
+      summariseQuizAnswers({
+        ...baseState,
+        region: "england",
+        startYearGroup: "2023-or-later",
+        hasAdditionalCourse: true,
+        postgradAnswer: "no",
+      }),
+    ).toEqual(["England", "Started 2023 or later"]);
+  });
+
+  it("omits the postgraduate answer when it adds no plan (self-funded or no)", () => {
+    // Self-funded (like "no") adds no POSTGRADUATE loan, so it must not appear
+    // in the recap of matched plans.
+    expect(
+      summariseQuizAnswers({
+        ...baseState,
+        region: "wales",
+        startYearGroup: "2023-or-later",
+        hasAdditionalCourse: false,
+        postgradAnswer: "self-funded",
+      }),
+    ).toEqual(["Wales", "Started 2023 or later"]);
   });
 });

--- a/src/lib/quiz/determinePlan.ts
+++ b/src/lib/quiz/determinePlan.ts
@@ -107,6 +107,54 @@ export interface QuizState {
 export type QuizStep =
   "region" | "start-year" | "additional-course" | "postgrad" | "result";
 
+const REGION_LABELS: Record<Region, string> = {
+  england: "England",
+  wales: "Wales",
+  scotland: "Scotland",
+  "northern-ireland": "Northern Ireland",
+};
+
+const START_YEAR_LABELS: Record<StartYearGroup, string> = {
+  "before-2012": "Started before 2012",
+  "2012-2022": "Started 2012–2022",
+  "2023-or-later": "Started 2023 or later",
+};
+
+/**
+ * Whether the current answers include a *distinct* additional-course loan: the
+ * user said yes AND the current region/year path still asks the question (a
+ * stale "yes" from an edited-away branch doesn't count). Written once and shared
+ * by the loan derivation and the recap so the two can never disagree. Typed as a
+ * guard so callers get non-null `region`/`startYearGroup` narrowing.
+ */
+function includesAdditionalCourseLoan(
+  state: QuizState,
+): state is QuizState & { region: Region; startYearGroup: StartYearGroup } {
+  return Boolean(
+    state.hasAdditionalCourse &&
+    state.region &&
+    state.startYearGroup &&
+    shouldAskAboutAdditionalCourse(state.region, state.startYearGroup),
+  );
+}
+
+/**
+ * Human-readable recap of the answers that produced a result, so the result
+ * screen can show *why* a plan was matched (e.g. "England · Started 2012–2022 ·
+ * Postgraduate loan") rather than an unexplained label. Only answers that were
+ * actually given — and that affect the outcome — appear.
+ */
+export function summariseQuizAnswers(state: QuizState): string[] {
+  const parts: string[] = [];
+  if (state.region) parts.push(REGION_LABELS[state.region]);
+  if (state.startYearGroup) parts.push(START_YEAR_LABELS[state.startYearGroup]);
+  if (includesAdditionalCourseLoan(state)) parts.push("Plus a later course");
+  // Only "loan" adds a postgraduate plan; self-funded/no add none, so — per this
+  // function's contract — they don't appear in the recap of matched plans.
+  if (state.postgradAnswer === "loan") parts.push("Postgraduate loan");
+  return parts;
+}
+
 /**
  * Determine all loan plan types from the full quiz state.
  */
@@ -125,8 +173,9 @@ export function determineAllLoans(state: QuizState): PlanType[] {
     loans.push(determinePlan({ region: state.region }));
   }
 
-  // Additional undergraduate course
-  if (state.hasAdditionalCourse && state.startYearGroup && state.region) {
+  // Additional undergraduate course — only when the current region/year path
+  // actually asks about it (guards a stale "yes" from an edited-away branch).
+  if (includesAdditionalCourseLoan(state)) {
     loans.push(getAdditionalCoursePlan(state.startYearGroup, state.region));
   }
 
@@ -135,5 +184,8 @@ export function determineAllLoans(state: QuizState): PlanType[] {
     loans.push("POSTGRADUATE");
   }
 
-  return loans;
+  // Plan type is the loan's identity downstream (result rows key on it, and so
+  // does balance setup), so collapse duplicates: e.g. a Welsh 2012–2022 student
+  // with a second course maps both undergraduate loans to PLAN_2.
+  return [...new Set(loans)];
 }


### PR DESCRIPTION
## Why

The `/which-plan` page had no visual hierarchy and no focus on its actual job — the quiz. This reshapes the page so the finder is the single focal object, and turns the result from a flat label into a moment that explains *why* a plan was matched. During that work, seven rounds of adversarial review (Codex + multi-agent code-review) surfaced a handful of correctness, analytics, and accessibility issues that are fixed here too.

## What changed

**Page hierarchy.** A dominant hero names the task, the quiz sits directly beneath as one anchored instrument card (progress-rail header seam → active step), and the old five plan cards — each of which read like a mini result screen — are demoted to a quiet, sunk at-a-glance reference table below.

**The result as a moment.** Instead of a flat label, the result now lands as: a spruce confidence badge, the matched plan name as the payoff, a recap of the answers that produced it (*"Matched from your answers: England · Started before 2012"*), and recovery via **Change your answers** (re-enters the quiz from the first question with answers preserved) / **Start over**. Blocks reveal in a short staggered cascade that collapses to an instant reveal under reduced-motion.

**Correctness.** A stale additional-course answer could leak a duplicate or phantom loan onto the new answer-edit path (e.g. editing *2012–2022 + "another course: yes"* down to *2023+*). A shared `includesAdditionalCourseLoan` guard now gates that answer in both the loan derivation and the recap so the two can't disagree, and a plan-type dedupe collapses cases where both undergraduate loans map to the same plan (also fixing a Welsh 2012–2022 + additional-course case that produced two identical `PLAN_2` entries).

**Analytics.** Quiz completion now fires once per *distinct* result, keyed on the resolved plan set: a no-op edit round-trip doesn't re-count, and a genuine change records the corrected plans, so the latest event is always the user's final plan. This deliberately trades a little over-counting on back-and-forth edits for attribution correctness.

**Accessibility.** On every step change focus moves to the new step's heading (it previously fell back to `<body>`); the move is StrictMode-safe so it no longer spuriously focuses/scrolls the quiz on dev load. `aria-describedby` ties each step's subtitle and the result recap to its heading; per-loan names in multi-plan results are `h3` so they're reachable by heading navigation; option accessible names are cleaned up; hover no longer mimics the selected state. The result is announced by programmatic focus-to-heading rather than a remounting `aria-live` region — the unreliable pattern a prior design critique had already replaced.

**Responsive.** The result's figure readout reflows to a label-left / value-right spec list on phones (the old fixed 3-column grid clipped values like £26,892 in a ~100px cell), reverting to the 3-up grid at `sm`.

**Copy.** Honest figure labels restored (*"Threshold / yr"*, *"Repayment rate"*, *"Write-off / yrs"*); the hero now says *"a few quick questions"* (was a false *"three"*).

**Tests.** e2e asserts the result plan-name heading at level 2 (it's an `h2` under the page's `h1` hero); unit tests cover the new recap, derivation guard, and dedupe behaviour. Also adds `.impeccable/` to `.gitignore` (local design-review tooling artifacts).

## Quiz flow

```mermaid
stateDiagram-v2
    [*] --> region
    region --> start_year: England / Wales
    region --> postgrad: Scotland / NI (year skipped)
    start_year --> additional_course: path asks
    start_year --> postgrad: path skips
    additional_course --> postgrad
    postgrad --> result
    result --> region: Change your answers (answers preserved)
    result --> [*]: Start over (state reset)
```

## Deferred follow-ups (not defects)

- Extend the shared `MetricReadout`/`MetricCell` with a compact + responsive-cell variant so the quiz result can retire its local `Stat` typography.
- Add roving tabindex to the shared `OptionCard` radiogroup pattern (quiz + five wizard steps) in a dedicated a11y pass — deliberately omitted here because the options auto-advance, which arrow-to-select would fight.
- Optional URL/state persistence for shareable/resumable results.
- The standalone quiz card intentionally sizes to each step's content — a trade-off constrained by the repo's no-arbitrary-Tailwind-values rule.