### PR TITLE
fix: reclaim the dead right margin on phone charts

### DIFF
--- a/src/components/charts/ChartBase.tsx
+++ b/src/components/charts/ChartBase.tsx
@@ -75,6 +75,9 @@ function useIsSmallScreen() {
 // mid-glyph; 48 clears half of "£150,000", the widest the formatters produce.
 const DEFAULT_CHART_MARGIN = { top: 25, right: 48, bottom: 25, left: 25 };
 
+/** Breathing room on a small screen, where no axis band is drawn to hold. */
+const SMALL_SCREEN_MARGIN = 10;
+
 /**
  * Where the rotated y-axis label is centred, measured from the SVG's left edge
  * rather than from the axis viewBox: the viewBox recharts hands the label
@@ -92,26 +95,49 @@ const Y_LABEL_X = 12;
 const Y_LABEL_GUTTER = 22;
 
 /**
- * On small screens keep the top/right margins from the caller (they hold the
- * annotation value label and near-edge readouts) but pull the tick-side margins
- * in — the ticks themselves are hidden and their reserved band zeroed by the
- * axis props below. The label is hidden there too, so it asks for no gutter.
+ * On small screens the ticks are hidden and their reserved bands zeroed by the
+ * axis props below, so the margins that exist to clear a tick are holding open
+ * a gutter around nothing — the default's 48 on the right left a 390px phone
+ * with an eighth of its chart blank, against a 10px margin on the left.
+ *
+ * A right margin the caller names by hand survives: only a chart that draws
+ * something out there — a benchmark label, an annotation tag that can ride the
+ * last x value — asks for one, and none of those go away with the ticks.
  */
 function resolveChartMargin(
   marginProp: ChartBaseProps["margin"],
   isSmallScreen: boolean,
   hasYLabel = false,
 ) {
-  const base = marginProp ?? DEFAULT_CHART_MARGIN;
+  const base = { ...DEFAULT_CHART_MARGIN, ...marginProp };
   if (isSmallScreen)
     return {
-      top: base.top ?? 25,
-      right: base.right ?? 25,
-      bottom: 10,
-      left: 10,
+      ...base,
+      right: marginProp?.right ?? SMALL_SCREEN_MARGIN,
+      bottom: SMALL_SCREEN_MARGIN,
+      left: SMALL_SCREEN_MARGIN,
     };
   if (!hasYLabel) return base;
-  return { ...base, left: (base.left ?? 25) + Y_LABEL_GUTTER };
+  return { ...base, left: base.left + Y_LABEL_GUTTER };
+}
+
+/**
+ * Martian Mono's advance width at the 11px the readouts are set in. A
+ * monospace face, so a label's character count is its width.
+ */
+const MONO_CHAR_WIDTH = 7.7;
+
+/**
+ * Slides a centred label back inside the chart, which clips at its own edge.
+ * Recharts hands a label only its own reference line's rect, so the measured
+ * chart width is the only thing there is to clamp the line's x against.
+ */
+function clampLabelX(x: number, lines: string[], chartWidth: number) {
+  if (chartWidth === 0) return x;
+  const half =
+    (Math.max(...lines.map((line) => line.length)) * MONO_CHAR_WIDTH) / 2 + 2;
+  if (half * 2 > chartWidth) return chartWidth / 2;
+  return Math.min(Math.max(x, half), chartWidth - half);
 }
 
 export interface ChartSeriesConfig {
@@ -184,6 +210,9 @@ export function ChartBase({
 }: ChartBaseProps) {
   const gradientId = useId();
   const [isActive, setIsActive] = useState(false);
+  // Only the crosshair readout needs this, and it only renders while the chart
+  // is active — so reading the width on the way in is both enough and current.
+  const [chartWidth, setChartWidth] = useState(0);
   const [crosshairPoint, setCrosshairPoint] = useState<CrosshairPoint | null>(
     null,
   );
@@ -350,14 +379,16 @@ export function ChartBase({
       className="size-full overflow-hidden select-none"
       {...(isCrosshair
         ? {
-            onMouseEnter: () => {
+            onMouseEnter: (event: React.MouseEvent<HTMLDivElement>) => {
               setIsActive(true);
+              setChartWidth(event.currentTarget.clientWidth);
             },
             onMouseLeave: () => {
               setIsActive(false);
             },
-            onTouchStart: () => {
+            onTouchStart: (event: React.TouchEvent<HTMLDivElement>) => {
               setIsActive(true);
+              setChartWidth(event.currentTarget.clientWidth);
             },
             onTouchEnd: () => {
               setIsActive(false);
@@ -525,9 +556,12 @@ export function ChartBase({
                     ? `${yText} at ${xText} ${seriesName}`
                     : `${yText} at ${xText}`;
                 });
+                // "£122,319 at Year 30" is wider than any margin could hold,
+                // so at the ends of the series it slides off the line instead.
+                const x = clampLabelX(viewBox.x, lines, chartWidth);
                 return (
                   <text
-                    x={viewBox.x}
+                    x={x}
                     y={viewBox.y}
                     textAnchor="middle"
                     fontFamily="var(--font-mono)"
@@ -542,7 +576,7 @@ export function ChartBase({
                       return (
                         <tspan
                           key={v.dataKey}
-                          x={viewBox.x}
+                          x={x}
                           dy={i === 0 ? -10 - (isMulti ? 14 : 0) : 14}
                           fill={`var(--color-${v.dataKey})`}
                         >

--- a/src/components/charts/TotalRepaymentChart.tsx
+++ b/src/components/charts/TotalRepaymentChart.tsx
@@ -66,7 +66,15 @@ export function TotalRepaymentChart() {
       interactionMode="none"
       annotations={annotations}
       xDomain={[MIN_SALARY, MAX_SALARY]}
-      margin={{ top: 25, right: 16, bottom: 8, left: 25 }}
+      margin={{
+        // Named rather than inherited: the salary tag rides the annotation all
+        // the way to £150,000, so this chart still needs the gutter on a phone,
+        // where the default one goes away with the ticks. At 16 the tag and the
+        // end tick were both sliced — "£150,00".
+        right: 48,
+        // The x-axis carries no label here, so it needs less room under the ticks.
+        bottom: 8,
+      }}
     />
   );
 }

--- a/src/components/detail/EffectiveRateBySalaryChart.tsx
+++ b/src/components/detail/EffectiveRateBySalaryChart.tsx
@@ -85,14 +85,12 @@ export function EffectiveRateBySalaryChart({
       horizontalAnnotations={horizontalAnnotations}
       xDomain={[MIN_SALARY, MAX_SALARY]}
       margin={{
-        top: 25,
-        // Matches the default: sized to clear half of the "£150,000" end tick,
-        // which this chart's x-axis is the one that produces.
+        // Named rather than inherited: the salary tag rides the annotation all
+        // the way to £150,000, so this chart still needs the gutter on a phone,
+        // where the default one goes away with the ticks.
         right: 48,
-        // Only this differs — the x-axis carries no label here, so it needs
-        // less room under the ticks.
+        // The x-axis carries no label here, so it needs less room under the ticks.
         bottom: 8,
-        left: 25,
       }}
     />
   );

--- a/src/components/guides/interest-rate-cap/HistoricalRatesChart.tsx
+++ b/src/components/guides/interest-rate-cap/HistoricalRatesChart.tsx
@@ -57,6 +57,11 @@ export function HistoricalRatesChart() {
             strokeDasharray: "6 4",
           },
         ]}
+        // Named rather than inherited: a bar chart hangs its benchmark label
+        // out in the right margin — an inside label would land on the last
+        // bar — so this one still needs the gutter on a phone, where the
+        // default goes away with the ticks.
+        margin={{ right: 48 }}
         showLegend
       />
     </div>


### PR DESCRIPTION
On a phone, the chart panels had a visible void down their right-hand side — the curve stopped well short of the panel edge while nearly touching the left. Reported from `/repaid`, but every chart on the site had it.

The cause: `ChartBase` reserves 48px on the right purely to clear *half* of the last x-axis tick, which recharts centres on the final data point at the very edge of the plot. Below 640px that same code path hides the tick labels and zeroes their axis bands — so the gutter was holding open space around nothing, against 10px on the left. That asymmetry was the gap.

Below 640px the right margin now matches the left, unless a chart asks for one by hand. On a 390px screen the `/repaid` plot goes from 263px to 301px wide; `/balance`, `/interest`, `/overpay` and the guide charts gain the same. Desktop is untouched.

**`/repaid` chart panel, 430px wide**

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/QingqiShi/uk-student-loan-study/pr-assets/fix/chart-right-margin/repaid-phone-before.png" width="450"> | <img src="https://raw.githubusercontent.com/QingqiShi/uk-student-loan-study/pr-assets/fix/chart-right-margin/repaid-phone-after.png" width="450"> |

Three charts genuinely draw into that band and so keep it explicitly, now named at the call site rather than inherited:

- the home chart and `/effective-rate` — the salary tag rides the annotation all the way to £150,000, so it can sit on the last x value even once the ticks are hidden;
- the interest-rate-cap historical bar chart — recharts hangs its "6% cap" benchmark label *outside* the plot, because an inside label would land on the last bar.

## Two clipping bugs found while measuring

Both pre-existing, both fixed here.

**The home chart's last x-axis tick was sliced mid-glyph at every width** — it read "£150,00". Its right margin was 16 where the label needs 31; it now uses the documented default of 48.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/QingqiShi/uk-student-loan-study/pr-assets/fix/chart-right-margin/home-endtick-before.png" width="450"> | <img src="https://raw.githubusercontent.com/QingqiShi/uk-student-loan-study/pr-assets/fix/chart-right-margin/home-endtick-after.png" width="450"> |

**The crosshair readout was cut whenever the pointer parked on the end of the series** on `/repaid` and `/balance` — "£122,319 at Year 30" is 146px wide and lost 23px off its right. No margin can hold a label that wide, so it now slides back inside the chart instead of overhanging it. This had to land with the margin change rather than separately: dropping the right margin alone would have taken the cut from 23px to 61px.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/QingqiShi/uk-student-loan-study/pr-assets/fix/chart-right-margin/crosshair-phone-before.png" width="450"> | <img src="https://raw.githubusercontent.com/QingqiShi/uk-student-loan-study/pr-assets/fix/chart-right-margin/crosshair-phone-after.png" width="450"> |

Every chart on every route was then measured at phone width, with the salary slider at both extremes and the crosshair parked on the last data point: no clipping anywhere, and the three charts that keep the band use all of it.