### PR TITLE
chore: update student loan figures from GOV.UK

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -44,7 +44,7 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - Repayment rate: 9% of income above threshold (6% for Postgraduate)
 - Monthly repayment thresholds: Plan 1 £2,241, Plan 2 £2,448, Plan 4 £2,816, Plan 5 £2,083, Postgraduate £1,750
 - Loans are written off after 25-40 years depending on plan type
-- CPI (Consumer Prices Index) annual rate: 2.6% (used as default discount rate for present-value calculations)
+- CPI (Consumer Prices Index) annual rate: 2.9% (used as default discount rate for present-value calculations)
 - Middle earners often pay the most in total repayments due to interest accumulation
 
 ## Plan Types Summary

--- a/src/lib/loans/plans.ts
+++ b/src/lib/loans/plans.ts
@@ -7,7 +7,7 @@
  * ISO date of the last time figures were actually changed by the automation.
  * Only updates when GOV.UK/BoE figures differ from what we have.
  */
-export const LAST_UPDATED = "2026-07-22T09:30:22.642Z";
+export const LAST_UPDATED = "2026-08-19T07:43:53.450Z";
 
 /**
  * Plan configurations for all UK student loan types.
@@ -50,7 +50,7 @@ export const PLAN_CONFIGS = {
 export const CURRENT_RATES = {
   rpi: 3.2,
   boeBaseRate: 3.75,
-  cpi: 2.6,
+  cpi: 2.9,
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

The daily GOV.UK figure checker detected a routine figure change that cleared the guarded auto-merge checks — every value is plausible, in range, and a small move. **This PR merges automatically once CI passes.**

### Figures changed
- CURRENT_RATES.cpi: 2.6% → 2.9%

### Cross-check against the source
- [Thresholds and repayment rates (GOV.UK)](https://www.gov.uk/repaying-your-student-loan/what-you-pay)
- [Write-off periods (GOV.UK)](https://www.gov.uk/repaying-your-student-loan/when-your-student-loan-gets-written-off-or-cancelled)

> Auto-generated by the GOV.UK figure freshness checker. A passing build does not verify the figures are correct. If auto-merge is not enabled, cross-check the values above against the sources before merging manually; if anything looks wrong, close the PR and check the scraper. This description is regenerated on each update — add review notes as comments, not here.
