### PR TITLE
docs: filter posthog inbox to live statuses by default

### DIFF
--- a/.claude/skills/posthog-inbox/SKILL.md
+++ b/.claude/skills/posthog-inbox/SKILL.md
@@ -18,13 +18,13 @@ Calls fail with `Missing PostHog API key` when the machine is not authenticated.
 The inbox holds signal reports: clusters of related observations from error tracking, session replay, and other scouts.
 
 ```sh
-posthog-cli api call inbox-reports-list '{"limit": 20}'
+posthog-cli api call inbox-reports-list '{"status": "ready,pending_input"}'
 posthog-cli api call inbox-reports-list '{"status": "ready"}'
 ```
 
-Statuses: `ready` is actionable now, `pending_input` waits on a human, earlier statuses are still in the pipeline, `suppressed` (dismissed) is hidden unless `include_all_statuses` is true.
+`status` takes a comma-separated list; without it the API returns every status except `suppressed`, mixing archived reports (`resolved`, `failed`) and in-pipeline ones (`potential`, `candidate`, `in_progress`) in with the actionable ones. `ready` is actionable now, `pending_input` waits on a human, earlier statuses are still in the pipeline, and `suppressed` (dismissed) is hidden unless `include_all_statuses` is true — that flag only dedupes against the whole inbox and is ignored once `status` is set. Filter to `ready,pending_input` for the live queue, or `ready` alone for only what can be picked up now.
 
-Before acting on a report, read its full work log — evidence, judgments, and log entries:
+Before acting on a report, read its full work log — evidence, judgments, and log entries. Reports can be stale: check `already_addressed` and verify the claimed gap against current code, project settings, and merged PRs before acting.
 
 ```sh
 posthog-cli api call inbox-report-artefacts-list '{"report_id": "<report-uuid>"}'


### PR DESCRIPTION
Running the posthog-inbox skill's default listing call returns every status except `suppressed`, so archived reports (`resolved`, `failed`) and in-pipeline ones (`potential`, `candidate`, `in_progress`) show up mixed in with the actionable ones (`ready`, `pending_input`). The default example now filters to `status: ready,pending_input` — the live queue — with the existing `status: ready` example kept for only what can be picked up right now. The statuses explanation is expanded to cover the comma-separated list and the `include_all_statuses` caveat: that flag only adds `suppressed` rows back for deduping against the whole inbox, and is ignored once an explicit `status` filter is set.

Separately, the guidance on acting on a report now says to check its `already_addressed` field and verify the claimed gap against current code, project settings, and merged PRs before acting — a report's suggestion can be stale even when the report itself is otherwise live.

This ports QingqiShi/shiqingqi.com#2691 from the sibling repo.