### PR TITLE
fix: send quiz back-click step name instead of index

### DIFF
--- a/src/components/quiz/QuizContainer.test.tsx
+++ b/src/components/quiz/QuizContainer.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { trackQuizBackClicked } from "@/lib/analytics";
+import { QuizContainer } from "./QuizContainer";
+
+vi.mock("@/lib/analytics", () => ({
+  trackQuizStarted: vi.fn(),
+  trackQuizRegionSelected: vi.fn(),
+  trackQuizYearSelected: vi.fn(),
+  trackQuizBackClicked: vi.fn(),
+  trackQuizCompleted: vi.fn(),
+}));
+
+describe("QuizContainer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports the step name the user went back from", async () => {
+    const user = userEvent.setup();
+
+    render(<QuizContainer />);
+
+    await user.click(screen.getByRole("radio", { name: "England" }));
+    await user.click(screen.getByRole("button", { name: "Go back" }));
+
+    expect(trackQuizBackClicked).toHaveBeenCalledWith("start-year");
+    expect(
+      screen.getByRole("heading", { name: "Where did you study?" }),
+    ).not.toBeNull();
+  });
+});

--- a/src/components/quiz/QuizContainer.tsx
+++ b/src/components/quiz/QuizContainer.tsx
@@ -273,7 +273,7 @@ export function QuizContainer({
   };
 
   const handleBack = () => {
-    trackQuizBackClicked(currentStepIndex);
+    trackQuizBackClicked(state.currentStep);
     dispatch({ type: "GO_BACK" });
   };
 
@@ -284,8 +284,8 @@ export function QuizContainer({
   };
 
   // Distinct from the progress back-arrow: this rewinds all the way to the first
-  // question (keeping answers) rather than one step, and it must not emit the
-  // step-scoped quiz_back_clicked event (the result has no valid step index).
+  // question (keeping answers) rather than one step, so it must not emit the
+  // step-scoped quiz_back_clicked event.
   const handleEditAnswers = () => {
     dispatch({ type: "EDIT_ANSWERS" });
   };

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,5 +1,6 @@
 import posthog from "posthog-js";
 import { posthogEnabled } from "@/lib/posthog";
+import type { QuizStep } from "@/lib/quiz/determinePlan";
 
 function track(event: string, properties: Record<string, unknown> = {}) {
   if (!posthogEnabled) return;
@@ -99,7 +100,7 @@ export function trackQuizYearSelected(yearGroup: string) {
   track("quiz_year_selected", { yearGroup });
 }
 
-export function trackQuizBackClicked(fromStep: number) {
+export function trackQuizBackClicked(fromStep: QuizStep) {
   track("quiz_back_clicked", { fromStep });
 }
 


### PR DESCRIPTION
A PostHog Signals report flagged that the assumptions wizard's `wizard_back_clicked` events all carried a null `fromStep`, hiding which wizard step people were backing out of. The wizard actually sends `fromStep` as a step-name string (e.g. `"rpi"`), but the which-plan quiz sends `fromStep` as its numeric progress index (1, 2, 3). Because the quiz's numeric values arrived first, PostHog typed the `fromStep` property as Numeric, and HogQL then nulls every string value on that property — which is why the wizard's back-click steps were invisible.

The PostHog property type has already been switched to String outside this PR, so the wizard's values are readable now. This change makes the quiz send its step name (e.g. `"start-year"`, `"postgrad"`) instead of its numeric index, so both step flows report `fromStep` as the same kind of value going forward, and quiz back-click friction can be localised to a step just like the wizard's.

The comment on the quiz's "edit answers" handler (which rewinds to the first question and intentionally skips this event) was reworded, since it no longer has a step index to be missing.