### PR TITLE
chore: add posthog inbox skill and pin cli project

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "POSTHOG_CLI_PROJECT_ID": "238904"
+  },
   "permissions": {
     "defaultMode": "bypassPermissions",
     "deny": ["Read(./.env)", "Read(./.env.*)"]

--- a/.claude/skills/posthog-inbox/SKILL.md
+++ b/.claude/skills/posthog-inbox/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: posthog-inbox
+description: Check the PostHog inbox and query PostHog data with posthog-cli. Use when the user asks to check PostHog, the inbox, signal reports, what PostHog found, or anything about PostHog analytics, error tracking, session replay, or feature flag data.
+---
+
+# PostHog inbox
+
+Use the globally installed `posthog-cli` (`pnpm add -g @posthog/cli` if missing). Do not use PostHog MCP tools, and do not run `posthog-cli api skill install` — this project deliberately avoids the `.agents/` skill layer.
+
+This repo's PostHog project is **StudentLoanStudy, ID `238904`, EU cloud**. Sessions inherit `POSTHOG_CLI_PROJECT_ID=238904` from the env block in `.claude/settings.json`, which overrides the machine-level login's active project. If the variable is missing from the environment, prefix each call with it. Do not call `switch-project` — it changes the machine-global default for other repos.
+
+## Auth
+
+Calls fail with `Missing PostHog API key` when the machine is not authenticated. Ask the user to run `! posthog-cli login` (one-time, credentials stay in the home directory). Never write PostHog credentials into the repo.
+
+## Check the inbox
+
+The inbox holds signal reports: clusters of related observations from error tracking, session replay, and other scouts.
+
+```sh
+posthog-cli api call inbox-reports-list '{"limit": 20}'
+posthog-cli api call inbox-reports-list '{"status": "ready"}'
+```
+
+Statuses: `ready` is actionable now, `pending_input` waits on a human, earlier statuses are still in the pipeline, `suppressed` (dismissed) is hidden unless `include_all_statuses` is true.
+
+Before acting on a report, read its full work log — evidence, judgments, and log entries:
+
+```sh
+posthog-cli api call inbox-report-artefacts-list '{"report_id": "<report-uuid>"}'
+```
+
+## Anything else PostHog
+
+Discover tools at runtime — never guess a schema:
+
+```sh
+posthog-cli api search <topic>
+posthog-cli api info <tool>
+posthog-cli api call <tool> '<json>'
+```
+
+`posthog-cli api --agent-help` prints the full agent guide. Mutating tools require `--confirm` and explicit user direction.

--- a/.gitignore
+++ b/.gitignore
@@ -39,9 +39,13 @@ playwright-report/
 # GOV.UK checker results
 scripts/check-govuk-figures/results/
 
-# Claude Code worktrees
+# Claude Code
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+.claude/settings.local.json
+
+# Agent skills installed on demand (posthog-cli api skill install)
+.agents/
 
 # impeccable design-review snapshots (local tooling artifacts)
 .impeccable/


### PR DESCRIPTION
Claude Code sessions in this repo can now check the PostHog inbox (signal reports) and query PostHog data, mirroring the setup merged into shiqingqi.com (QingqiShi/shiqingqi.com#2687). The integration is deliberately thin: it rides the globally installed `posthog-cli` with machine-level auth (`posthog-cli login`), keeps all credentials out of the repo, and rejects PostHog's bespoke agent-skill infrastructure (the `.agents/` skill installs) and any standing steering text in CLAUDE.md — that route was ruled out after PostHog tooling injected a steering section into a global CLAUDE.md uninvited.

Three parts:

- **A committed project skill** (`.claude/skills/posthog-inbox/SKILL.md`) that triggers whenever PostHog comes up. It carries live-verified inbox commands (`inbox-reports-list`, `inbox-report-artefacts-list`), auth-failure handling (ask the user to run `! posthog-cli login`), an explicit instruction not to use PostHog MCP tools or `posthog-cli api skill install`, and a warning against `switch-project`, which changes the machine-global default project for every other repo.
- **A pinned project ID**: `.claude/settings.json` gains an env block setting `POSTHOG_CLI_PROJECT_ID=238904` (StudentLoanStudy, EU cloud), so every session targets this repo's own PostHog project. The machine-level login's active project happens to point here today, but it stores a single active project across all repos — the committed pin makes the target explicit and survives future re-logins and project switches. A `.env` file was rejected because this repo's settings deny agents reading `.env` files; the project ID is public (it appears in PostHog URLs), so committing it is safe.
- **Two `.gitignore` guards**: `.claude/settings.local.json` (in the committed `.gitignore` so the ignore stays visible in the tree, not hidden in `.git/info/exclude`) and `.agents/`, so a stray PostHog skill install can never pollute the tree.