### PR TITLE
feat: correct moving-abroad claims, add overseas repayment estimator

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,5 +1,6 @@
 import AxeBuilder from "@axe-core/playwright";
 import { type Page, test, expect } from "@playwright/test";
+import { ESTIMATOR_ANCHOR_ID } from "../src/components/guides/moving-abroad/overseas-data";
 import { openConfigWizard, waitForResults } from "./helpers";
 
 function axeScan(page: Page) {
@@ -50,6 +51,19 @@ test.describe("Accessibility", () => {
     // Wait for verdict to load
     const verdict = page.locator("[role='status'][aria-live='polite']").first();
     await expect(verdict).toBeVisible({ timeout: 15_000 });
+
+    const results = await axeScan(page).analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test("moving abroad guide has no WCAG 2.1 AA violations", async ({
+    page,
+  }) => {
+    await page.goto("/guides/moving-abroad");
+    // The estimator is the guide's one client component; once its readout has
+    // hydrated, the scan covers the interactive controls as well as the prose.
+    await expect(page.locator(`#${ESTIMATOR_ANCHOR_ID}`)).toBeVisible();
+    await expect(page.getByLabel("Destination")).toHaveValue("Australia");
 
     const results = await axeScan(page).analyze();
     expect(results.violations).toEqual([]);

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -25,7 +25,7 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - [RPI vs CPI](https://studentloanstudy.uk/guides/rpi-vs-cpi): Why student loan interest uses RPI while general inflation is measured by CPI, and what that gap means
 - [Student Loan & Mortgage](https://studentloanstudy.uk/guides/student-loan-vs-mortgage): Whether a student loan affects your mortgage — affordability, whether it counts as income, your credit file, and paying it off first
 - [Pay Upfront or Take Loan?](https://studentloanstudy.uk/guides/pay-upfront-or-take-loan): Should parents pay tuition upfront or let their child take the loan?
-- [Moving Abroad](https://studentloanstudy.uk/guides/moving-abroad): What happens to your student loan if you leave the UK
+- [Moving Abroad](https://studentloanstudy.uk/guides/moving-abroad): What happens to your student loan if you leave the UK — SLC's country thresholds for every plan and an estimator for your monthly repayment in any country
 - [Self-Employment](https://studentloanstudy.uk/guides/self-employment): How repayments work through Self Assessment for freelancers
 - [Threshold Freeze Explained](https://studentloanstudy.uk/guides/threshold-freeze): How the Plan 2 threshold freeze from 2027-2030 increases monthly repayments and what the parliamentary inquiry means
 

--- a/scripts/check-govuk-figures/classify.test.ts
+++ b/scripts/check-govuk-figures/classify.test.ts
@@ -18,25 +18,54 @@ describe("classifyChange", () => {
     ).toEqual({ decision: "auto", reviewReasons: [] });
   });
 
-  it("auto-merges a routine repayment-threshold uprating", () => {
-    // ~4% annual uprating, with a consistent annual/monthly row.
-    expect(
-      classifyChange(
-        [{ field: "PLAN_5.monthlyThreshold", current: 2083, scraped: 2166 }],
-        [row("PLAN_5", 2166)],
-      ).decision,
-    ).toBe("auto");
-  });
-
-  it("auto-merges when every field in the batch is routine and in bounds", () => {
+  it("auto-merges when every field in the batch is a routine market rate", () => {
     const mismatches: Mismatch[] = [
       { field: "CURRENT_RATES.rpi", current: 3.2, scraped: 4.1 },
       { field: "CURRENT_RATES.cpi", current: 2.8, scraped: 3.0 },
-      { field: "PLAN_2.monthlyThreshold", current: 2274, scraped: 2350 },
     ];
     expect(classifyChange(mismatches, [row("PLAN_2", 2350)]).decision).toBe(
       "auto",
     );
+  });
+
+  it("reviews a routine repayment-threshold uprating so the overseas dataset is refreshed", () => {
+    // ~4% annual uprating, in bounds and internally consistent — but every
+    // overseas band multiplies the UK threshold, and that dataset is hand-copied.
+    const result = classifyChange(
+      [{ field: "PLAN_5.monthlyThreshold", current: 2083, scraped: 2166 }],
+      [row("PLAN_5", 2166)],
+    );
+    expect(result.decision).toBe("review");
+    expect(result.reviewReasons).toEqual([
+      "PLAN_5.monthlyThreshold: a UK repayment threshold moved — refresh src/lib/loans/overseasThresholds.ts from the 6 April GOV.UK overseas tables (Plan 1/2/4/5/Postgraduate)",
+    ]);
+  });
+
+  it("names the overseas refresh for every plan's threshold", () => {
+    for (const plan of [
+      "PLAN_1",
+      "PLAN_2",
+      "PLAN_4",
+      "PLAN_5",
+      "POSTGRADUATE",
+    ]) {
+      const result = classifyChange(
+        [{ field: `${plan}.monthlyThreshold`, current: 2200, scraped: 2300 }],
+        [row(plan, 2300)],
+      );
+      expect(result.decision).toBe("review");
+      expect(
+        result.reviewReasons.some((r) => r.includes("overseasThresholds")),
+      ).toBe(true);
+    }
+  });
+
+  it("leaves a market-rate move clear of the overseas refresh reason", () => {
+    const result = classifyChange(
+      [{ field: "CURRENT_RATES.rpi", current: 3.2, scraped: 4.1 }],
+      [],
+    );
+    expect(result.reviewReasons).toEqual([]);
   });
 
   it("reviews a structural field (repayment rate) even if plausible", () => {
@@ -129,7 +158,9 @@ describe("classifyChange", () => {
       [{ plan: "PLAN_1", monthlyThreshold: 2448, yearlyThreshold: 26900 }],
     );
     expect(result.decision).toBe("review");
-    expect(result.reviewReasons[0]).toContain("inconsistent");
+    expect(result.reviewReasons.some((r) => r.includes("inconsistent"))).toBe(
+      true,
+    );
   });
 
   it("reviews an inconsistent threshold row even when its monthly value is unchanged", () => {

--- a/scripts/check-govuk-figures/classify.ts
+++ b/scripts/check-govuk-figures/classify.ts
@@ -10,9 +10,11 @@ import type { Mismatch, ScrapedPlanThreshold } from "./types";
  * plausible and whose move is small. Anything else falls back to a human-
  * reviewed PR: a structural field (repayment rate, write-off period, the Plan 2
  * sliding-scale interest thresholds), an out-of-bounds value, a large jump, a
- * non-positive rate, or a repayment threshold whose monthly and annual figures
- * disagree. This catches a mis-scrape — e.g. an annual repayment threshold of
- * £26,760 read as £2,676 — before it can reach production.
+ * non-positive rate, a repayment threshold whose monthly and annual figures
+ * disagree, or any repayment-threshold move at all (see
+ * {@link OVERSEAS_REFRESH_REASON}). This catches a mis-scrape — e.g. an annual
+ * repayment threshold of £26,760 read as £2,676 — before it can reach
+ * production.
  */
 
 interface FieldBound {
@@ -29,10 +31,12 @@ interface FieldBound {
   increaseOnly?: boolean;
 }
 
-// Only these routine fields are eligible for auto-merge. Every other field —
+// Bounds for the fields the scrape can move routinely. Every other field —
 // repayment rate, write-off period, the Plan 2 interest thresholds — is
 // structural and legislative: a change there is rare and always deserves human
 // review, so it is deliberately absent from this map (an unknown field reviews).
+// A monthly threshold still carries bounds, for a precise diagnosis, even though
+// it can never auto-merge (see needsOverseasRefresh).
 const AUTO_MERGE_BOUNDS: Record<string, FieldBound> = {
   // Monthly repayment thresholds (the annual value / 12). Annual thresholds sit
   // around £15k–£40k, so monthly ~£1,250–£3,333; annual upratings move a few
@@ -125,6 +129,19 @@ function unsafeReason(m: Mismatch): string | null {
 }
 
 /**
+ * The overseas dataset in src/lib/loans/overseasThresholds.ts is copied by hand
+ * from the five GOV.UK country tables, and every band there is a multiple of the
+ * UK threshold. A UK threshold move therefore leaves that dataset stale, so the
+ * automation must never merge one unattended.
+ */
+const OVERSEAS_REFRESH_REASON =
+  "a UK repayment threshold moved — refresh src/lib/loans/overseasThresholds.ts from the 6 April GOV.UK overseas tables (Plan 1/2/4/5/Postgraduate)";
+
+function needsOverseasRefresh(field: string): boolean {
+  return field.endsWith(".monthlyThreshold");
+}
+
+/**
  * Every scraped threshold row must be internally consistent, whether or not its
  * monthly value changed — a bad annual figure still flows into the generated
  * files (llms.txt, comments). GOV.UK floors the monthly from the annual, so
@@ -153,9 +170,10 @@ export interface Classification {
 
 /**
  * Classify a change for the guarded auto-merge. The decision is `auto` only
- * when *every* mismatch is a routine, in-bounds, small move **and** every
- * scraped threshold row is internally consistent; a single disqualifying field
- * or row sends the whole batch to `review`. `thresholds` are all scraped rows,
+ * when *every* mismatch is a routine, in-bounds, small move that leaves no
+ * hand-maintained dataset stale **and** every scraped threshold row is
+ * internally consistent; a single disqualifying field or row sends the whole
+ * batch to `review`. `thresholds` are all scraped rows,
  * checked independently so a bad annual on an unchanged monthly can't ride
  * along with an otherwise-safe rate move.
  */
@@ -168,6 +186,9 @@ export function classifyChange(
     const reason = unsafeReason(m);
     if (reason) {
       reviewReasons.push(`${m.field}: ${reason}`);
+    }
+    if (needsOverseasRefresh(m.field)) {
+      reviewReasons.push(`${m.field}: ${OVERSEAS_REFRESH_REASON}`);
     }
   }
   reviewReasons.push(...thresholdRowIssues(thresholds));

--- a/scripts/check-govuk-figures/templates.ts
+++ b/scripts/check-govuk-figures/templates.ts
@@ -236,7 +236,7 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - [RPI vs CPI](https://studentloanstudy.uk/guides/rpi-vs-cpi): Why student loan interest uses RPI while general inflation is measured by CPI, and what that gap means
 - [Student Loan & Mortgage](https://studentloanstudy.uk/guides/student-loan-vs-mortgage): Whether a student loan affects your mortgage — affordability, whether it counts as income, your credit file, and paying it off first
 - [Pay Upfront or Take Loan?](https://studentloanstudy.uk/guides/pay-upfront-or-take-loan): Should parents pay tuition upfront or let their child take the loan?
-- [Moving Abroad](https://studentloanstudy.uk/guides/moving-abroad): What happens to your student loan if you leave the UK
+- [Moving Abroad](https://studentloanstudy.uk/guides/moving-abroad): What happens to your student loan if you leave the UK — SLC's country thresholds for every plan and an estimator for your monthly repayment in any country
 - [Self-Employment](https://studentloanstudy.uk/guides/self-employment): How repayments work through Self Assessment for freelancers
 - [Threshold Freeze Explained](https://studentloanstudy.uk/guides/threshold-freeze): How the Plan 2 threshold freeze from 2027-2030 increases monthly repayments and what the parliamentary inquiry means
 

--- a/src/app/guides/moving-abroad/layout.tsx
+++ b/src/app/guides/moving-abroad/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { movingAbroadFaqs } from "@/components/guides/moving-abroad/overseas-data";
 
 const description =
-  "Yes — you still repay your UK student loan abroad, and moving doesn't wipe it. See how SLC thresholds shift in Australia, Canada, the USA, Dubai and Spain, plus what to do before you go.";
+  "Yes — you still repay your UK student loan abroad; moving doesn't wipe it. Estimate your repayment in any country. Student loans never touch your credit score.";
 
 export const metadata: Metadata = {
   title: "What Happens to Your Student Loan If You Move Abroad? (UK)",
@@ -19,6 +19,9 @@ export const metadata: Metadata = {
     "student loan Dubai UAE",
     "student loan Spain",
     "student loan wiped moving abroad",
+    "student loan abroad calculator",
+    "student loan overseas threshold",
+    "student loan credit score abroad",
   ],
   alternates: {
     canonical: "/guides/moving-abroad",
@@ -86,7 +89,7 @@ const articleSchema = {
     url: "https://studentloanstudy.uk",
   },
   datePublished: "2026-02-14",
-  dateModified: "2026-07-10",
+  dateModified: "2026-08-28",
 };
 
 // Note: JSON-LD scripts render in body for nested layouts (Next.js limitation).

--- a/src/app/sitemap.xml
+++ b/src/app/sitemap.xml
@@ -60,7 +60,7 @@
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/moving-abroad</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-08-28</lastmod>
   </url>
   <url>
     <loc>https://studentloanstudy.uk/guides/self-employment</loc>

--- a/src/components/guides/guide-parts.tsx
+++ b/src/components/guides/guide-parts.tsx
@@ -244,10 +244,6 @@ export function GuideArticle({
   );
 }
 
-/** Inline prose link: spruce-ink with a hairline underline that thickens on hover. */
-export const guideLink =
-  "font-medium text-cta underline decoration-1 underline-offset-4 transition-[text-decoration-color,color] hover:text-cta/80";
-
 /**
  * Breakout figures (charts, wide tables) span all three tracks of the reading
  * grid to read wider than the prose that frames them. The `!` overrides the
@@ -281,65 +277,6 @@ export function KeyTakeaways({ children }: { children: React.ReactNode }) {
         {children}
       </ul>
     </Panel>
-  );
-}
-
-const SEAM_COLS: Record<number, string> = {
-  1: "grid-cols-1",
-  2: "grid-cols-1 sm:grid-cols-2",
-  3: "grid-cols-1 sm:grid-cols-3",
-};
-
-/**
- * A spec-sheet grid: cells joined by 1px hairline seams (gap-px over the border
- * ground), the same etched-divider language as the homepage readout. Use it for
- * feature groups that were previously floating icon cards.
- */
-export function SeamGrid({
-  columns = 2,
-  className,
-  children,
-}: {
-  columns?: 1 | 2 | 3;
-  className?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div
-      className={cn(
-        "grid gap-px overflow-hidden rounded-xl bg-border ring-1 ring-border",
-        SEAM_COLS[columns],
-        className,
-      )}
-    >
-      {children}
-    </div>
-  );
-}
-
-/** One cell of a {@link SeamGrid}: optional spruce icon, engraved label, prose. */
-export function SeamCell({
-  icon,
-  eyebrow,
-  title,
-  children,
-  className,
-}: {
-  icon?: React.ReactNode;
-  eyebrow?: React.ReactNode;
-  title?: React.ReactNode;
-  children: React.ReactNode;
-  className?: string;
-}) {
-  return (
-    <div className={cn("flex flex-col gap-2 bg-card p-4 sm:p-5", className)}>
-      {icon != null && <div>{icon}</div>}
-      {eyebrow != null && <Eyebrow marker={false}>{eyebrow}</Eyebrow>}
-      {title != null && (
-        <p className="font-semibold text-foreground">{title}</p>
-      )}
-      <div className="text-sm text-muted-foreground">{children}</div>
-    </div>
   );
 }
 

--- a/src/components/guides/guide-primitives.tsx
+++ b/src/components/guides/guide-primitives.tsx
@@ -1,0 +1,106 @@
+import { Eyebrow } from "@/components/typography/Eyebrow";
+import { cn } from "@/lib/utils";
+
+/**
+ * The leaf half of the guide archetype: the pieces a client component can pull
+ * in without dragging the whole guide shell (breadcrumb, related guides, the
+ * contents rail) into its browser chunk. {@link file://./guide-parts.tsx
+ * guide-parts.tsx} holds the server-only shell that builds on these.
+ */
+
+/** Inline prose link: spruce-ink with a hairline underline that thickens on hover. */
+export const guideLink =
+  "font-medium text-cta underline decoration-1 underline-offset-4 transition-[text-decoration-color,color] hover:text-cta/80";
+
+/** An off-site prose link (GOV.UK, HMRC), opened in a new tab. */
+export function ExternalLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={guideLink}
+    >
+      {children}
+    </a>
+  );
+}
+
+/**
+ * One chip of a segmented toggle — the control every guide figure uses to switch
+ * its scenario (salary, RPI, destination). Ink-on-paper when active, a muted
+ * chip when not.
+ */
+export function segmentToggle(active: boolean): string {
+  return cn(
+    "rounded-md px-3 py-1 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+    active
+      ? "bg-foreground text-background"
+      : "bg-muted text-muted-foreground hover:bg-muted/80",
+  );
+}
+
+const SEAM_COLS: Record<number, string> = {
+  1: "grid-cols-1",
+  2: "grid-cols-1 sm:grid-cols-2",
+  3: "grid-cols-1 sm:grid-cols-3",
+};
+
+/**
+ * A spec-sheet grid: cells joined by 1px hairline seams (gap-px over the border
+ * ground), the same etched-divider language as the homepage readout. Use it for
+ * feature groups that were previously floating icon cards.
+ */
+export function SeamGrid({
+  columns = 2,
+  className,
+  children,
+}: {
+  columns?: 1 | 2 | 3;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "grid gap-px overflow-hidden rounded-xl bg-border ring-1 ring-border",
+        SEAM_COLS[columns],
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** One cell of a {@link SeamGrid}: optional spruce icon, engraved label, prose. */
+export function SeamCell({
+  icon,
+  eyebrow,
+  title,
+  children,
+  className,
+}: {
+  icon?: React.ReactNode;
+  eyebrow?: React.ReactNode;
+  title?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex flex-col gap-2 bg-card p-4 sm:p-5", className)}>
+      {icon != null && <div>{icon}</div>}
+      {eyebrow != null && <Eyebrow marker={false}>{eyebrow}</Eyebrow>}
+      {title != null && (
+        <p className="font-semibold text-foreground">{title}</p>
+      )}
+      <div className="text-sm text-muted-foreground">{children}</div>
+    </div>
+  );
+}

--- a/src/components/guides/how-interest-works/InterestGuide.tsx
+++ b/src/components/guides/how-interest-works/InterestGuide.tsx
@@ -4,7 +4,8 @@ import { Heading } from "@/components/typography/Heading";
 import { formatGBP, formatPercent } from "@/lib/format";
 import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
 import { getCurrentTaxYearLabel } from "@/lib/taxYear";
-import { GuideArticle, guideBreakout, guideLink } from "../guide-parts";
+import { GuideArticle, guideBreakout } from "../guide-parts";
+import { guideLink } from "../guide-primitives";
 import { CurrentRatesTable } from "./CurrentRatesTable";
 import { InterestRateChart } from "./InterestRateChart";
 

--- a/src/components/guides/interest-rate-cap/BalanceWithCapChart.tsx
+++ b/src/components/guides/interest-rate-cap/BalanceWithCapChart.tsx
@@ -6,6 +6,7 @@ import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
 import type { ChartConfig } from "@/components/ui/chart";
 import { getAnnualInterestRate } from "@/lib/loans/interest";
 import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
+import { segmentToggle } from "../guide-primitives";
 import { INTEREST_CAP } from "./historical-rates";
 
 const RPI_OPTIONS = [
@@ -127,11 +128,7 @@ export function BalanceWithCapChart() {
               onClick={() => {
                 setRpi(option.value);
               }}
-              className={`rounded-md px-3 py-1 text-sm font-medium transition-colors ${
-                rpi === option.value
-                  ? "bg-foreground text-background"
-                  : "bg-muted text-muted-foreground hover:bg-muted/80"
-              }`}
+              className={segmentToggle(rpi === option.value)}
             >
               {option.label}
             </button>

--- a/src/components/guides/moving-abroad/BandLadderTable.tsx
+++ b/src/components/guides/moving-abroad/BandLadderTable.tsx
@@ -1,0 +1,71 @@
+import { ScrollFadeWrapper } from "@/components/shared/ScrollFadeWrapper";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatGBP, formatGBPPence, formatMultiplier } from "@/lib/format";
+import { surfaceCard } from "@/lib/surfaces";
+import { specHead, specHeadNum, specNum } from "../guide-parts";
+import { bandLadder } from "./overseas-data";
+
+/** SLC's seven price bands, lowest multiplier first. */
+export function BandLadderTable() {
+  return (
+    <ScrollFadeWrapper className={surfaceCard}>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead scope="col" className={specHead}>
+              Band
+            </TableHead>
+            <TableHead scope="col" className={specHeadNum}>
+              Multiplier
+            </TableHead>
+            <TableHead scope="col" className={specHeadNum}>
+              Plan 2 threshold
+            </TableHead>
+            <TableHead scope="col" className={specHeadNum}>
+              Fixed monthly (Plan 2)
+            </TableHead>
+            <TableHead scope="col" className={specHead}>
+              Territories
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {bandLadder.map((row) => (
+            <TableRow key={row.id}>
+              <TableHead scope="row" className="font-semibold text-foreground">
+                {row.id}
+                {row.multiplier === 1 && (
+                  <span className="ml-2 font-normal text-muted-foreground">
+                    UK band
+                  </span>
+                )}
+              </TableHead>
+              <TableCell className={specNum}>
+                {formatMultiplier(row.multiplier)}
+              </TableCell>
+              <TableCell className={specNum}>
+                {formatGBP(row.plan2Threshold)}
+              </TableCell>
+              <TableCell className={specNum}>
+                {formatGBPPence(row.plan2FixedMonthly)}
+              </TableCell>
+              <TableCell className="min-w-48 whitespace-normal text-muted-foreground">
+                <span className="font-mono text-foreground tabular-nums">
+                  {row.territoryCount}
+                </span>{" "}
+                &middot; {row.examples}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </ScrollFadeWrapper>
+  );
+}

--- a/src/components/guides/moving-abroad/FeaturedDestinationsTable.tsx
+++ b/src/components/guides/moving-abroad/FeaturedDestinationsTable.tsx
@@ -1,0 +1,66 @@
+import { ScrollFadeWrapper } from "@/components/shared/ScrollFadeWrapper";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatGBP, formatGBPPence, formatMultiplier } from "@/lib/format";
+import { surfaceCard } from "@/lib/surfaces";
+import { specHead, specHeadNum, specNum } from "../guide-parts";
+import { featuredDestinations } from "./overseas-data";
+
+/** The destinations readers ask about most, ordered by band. */
+export function FeaturedDestinationsTable() {
+  return (
+    <ScrollFadeWrapper className={surfaceCard}>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead scope="col" className={specHead}>
+              Destination
+            </TableHead>
+            <TableHead scope="col" className={specHeadNum}>
+              Band multiplier
+            </TableHead>
+            <TableHead scope="col" className={specHeadNum}>
+              Plan 2 threshold
+            </TableHead>
+            <TableHead scope="col" className={specHeadNum}>
+              Plan 5 threshold
+            </TableHead>
+            <TableHead scope="col" className={specHeadNum}>
+              Fixed monthly (Plan 2)
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {featuredDestinations.map((row) => (
+            <TableRow key={row.label}>
+              <TableHead
+                scope="row"
+                className="font-semibold whitespace-normal text-foreground"
+              >
+                {row.label}
+              </TableHead>
+              <TableCell className={specNum}>
+                {formatMultiplier(row.multiplier)}
+              </TableCell>
+              <TableCell className={specNum}>
+                {formatGBP(row.plan2Threshold)}
+              </TableCell>
+              <TableCell className={specNum}>
+                {formatGBP(row.plan5Threshold)}
+              </TableCell>
+              <TableCell className={specNum}>
+                {formatGBPPence(row.plan2FixedMonthly)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </ScrollFadeWrapper>
+  );
+}

--- a/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
+++ b/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
@@ -1,54 +1,57 @@
 import {
+  AirplaneTakeOff01Icon,
   AlertCircleIcon,
-  Globe02Icon,
+  CancelCircleIcon,
   CoinsPoundIcon,
-  CreditCardIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { Panel } from "@/components/instrument/Panel";
-import { ScrollFadeWrapper } from "@/components/shared/ScrollFadeWrapper";
 import { Heading } from "@/components/typography/Heading";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { formatGBP } from "@/lib/format";
+  formatGBP,
+  formatGBPPence,
+  formatMultiplier,
+  formatPercent,
+} from "@/lib/format";
+import { OVERSEAS_TAX_YEAR } from "@/lib/loans/overseasThresholds";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
-import { surfaceCard } from "@/lib/surfaces";
 import {
   GuideArticle,
   guideBreakout,
-  guideLink,
   KeyTakeaways,
-  SeamCell,
-  SeamGrid,
-  specHead,
-  specHeadNum,
-  specNum,
   Step,
   StepList,
 } from "../guide-parts";
 import {
+  ExternalLink,
+  guideLink,
+  SeamCell,
+  SeamGrid,
+} from "../guide-primitives";
+import { BandLadderTable } from "./BandLadderTable";
+import { FeaturedDestinationsTable } from "./FeaturedDestinationsTable";
+import {
+  bandCount,
+  ESTIMATOR_ANCHOR_ID,
+  featured,
+  govUkArrearsGuidanceLink,
+  govUkHowYouRepayLink,
   govUkOverseasThresholdsLink,
+  govUkUpdateEmploymentDetailsLink,
+  highestBand,
+  lowestBand,
   movingAbroadFaqs,
-  overseasComparisonLabel,
-  overseasThresholds,
-  UK_PLAN2_THRESHOLD,
+  SLC_ARREARS_PHONE,
+  territoriesBelowSpain,
 } from "./overseas-data";
+import { OverseasRepaymentEstimator } from "./OverseasRepaymentEstimator";
 
-const undergradRate = `${String(PLAN_CONFIGS.PLAN_2.repaymentRate * 100)}%`;
-const postgradRate = `${String(PLAN_CONFIGS.POSTGRADUATE.repaymentRate * 100)}%`;
-
-const govUkAbroadLink =
-  "https://www.gov.uk/repaying-your-student-loan/repaying-from-abroad";
-
-const linkClasses = guideLink;
+const undergradRate = formatPercent(PLAN_CONFIGS.PLAN_2.repaymentRate * 100);
+const postgradRate = formatPercent(
+  PLAN_CONFIGS.POSTGRADUATE.repaymentRate * 100,
+);
 
 export function MovingAbroadGuide() {
   return (
@@ -59,8 +62,9 @@ export function MovingAbroadGuide() {
         <>
           Moving overseas doesn&rsquo;t make your student loan disappear. The
           Student Loans Company (SLC) continues to collect repayments regardless
-          of where you live, and the rules for how much you pay change when you
-          leave the UK.
+          of where you live. The repayment rules are the same as in the UK, but
+          the threshold you repay above is set per country, and you pay SLC
+          directly instead of through your employer.
         </>
       }
       related={{
@@ -69,73 +73,50 @@ export function MovingAbroadGuide() {
         tools: ["/repaid", "/"],
         extraLinks: [
           {
-            href: "https://www.gov.uk/repaying-your-student-loan/repaying-from-abroad",
-            label: "GOV.UK: Repaying from Abroad",
+            href: govUkHowYouRepayLink,
+            label: "GOV.UK: How to repay (leaving the UK)",
+          },
+          {
+            href: govUkUpdateEmploymentDetailsLink,
+            label: "GOV.UK: Update your employment details",
+          },
+          {
+            href: govUkOverseasThresholdsLink,
+            label: "GOV.UK: Overseas thresholds for Plan 2",
           },
         ],
       }}
     >
       <section className="space-y-4">
         <Heading as="h2" size="section">
-          You Must Notify SLC
+          At a glance
         </Heading>
-        <p className="text-muted-foreground">
-          If you&rsquo;re planning to leave the UK for more than three months,
-          you are legally required to inform SLC. This applies whether
-          you&rsquo;re moving for work, travel, or any other reason.
-        </p>
-        <ul className="list-inside list-disc space-y-2 text-muted-foreground">
-          <li>
-            Notify SLC <strong>within three months</strong> of moving abroad
-          </li>
-          <li>Provide your new overseas address and contact details</li>
-          <li>
-            Submit evidence of your income through the{" "}
-            <a
-              href={govUkAbroadLink}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={linkClasses}
-            >
-              overseas income assessment form
-            </a>
-          </li>
-          <li>
-            Continue providing income evidence annually to keep your repayments
-            accurate
-          </li>
-        </ul>
-      </section>
-
-      <section className="space-y-4">
-        <Heading as="h2" size="section">
-          How Repayments Work Abroad
-        </Heading>
-        <p className="text-muted-foreground">
-          When you live in the UK, repayments are automatically deducted from
-          your salary through PAYE. Abroad, the system works differently.
-        </p>
-        <SeamGrid columns={3}>
+        <SeamGrid columns={2}>
           <SeamCell
             icon={
               <HugeiconsIcon
-                icon={Globe02Icon}
+                icon={CancelCircleIcon}
                 className="size-5 text-primary"
               />
             }
-            title="Country thresholds"
+            title="Is it wiped?"
           >
-            SLC sets{" "}
-            <a
-              href={govUkAbroadLink}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={linkClasses}
-            >
-              country-specific repayment thresholds
-            </a>{" "}
-            based on local cost of living — they may be higher or lower than the
-            UK threshold.
+            No. Your balance is only written off at the end of your plan&rsquo;s
+            term (25 to 40 years), and write-off may not apply if you&rsquo;re
+            in breach of your repayment obligations.
+          </SeamCell>
+          <SeamCell
+            icon={
+              <HugeiconsIcon
+                icon={AirplaneTakeOff01Icon}
+                className="size-5 text-primary"
+              />
+            }
+            title="When to tell SLC"
+          >
+            Before you leave, if you&rsquo;ll be outside the UK for more than 3
+            months &mdash; even if you won&rsquo;t be earning. The Republic of
+            Ireland counts as overseas.
           </SeamCell>
           <SeamCell
             icon={
@@ -144,103 +125,130 @@ export function MovingAbroadGuide() {
                 className="size-5 text-primary"
               />
             }
-            title="Repayment rates"
+            title="What you repay"
           >
-            You still repay {undergradRate} of income above the threshold for
-            undergraduate loans ({postgradRate} for Postgraduate Loans).
+            {undergradRate} of income above your country&rsquo;s threshold (
+            {postgradRate} for a Postgraduate loan), paid directly to SLC each
+            month and rounded down to whole pounds.
           </SeamCell>
           <SeamCell
             icon={
               <HugeiconsIcon
-                icon={CreditCardIcon}
-                className="size-5 text-primary"
+                icon={AlertCircleIcon}
+                className="size-5 text-signal"
               />
             }
-            title="Direct payments to SLC"
+            title="If you don't respond"
           >
-            Repayments are made directly to SLC rather than through your
-            employer.
+            A fixed monthly amount for your country &mdash;{" "}
+            {formatGBPPence(featured.australia.plan2FixedMonthly)} in Australia,{" "}
+            {formatGBPPence(featured.spain.plan2FixedMonthly)} in Spain for Plan
+            2 &mdash; and, on a Plan 2 loan, interest at the highest rate.
           </SeamCell>
         </SeamGrid>
       </section>
 
       <section className="space-y-4">
         <Heading as="h2" size="section">
-          Country-by-Country: How Your Threshold Changes
+          You must tell SLC before you leave
         </Heading>
         <p className="text-muted-foreground">
-          SLC doesn&rsquo;t use a single overseas threshold for everyone. Every
-          country is placed into a price-level band that multiplies the UK
-          threshold up or down based on local living costs, so the salary at
-          which you start repaying can sit below or above the UK&rsquo;s{" "}
-          {formatGBP(UK_PLAN2_THRESHOLD)}. This is where{" "}
-          <strong>middle earners abroad feel it most</strong> &mdash; in a
-          lower-threshold country, a mid-range salary that would barely trigger
-          repayments at home can pull a much bigger slice into the{" "}
-          {undergradRate} repayment band.
+          If you&rsquo;ll be outside the UK for more than 3 months &mdash; for
+          work, travel or any other reason &mdash; you must tell SLC before you
+          go. The duty is triggered by the length of the absence, not by whether
+          you&rsquo;ll be earning, and the Republic of Ireland counts as
+          overseas. Under 3 months away you don&rsquo;t need to tell SLC before
+          you go: you stay a UK taxpayer, and repayments carry on through PAYE
+          if you&rsquo;re employed or Self Assessment if you&rsquo;re
+          self-employed.
         </p>
-        <p className="text-muted-foreground">
-          The process is the same wherever you go: notify SLC within three
-          months, complete the overseas income assessment on your worldwide
-          income (converted into pounds), and re-submit evidence every year.
-          Only the threshold changes by country. Skip the assessment and SLC
-          falls back to fixed repayment amounts that are usually higher than
-          income-based ones.
+        <ul className="list-inside list-disc space-y-2 text-muted-foreground">
+          <li>
+            <ExternalLink href={govUkUpdateEmploymentDetailsLink}>
+              Update your employment details online
+            </ExternalLink>{" "}
+            &mdash; the service tells you exactly what SLC needs, and you can
+            record that you&rsquo;re unemployed.
+          </li>
+          <li>
+            Give evidence of your income: usually your last three months&rsquo;
+            payslips, or proof such as a recent bank statement if you&rsquo;re
+            not earning.
+          </li>
+          <li>
+            SLC then sets a repayment schedule in pounds sterling for up to 12
+            months, or defers repayments for 12 months if you&rsquo;re under
+            your country&rsquo;s threshold.
+          </li>
+          <li>
+            Update your details every year &mdash; SLC reassesses your income
+            annually, and you must tell it if your income changes in between.
+          </li>
+        </ul>
+      </section>
+
+      <section className="space-y-4">
+        <Heading as="h2" size="section" id={ESTIMATOR_ANCHOR_ID}>
+          Estimate your repayments in any country
+        </Heading>
+        <p className="text-pretty text-muted-foreground">
+          Pick a destination, your plan and your salary. The estimator applies
+          SLC&rsquo;s {OVERSEAS_TAX_YEAR} threshold for that country, converts
+          at the HMRC rate SLC uses, and shows what you&rsquo;d repay each month
+          against the UK &mdash; and what SLC charges instead if you don&rsquo;t
+          update your details.
         </p>
       </section>
 
       <div className={guideBreakout}>
-        <ScrollFadeWrapper className={surfaceCard}>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead scope="col" className={specHead}>
-                  Destination
-                </TableHead>
-                <TableHead scope="col" className={specHeadNum}>
-                  Plan 2 threshold (2026/27)
-                </TableHead>
-                <TableHead scope="col" className={specHead}>
-                  Compared to the UK
-                </TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {overseasThresholds.map((row) => (
-                <TableRow key={row.country}>
-                  <TableHead
-                    scope="row"
-                    className="font-semibold text-foreground"
-                  >
-                    {row.country}
-                  </TableHead>
-                  <TableCell className={specNum}>
-                    {formatGBP(row.threshold)}
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {overseasComparisonLabel(row.threshold)}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </ScrollFadeWrapper>
+        <OverseasRepaymentEstimator />
+      </div>
+
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          Country-by-country: how your threshold changes
+        </Heading>
+        <p className="text-muted-foreground">
+          SLC doesn&rsquo;t use a single overseas threshold. Every territory is
+          placed into one of {String(bandCount)} bands, from{" "}
+          {formatMultiplier(lowestBand.multiplier)} to{" "}
+          {formatMultiplier(highestBand.multiplier)} the UK threshold, using the
+          World Bank&rsquo;s Price Level Index &mdash; a measure of local costs
+          such as food, housing and transport. The bands are reset every 6
+          April, so your repayments can change even if your income hasn&rsquo;t.
+          This is where <strong>middle earners abroad feel it most</strong>{" "}
+          &mdash; in a lower-band country, a mid-range income that would barely
+          trigger repayments at home pulls a much bigger slice into the{" "}
+          {undergradRate} repayment band.
+        </p>
+        <p className="text-muted-foreground">
+          The process is the same wherever you go: tell SLC before you leave,
+          give details of your gross income (usually your last three
+          months&rsquo; payslips), which SLC converts into pounds sterling, and
+          update your details every year. Only the threshold changes by country.
+          Skip the update and SLC charges the fixed monthly repayment for your
+          country, which may be higher than an income-based amount.
+        </p>
+      </section>
+
+      <div className={guideBreakout}>
+        <BandLadderTable />
+      </div>
+
+      <div className={guideBreakout}>
+        <FeaturedDestinationsTable />
       </div>
 
       <div className="space-y-4">
         <p className="text-xs text-muted-foreground sm:text-sm">
-          Figures are SLC&rsquo;s Plan 2 (undergraduate) overseas thresholds for
-          2026/27, set against the UK threshold of{" "}
-          {formatGBP(UK_PLAN2_THRESHOLD)}. Other plans use a different base
-          figure, and SLC revises every country each April &mdash; always{" "}
-          <a
-            href={govUkOverseasThresholdsLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={linkClasses}
-          >
+          Figures are SLC&rsquo;s overseas thresholds for {OVERSEAS_TAX_YEAR},
+          set against the UK Plan 2 threshold of{" "}
+          {formatGBP(featured.uk.plan2Threshold)}. The band letters are ours
+          &mdash; GOV.UK lists one row per territory. Every plan has its own
+          table, and SLC revises every country each 6 April &mdash; always{" "}
+          <ExternalLink href={govUkOverseasThresholdsLink}>
             check the latest figures on GOV.UK
-          </a>
+          </ExternalLink>
           .
         </p>
         <ul className="list-inside list-disc space-y-2 text-muted-foreground">
@@ -248,86 +256,205 @@ export function MovingAbroadGuide() {
             <strong className="text-foreground">
               Australia, Canada &amp; New Zealand:
             </strong>{" "}
-            currently sit in the same band as the UK, so your threshold matches
-            the home figure and repayments feel much like they did in the UK.
+            sit in the same band as the UK (
+            {formatMultiplier(featured.australia.multiplier)}), so the threshold
+            is identical to the home figure &mdash;{" "}
+            {formatGBP(featured.australia.plan2Threshold)} for Plan 2. The
+            difference is mechanical: you pay SLC directly each month on a
+            schedule built from your payslips, converted at HMRC&rsquo;s annual
+            average exchange rate.
           </li>
           <li>
-            <strong className="text-foreground">Spain:</strong> a lower band
-            pulls the threshold below the UK&rsquo;s, so repayments start
-            earlier &mdash; a classic squeeze on middle earners.
+            <strong className="text-foreground">Spain &amp; the UAE:</strong>{" "}
+            both sit at {formatMultiplier(featured.spain.multiplier)} &mdash;
+            band {featured.spain.territory.band} of {String(bandCount)},{" "}
+            {formatGBP(featured.spain.plan2Threshold)} for Plan 2 &mdash; so
+            repayments start{" "}
+            {formatGBP(
+              featured.uk.plan2Threshold - featured.spain.plan2Threshold,
+            )}{" "}
+            of income earlier than at home. Dubai&rsquo;s lack of local income
+            tax makes no difference: your UK student loan is separate from local
+            tax, so a tax-free income is caught sooner, not exempted.
           </li>
           <li>
-            <strong className="text-foreground">UAE (Dubai):</strong> there is
-            no local income tax, but your UK student loan is separate from that
-            &mdash; the SLC threshold is still lower than the UK&rsquo;s, so a
-            tax-free salary is caught sooner, not exempted.
+            <strong className="text-foreground">United States:</strong>{" "}
+            {formatMultiplier(featured.usa.multiplier)} (
+            {formatGBP(featured.usa.plan2Threshold)} for Plan 2) lifts the
+            threshold above the UK&rsquo;s, so you keep more of your income
+            before repayments begin. Only Bermuda and the Cayman Islands sit
+            higher, at {formatMultiplier(highestBand.multiplier)}.
           </li>
           <li>
-            <strong className="text-foreground">United States:</strong> a higher
-            band lifts the threshold above the UK&rsquo;s, so you keep more of
-            your salary before repayments begin.
+            <strong className="text-foreground">The lowest bands:</strong>{" "}
+            {String(territoriesBelowSpain)} territories sit below Spain&rsquo;s
+            band, down to {formatMultiplier(lowestBand.multiplier)} (
+            {formatGBP(lowestBand.plan2Threshold)}) in countries such as India,
+            Pakistan and Nigeria &mdash; where even a modest local income
+            converted to pounds can clear the threshold.
           </li>
         </ul>
       </div>
 
       <section className="space-y-4">
-        <Alert className="border-signal/30 bg-signal-wash text-signal">
-          <HugeiconsIcon icon={AlertCircleIcon} className="size-4" />
-          <AlertTitle>
-            What If You Don&rsquo;t Provide Income Evidence?
-          </AlertTitle>
-          <AlertDescription className="text-signal">
-            <p>
-              If you fail to complete the overseas income assessment, SLC
-              doesn&rsquo;t simply stop collecting. Instead, they apply{" "}
-              <strong>fixed repayment amounts</strong> that are not based on
-              your actual income.
-            </p>
-            <ul className="mt-2 list-inside list-disc space-y-1 marker:text-signal">
-              <li>
-                Fixed amounts can be <strong>significantly higher</strong> than
-                what you would pay based on your real income
-              </li>
-              <li>
-                This effectively acts as a penalty for not engaging with the
-                process
-              </li>
-              <li>
-                You can avoid this by submitting your income evidence on time
-                each year
-              </li>
-            </ul>
-          </AlertDescription>
-        </Alert>
+        <Heading as="h2" size="section">
+          How SLC works out your income
+        </Heading>
+        <p className="text-muted-foreground">
+          SLC assesses your gross annual income in pounds sterling. If
+          you&rsquo;re paid monthly it takes your last three months&rsquo;
+          payslips, averages them and multiplies by 12 (12 weekly or 6
+          fortnightly payslips work the same way). Regular bonuses, overtime and
+          commission are inside that average; one-off payments are added
+          afterwards; superannuation isn&rsquo;t counted.
+        </p>
+        <ul className="list-inside list-disc space-y-2 text-muted-foreground">
+          <li>
+            <strong className="text-foreground">Exchange rate:</strong>{" "}
+            HMRC&rsquo;s average rate for the most recent calendar year,
+            reviewed every 6 April. It doesn&rsquo;t follow month-to-month
+            movements, so a currency swing changes nothing until the next April.
+          </li>
+          <li>
+            <strong className="text-foreground">Fees:</strong> you repay in
+            pounds, and you bear any currency-conversion and bank-transfer costs
+            yourself.
+          </li>
+          <li>
+            <strong className="text-foreground">Schedule:</strong> an
+            income-based schedule runs for up to 12 months, then SLC reassesses.
+            Tell SLC if your income rises or falls in between, so your
+            repayments are reassessed.
+          </li>
+          <li>
+            <strong className="text-foreground">UK-taxed income:</strong> income
+            already collected through PAYE or Self Assessment is disregarded, so
+            you&rsquo;re not assessed twice on the same money.
+          </li>
+        </ul>
       </section>
 
       <section className="space-y-4">
         <Heading as="h2" size="section">
-          Consequences of Non-Compliance
+          Interest while you&rsquo;re abroad
         </Heading>
-        <p className="text-pretty text-muted-foreground">
-          Ignoring your student loan obligations while abroad can have serious
-          consequences. SLC has several enforcement mechanisms available.
+        <p className="text-muted-foreground">
+          For Plan 2, the interest rate is set from the income you give in your
+          overseas assessment, using your country&rsquo;s lower and upper
+          interest thresholds, and applies for the length of that assessment.
+          The{" "}
+          <Link href="/guides/how-interest-works" className={guideLink}>
+            sliding scale
+          </Link>{" "}
+          is the same shape as at home &mdash; RPI at the lower threshold, RPI +
+          3% at the upper &mdash; but the thresholds move with the band:
+          Spain&rsquo;s run from {formatGBP(featured.spain.plan2Threshold)} to{" "}
+          {formatGBP(featured.spain.plan2UpperThreshold)}, the United
+          States&rsquo; from {formatGBP(featured.usa.plan2Threshold)} to{" "}
+          {formatGBP(featured.usa.plan2UpperThreshold)}, against{" "}
+          {formatGBP(featured.uk.plan2Threshold)} to{" "}
+          {formatGBP(featured.uk.plan2UpperThreshold)} in the UK. The{" "}
+          <Link href="/guides/interest-rate-cap" className={guideLink}>
+            Plan 2 interest cap
+          </Link>{" "}
+          still applies.
+        </p>
+        <p className="text-muted-foreground">
+          If you don&rsquo;t keep your employment details up to date, Plan 2
+          interest goes to the highest rate &mdash; RPI + 3% &mdash; whatever
+          your income, for as long as your details are out of date. Plan 1, Plan
+          4, Plan 5 and Postgraduate interest rates are not income-based, so an
+          overseas assessment does not change them.
+        </p>
+      </section>
+
+      <section className="space-y-4">
+        <Alert className="border-signal/30 bg-signal-wash text-signal">
+          <HugeiconsIcon icon={AlertCircleIcon} className="size-4" />
+          <AlertTitle>What if you don&rsquo;t update your details?</AlertTitle>
+          <AlertDescription className="text-signal">
+            <p>
+              SLC doesn&rsquo;t stop collecting. It charges the{" "}
+              <strong>fixed monthly repayment</strong> for your country instead
+              of an income-based figure &mdash; for Plan 2 in{" "}
+              {OVERSEAS_TAX_YEAR} that is{" "}
+              {formatGBPPence(featured.spain.plan2FixedMonthly)} in Spain and
+              the UAE, {formatGBPPence(featured.australia.plan2FixedMonthly)} in
+              Australia, Canada and New Zealand, and{" "}
+              {formatGBPPence(featured.usa.plan2FixedMonthly)} in the United
+              States.
+            </p>
+            <ul className="mt-2 list-inside list-disc space-y-1 marker:text-signal">
+              <li>
+                The fixed amount <strong>may be higher</strong> than an
+                income-based repayment &mdash; it is set from twice the median
+                graduate salary, not from your income.
+              </li>
+              <li>
+                It is not an additional charge: every pound paid still reduces
+                your balance. But every month you don&rsquo;t pay it becomes{" "}
+                <ExternalLink href={govUkArrearsGuidanceLink}>
+                  arrears
+                </ExternalLink>
+                .
+              </li>
+              <li>
+                Plan 2 interest moves to the <strong>highest rate</strong>, RPI
+                + 3%, for as long as your details are out of date.
+              </li>
+              <li>
+                SLC can charge a <strong>penalty</strong>, demand the whole loan
+                plus interest and penalties in <strong>one lump sum</strong>,
+                and add the cost of tracing you and recovering the debt to your
+                loan.
+              </li>
+              <li>
+                SLC can take <strong>court action</strong> to recover the debt.
+                A court order is enforced as a civil debt whether you&rsquo;re
+                in the UK or abroad, and you bear the legal costs.
+              </li>
+            </ul>
+          </AlertDescription>
+        </Alert>
+        <p className="text-muted-foreground">
+          <strong className="text-foreground">
+            Student loans do not appear on credit reports or affect your credit
+            score
+          </strong>{" "}
+          &mdash; GOV.UK says so in plain words, and that stays true abroad.
+          Only a court judgment obtained after legal action could reach your
+          credit file.
+        </p>
+      </section>
+
+      <section className="space-y-4">
+        <Heading as="h2" size="section">
+          Returning to the UK
+        </Heading>
+        <p className="text-muted-foreground">
+          Update your employment details as soon as you&rsquo;re back after more
+          than 3 months away. If you don&rsquo;t, SLC keeps charging you at the
+          rate for the country you&rsquo;ve left &mdash; which can mean paying
+          more than you need to, or a higher interest rate &mdash; and once
+          you&rsquo;re in UK employment, PAYE deductions restart on top.
         </p>
         <Panel>
-          <ul className="list-disc space-y-2 pl-5 text-muted-foreground marker:text-signal">
+          <ul className="list-disc space-y-2 pl-5 text-muted-foreground marker:text-primary">
             <li>
-              SLC can take <strong>legal action</strong> to recover the debt.
+              PAYE deductions <strong>do not clear overseas arrears</strong>.
+              Arrange any arrears separately with SLC&rsquo;s arrears line on{" "}
+              <span className="font-mono text-foreground tabular-nums">
+                {SLC_ARREARS_PHONE}
+              </span>
+              .
             </li>
             <li>
-              Your debt may be passed to <strong>collection agencies</strong>.
+              Short visits home of under 3 months don&rsquo;t change your
+              overseas status &mdash; your overseas schedule carries on.
             </li>
             <li>
-              If you return to the UK, missed payments could{" "}
-              <strong>affect your credit record</strong>.
-            </li>
-            <li>
-              Additional <strong>penalties and interest</strong> may be applied
-              to your balance.
-            </li>
-            <li>
-              HMRC can resume automatic deductions from your salary if you
-              return to UK employment.
+              Interest reverts to the standard UK calculation from the date you
+              return.
             </li>
           </ul>
         </Panel>
@@ -335,55 +462,50 @@ export function MovingAbroadGuide() {
 
       <section className="space-y-4">
         <Heading as="h2" size="section">
-          Practical Steps Before You Move
+          Practical steps before you move
         </Heading>
         <p className="text-muted-foreground">
           If you&rsquo;re planning to move abroad, take these steps to stay on
           top of your loan.
         </p>
         <StepList>
-          {[
-            {
-              title: "Notify SLC",
-              description:
-                "Inform SLC of your move and new address as early as possible.",
-            },
-            {
-              title: "Complete the overseas income assessment",
-              description:
-                "Submit the form to ensure your repayments are based on your actual income.",
-            },
-            {
-              title: "Check your country\u2019s threshold",
-              description:
-                "Look up the SLC website so you know what to expect for your destination.",
-            },
-            {
-              title: "Set up a payment method",
-              description:
-                "Arrange a way to make direct repayments to SLC from abroad.",
-            },
-            {
-              title: "Keep records",
-              description:
-                "Save all correspondence and payment confirmations with SLC.",
-            },
-            {
-              title: "Set annual reminders",
-              description:
-                "Resubmit income evidence before the deadline each year.",
-            },
-          ].map((step, i) => (
-            <Step key={step.title} index={i + 1} title={step.title}>
-              {step.description}
-            </Step>
-          ))}
+          <Step index={1} title="Tell SLC before you leave">
+            If you&rsquo;ll be away for more than 3 months, even if you
+            won&rsquo;t be earning. The Republic of Ireland counts as overseas.
+          </Step>
+          <Step index={2} title="Update your employment details online">
+            Give the evidence the service asks for &mdash; usually three
+            months&rsquo; payslips, or a bank statement if you&rsquo;re not
+            earning &mdash; so SLC sets an income-based schedule or defers your
+            repayments for 12 months.
+          </Step>
+          <Step index={3} title="Check your country's threshold">
+            Use the{" "}
+            <a href={`#${ESTIMATOR_ANCHOR_ID}`} className={guideLink}>
+              estimator above
+            </a>{" "}
+            or the GOV.UK table for your plan, so you know what to expect before
+            the first schedule arrives.
+          </Step>
+          <Step index={4} title="Set up a way to pay">
+            A Direct Debit or an international debit card through your online
+            account, or an international bank transfer quoting your customer
+            reference number. You bear conversion and bank fees.
+          </Step>
+          <Step index={5} title="Keep records">
+            Payslips, the evidence you sent, and every SLC letter and payment
+            confirmation.
+          </Step>
+          <Step index={6} title="Set an annual reminder">
+            SLC reassesses your income every year and any schedule lasts at most
+            12 months. Tell SLC sooner if your income changes.
+          </Step>
         </StepList>
       </section>
 
       <section className="space-y-4">
         <Heading as="h2" size="section">
-          Moving Abroad: Frequently Asked Questions
+          Moving abroad: frequently asked questions
         </Heading>
         <Panel
           padding={false}
@@ -401,22 +523,28 @@ export function MovingAbroadGuide() {
       <KeyTakeaways>
         <li>
           Moving abroad does <strong>not</strong> cancel or pause your student
-          loan repayments.
+          loan. Write-off still comes only at the end of your plan&rsquo;s term,
+          and may not apply if you&rsquo;re in breach.
         </li>
         <li>
-          You must notify SLC within three months and provide annual income
-          evidence.
+          Tell SLC <strong>before you leave</strong> for more than 3 months, and
+          update your employment details every year &mdash; even if you&rsquo;re
+          not earning.
         </li>
         <li>
-          Repayment thresholds vary by country based on local cost of living.
+          Your threshold depends on your country: {String(bandCount)} bands from{" "}
+          {formatMultiplier(lowestBand.multiplier)} to{" "}
+          {formatMultiplier(highestBand.multiplier)} the UK figure, reset every
+          6 April.
         </li>
         <li>
-          Failing to engage with SLC results in fixed repayment amounts that are
-          typically higher than income-based payments.
+          If you don&rsquo;t update your details, SLC charges your
+          country&rsquo;s fixed monthly repayment, applies the highest interest
+          rate to a Plan 2 loan, and can demand the whole loan.
         </li>
         <li>
-          Non-compliance can lead to legal action, collection agencies, and
-          credit impacts if you return to the UK.
+          Student loans don&rsquo;t appear on credit reports or affect your
+          credit score &mdash; abroad or at home.
         </li>
         <li>
           Before you move, check your remaining balance and repayment timeline

--- a/src/components/guides/moving-abroad/OverseasRepaymentEstimator.tsx
+++ b/src/components/guides/moving-abroad/OverseasRepaymentEstimator.tsx
@@ -1,0 +1,489 @@
+"use client";
+
+import { ArrowDown01Icon, ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
+import { useId, useState } from "react";
+import { NumericFormat } from "react-number-format";
+import { CustomInput } from "@/components/home/CurrencyInput";
+import {
+  metricValueClass,
+  type MetricTone,
+} from "@/components/instrument/MetricReadout";
+import { Panel, PanelHeader } from "@/components/instrument/Panel";
+import { Figure } from "@/components/typography/Figure";
+import { Label } from "@/components/ui/label";
+import { MAX_SALARY, MIN_SALARY } from "@/constants";
+import {
+  formatExchangeRate,
+  formatGBP,
+  formatGBPPence,
+  formatMultiplier,
+  formatPercent,
+} from "@/lib/format";
+import {
+  estimateOverseasRepayment,
+  fromGBP,
+  getTerritory,
+  requireTerritory,
+  toGBP,
+  usesSterling,
+  type OverseasRepaymentEstimate,
+} from "@/lib/loans/overseas";
+import {
+  OVERSEAS_SOURCE_URLS,
+  OVERSEAS_TAX_YEAR,
+  OVERSEAS_TERRITORIES,
+  type OverseasTerritory,
+} from "@/lib/loans/overseasThresholds";
+import {
+  PLAN_DISPLAY_INFO,
+  POSTGRADUATE_DISPLAY_INFO,
+} from "@/lib/loans/plans";
+import type { PlanType } from "@/lib/loans/types";
+import { PRESETS } from "@/lib/presets";
+import { cn } from "@/lib/utils";
+import {
+  ExternalLink,
+  guideLink,
+  SeamCell,
+  SeamGrid,
+  segmentToggle,
+} from "../guide-primitives";
+
+const PLAN_LABELS: Record<PlanType, string> = {
+  PLAN_1: PLAN_DISPLAY_INFO.PLAN_1.name,
+  PLAN_2: PLAN_DISPLAY_INFO.PLAN_2.name,
+  PLAN_4: PLAN_DISPLAY_INFO.PLAN_4.name,
+  PLAN_5: PLAN_DISPLAY_INFO.PLAN_5.name,
+  POSTGRADUATE: POSTGRADUATE_DISPLAY_INFO.name,
+};
+
+/** The chip order, matching PLAN_PAGE_ORDER in src/lib/planContent.ts. */
+const PLAN_ORDER: PlanType[] = [
+  "PLAN_1",
+  "PLAN_2",
+  "PLAN_4",
+  "PLAN_5",
+  "POSTGRADUATE",
+];
+
+/**
+ * The calculator needs a balance to model and the guide cannot know the
+ * reader's, so the link hands over the plan's preset balance.
+ */
+function presetBalance(plan: PlanType): number {
+  return (
+    PRESETS.flatMap((preset) => preset.loans).find(
+      (loan) => loan.planType === plan,
+    )?.balance ?? 45_000
+  );
+}
+
+const TYPICAL_BALANCE: Record<PlanType, number> = {
+  PLAN_1: presetBalance("PLAN_1"),
+  PLAN_2: presetBalance("PLAN_2"),
+  PLAN_4: presetBalance("PLAN_4"),
+  PLAN_5: presetBalance("PLAN_5"),
+  POSTGRADUATE: presetBalance("POSTGRADUATE"),
+};
+
+const DEFAULT_TERRITORY = requireTerritory("Australia");
+const DEFAULT_INCOME_GBP = 40_000;
+
+/**
+ * A `<select>` cannot render through `<Input>` — base-ui's input takes no
+ * `render` prop — so it carries Input's own classes. Keep in step with
+ * src/components/ui/input.tsx.
+ */
+const SELECT_CLASS = cn(
+  "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-[3px] aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+  "h-9 appearance-none pr-9",
+);
+
+function calculatorHref(plan: PlanType, incomeGBP: number): string {
+  const salary = Math.min(
+    MAX_SALARY,
+    Math.max(MIN_SALARY, Math.round(incomeGBP)),
+  );
+  return `/?loans=${plan}:${String(TYPICAL_BALANCE[plan])}&sal=${String(salary)}`;
+}
+
+function ThresholdNote({ estimate }: { estimate: OverseasRepaymentEstimate }) {
+  if (estimate.band.multiplier === 1) {
+    return <>the same as the UK&rsquo;s {formatGBP(estimate.ukThreshold)}</>;
+  }
+  return (
+    <>
+      {formatMultiplier(estimate.band.multiplier)} the UK&rsquo;s{" "}
+      {formatGBP(estimate.ukThreshold)}
+    </>
+  );
+}
+
+function RepaymentNote({ estimate }: { estimate: OverseasRepaymentEstimate }) {
+  const { monthlyRepayment, ukMonthlyRepayment, territory } = estimate;
+  if (monthlyRepayment === 0) {
+    return (
+      <>
+        Your income is below {territory.name}&rsquo;s threshold. Update your
+        details and SLC can defer repayments for 12 months.
+      </>
+    );
+  }
+  const delta = monthlyRepayment - ukMonthlyRepayment;
+  return (
+    <>
+      {formatPercent(estimate.repaymentRate * 100)} of the{" "}
+      {formatGBP(Math.round(estimate.incomeAboveThreshold))} above your
+      threshold &mdash; {formatGBP(Math.round(estimate.annualRepayment))} a
+      year, rounded down to whole pounds each month.{" "}
+      {delta === 0 ? (
+        <span className="font-medium text-foreground">
+          The same as in the UK.
+        </span>
+      ) : (
+        <span
+          className={cn(
+            "font-mono font-semibold tabular-nums",
+            delta > 0 ? "text-signal" : "text-cta",
+          )}
+        >
+          {delta > 0 ? "+" : "−"}
+          {formatGBP(Math.abs(delta))}
+          <span className="font-sans font-medium"> a month vs the UK</span>
+        </span>
+      )}
+    </>
+  );
+}
+
+function FixedNote({ estimate }: { estimate: OverseasRepaymentEstimate }) {
+  const { fixedMonthlyRepayment, monthlyRepayment, plan } = estimate;
+  const delta = fixedMonthlyRepayment - monthlyRepayment;
+  let comparison: string;
+  if (monthlyRepayment === 0) {
+    comparison = "a month, whatever your income";
+  } else if (delta === 0) {
+    comparison = "a month — the same as your income-based figure";
+  } else if (delta > 0) {
+    comparison = `a month — ${formatGBPPence(delta)} more than your income-based figure`;
+  } else {
+    comparison = `a month — ${formatGBPPence(-delta)} less than your income-based figure`;
+  }
+  // Only Plan 2 interest tracks income, so only Plan 2 has a highest rate.
+  const interest =
+    plan === "PLAN_2" ? ", plus interest at the highest rate" : "";
+  return (
+    <>
+      {comparison}
+      {interest}. It still reduces your balance, but unpaid months become
+      arrears.
+    </>
+  );
+}
+
+function interestReadout(estimate: OverseasRepaymentEstimate): {
+  figure: string;
+  note: React.ReactNode;
+} {
+  const { plan, band, territory } = estimate;
+  switch (plan) {
+    case "PLAN_2":
+      return {
+        figure: `RPI + ${(estimate.plan2InterestAboveRpi ?? 0).toFixed(1)}%`,
+        note: (
+          <>
+            Based on the income you give SLC, against {territory.name}&rsquo;s
+            interest thresholds of {formatGBP(estimate.threshold)} to{" "}
+            {formatGBP(band.plan2UpperThreshold)}: RPI at the lower, RPI + 3% at
+            the upper. The{" "}
+            <Link href="/guides/interest-rate-cap" className={guideLink}>
+              Plan 2 interest cap
+            </Link>{" "}
+            still applies.
+          </>
+        ),
+      };
+    case "PLAN_1":
+    case "PLAN_4":
+      return {
+        figure: "RPI",
+        note: "Or the BoE base rate + 1% if that is lower — the same rule as in the UK.",
+      };
+    case "PLAN_5":
+      return {
+        figure: "RPI",
+        note: "Plan 5 interest is RPI only, in the UK or abroad.",
+      };
+    case "POSTGRADUATE":
+      return {
+        figure: "RPI + 3%",
+        note: "Postgraduate interest is RPI + 3% wherever you live.",
+      };
+  }
+}
+
+export function OverseasRepaymentEstimator() {
+  const id = useId();
+  const destinationId = `${id}-destination`;
+  const planLabelId = `${id}-plan-label`;
+  const salaryId = `${id}-salary`;
+  const currencyLabelId = `${id}-currency-label`;
+
+  const [territory, setTerritory] =
+    useState<OverseasTerritory>(DEFAULT_TERRITORY);
+  const [plan, setPlan] = useState<PlanType>("PLAN_2");
+  const [incomeGBP, setIncomeGBP] = useState<number | "">(DEFAULT_INCOME_GBP);
+  const [showLocal, setShowLocal] = useState(false);
+
+  const sterling = usesSterling(territory);
+  const localCurrency = showLocal && !sterling;
+  const income = incomeGBP === "" ? 0 : incomeGBP;
+  const displayedIncome =
+    incomeGBP === ""
+      ? ""
+      : Math.round(localCurrency ? fromGBP(incomeGBP, territory) : incomeGBP);
+
+  const estimate = estimateOverseasRepayment({
+    plan,
+    territory,
+    annualIncomeGBP: income,
+  });
+  const interest = interestReadout(estimate);
+
+  const readouts: {
+    eyebrow: string;
+    figure: string;
+    tone?: MetricTone;
+    note: React.ReactNode;
+  }[] = [
+    {
+      eyebrow: `Your repayment threshold in ${territory.name}`,
+      figure: formatGBP(estimate.threshold),
+      note: <ThresholdNote estimate={estimate} />,
+    },
+    {
+      eyebrow: "Monthly repayment",
+      figure: formatGBP(estimate.monthlyRepayment),
+      note: <RepaymentNote estimate={estimate} />,
+    },
+    {
+      eyebrow: "If you don't update your details",
+      figure: formatGBPPence(estimate.fixedMonthlyRepayment),
+      tone: "cost",
+      note: <FixedNote estimate={estimate} />,
+    },
+    {
+      eyebrow: "Interest while abroad",
+      figure: interest.figure,
+      note: interest.note,
+    },
+  ];
+
+  return (
+    <Panel data-slot="overseas-estimator" className="space-y-5">
+      <PanelHeader
+        caption={`Fig. 1 — Overseas repayment estimator · ${OVERSEAS_TAX_YEAR} SLC thresholds`}
+        figure={`Band ${estimate.band.id} · ${formatMultiplier(estimate.band.multiplier)}`}
+      />
+
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor={destinationId}>Destination</Label>
+          <div className="relative">
+            <select
+              id={destinationId}
+              value={territory.name}
+              onChange={(event) => {
+                const next = getTerritory(event.target.value);
+                if (next) setTerritory(next);
+              }}
+              className={SELECT_CLASS}
+            >
+              {OVERSEAS_TERRITORIES.map((option) => (
+                <option key={option.name} value={option.name}>
+                  {option.name}
+                </option>
+              ))}
+            </select>
+            <HugeiconsIcon
+              icon={ArrowDown01Icon}
+              aria-hidden="true"
+              className="pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2 text-muted-foreground"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <span
+            id={planLabelId}
+            className="flex items-center text-sm leading-none font-medium"
+          >
+            Plan
+          </span>
+          <div
+            role="group"
+            aria-labelledby={planLabelId}
+            className="flex flex-wrap gap-1"
+          >
+            {PLAN_ORDER.map((option) => (
+              <button
+                key={option}
+                type="button"
+                aria-pressed={plan === option}
+                onClick={() => {
+                  setPlan(option);
+                }}
+                className={segmentToggle(plan === option)}
+              >
+                {PLAN_LABELS[option]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="min-w-0 flex-1 space-y-2">
+            <Label htmlFor={salaryId}>Annual salary</Label>
+            <div className="relative">
+              {!localCurrency && (
+                <span
+                  aria-hidden="true"
+                  className="absolute top-1/2 left-3 -translate-y-1/2 text-muted-foreground"
+                >
+                  £
+                </span>
+              )}
+              <NumericFormat
+                id={salaryId}
+                value={displayedIncome}
+                onValueChange={(values, sourceInfo) => {
+                  // Only user input carries an event. A prop-driven re-format
+                  // must not round-trip the GBP figure through the local
+                  // currency and drift it.
+                  if (sourceInfo.event === undefined) return;
+                  if (values.floatValue === undefined) {
+                    setIncomeGBP("");
+                    return;
+                  }
+                  setIncomeGBP(
+                    localCurrency
+                      ? toGBP(values.floatValue, territory)
+                      : values.floatValue,
+                  );
+                }}
+                customInput={CustomInput}
+                className={cn(
+                  "h-9 font-mono tabular-nums",
+                  !localCurrency && "pl-7",
+                )}
+                decimalScale={0}
+                thousandSeparator
+                allowNegative={false}
+                inputMode="numeric"
+              />
+            </div>
+          </div>
+          {!sterling && (
+            <div className="space-y-2">
+              <span
+                id={currencyLabelId}
+                className="flex items-center text-sm leading-none font-medium"
+              >
+                Currency
+              </span>
+              <div
+                role="group"
+                aria-labelledby={currencyLabelId}
+                className="flex flex-wrap gap-1"
+              >
+                <button
+                  type="button"
+                  aria-pressed={!localCurrency}
+                  onClick={() => {
+                    setShowLocal(false);
+                  }}
+                  className={segmentToggle(!localCurrency)}
+                >
+                  GBP
+                </button>
+                <button
+                  type="button"
+                  aria-pressed={localCurrency}
+                  onClick={() => {
+                    setShowLocal(true);
+                  }}
+                  className={segmentToggle(localCurrency)}
+                >
+                  {territory.currency}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div aria-live="polite" data-slot="overseas-estimator-readout">
+        <SeamGrid columns={2}>
+          {readouts.map((readout) => (
+            <SeamCell key={readout.eyebrow} eyebrow={readout.eyebrow}>
+              <p className={metricValueClass(readout.tone)}>
+                <Figure value={readout.figure} />
+              </p>
+              <p className="mt-2">{readout.note}</p>
+            </SeamCell>
+          ))}
+        </SeamGrid>
+      </div>
+
+      <div className="flex flex-col gap-3 border-t border-border pt-4 text-sm text-muted-foreground sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+        <div className="space-y-1">
+          <p>
+            {sterling ? (
+              <>
+                SLC uses a rate of 1 for {territory.name}, so no conversion
+                applies.
+              </>
+            ) : (
+              <>
+                SLC uses HMRC&rsquo;s annual average rate: 1{" "}
+                {territory.currency} ={" "}
+                <span className="font-mono text-foreground tabular-nums">
+                  {formatExchangeRate(territory.exchangeRateToGBP)}
+                </span>
+                {localCurrency && (
+                  <>
+                    {" "}
+                    &mdash; your salary is{" "}
+                    <span className="font-mono text-foreground tabular-nums">
+                      {formatGBP(Math.round(income))}
+                    </span>
+                  </>
+                )}
+                .
+              </>
+            )}
+          </p>
+          <p>
+            <ExternalLink href={OVERSEAS_SOURCE_URLS[plan]}>
+              GOV.UK: {PLAN_LABELS[plan]} overseas thresholds,{" "}
+              {OVERSEAS_TAX_YEAR}
+            </ExternalLink>
+          </p>
+        </div>
+        <Link
+          href={calculatorHref(plan, income)}
+          className="group inline-flex shrink-0 items-center gap-1.5 font-semibold text-foreground no-underline transition-colors hover:text-cta"
+        >
+          Model the rest of your loan at this salary
+          <HugeiconsIcon
+            icon={ArrowRight01Icon}
+            aria-hidden="true"
+            className="size-4 shrink-0 text-primary transition-transform group-hover:translate-x-0.5"
+          />
+        </Link>
+      </div>
+    </Panel>
+  );
+}

--- a/src/components/guides/moving-abroad/overseas-data.ts
+++ b/src/components/guides/moving-abroad/overseas-data.ts
@@ -1,97 +1,182 @@
-import { formatGBP } from "@/lib/format";
+import {
+  formatExchangeRate,
+  formatGBP,
+  formatGBPPence,
+  formatMultiplier,
+} from "@/lib/format";
+import { getOverseasBand, requireTerritory } from "@/lib/loans/overseas";
+import {
+  OVERSEAS_BANDS,
+  OVERSEAS_PUBLICATION_URLS,
+  OVERSEAS_TAX_YEAR,
+  OVERSEAS_TERRITORIES,
+  type OverseasBandId,
+} from "@/lib/loans/overseasThresholds";
 
-// SLC sets a separate repayment threshold for each country by placing it in a
-// price-level band that multiplies the UK threshold. The figures below are the
-// Plan 2 (undergraduate) overseas thresholds for the 2026/27 tax year, as
-// published by SLC on GOV.UK. They are hardcoded because they describe a
-// specific tax year and must not shift when the live UK config updates — SLC
-// revises them every April, hence the "check the latest" caveat shown in the UI.
-export const UK_PLAN2_THRESHOLD = 29_385; // 2026/27 UK Plan 2 threshold
-const LOWER_BAND_THRESHOLD = 23_510; // e.g. Spain, UAE (~0.8× the UK band)
-const HIGHER_BAND_THRESHOLD = 35_260; // e.g. USA (~1.2× the UK band)
+// Every figure on the page derives from the 2026/27 SLC dataset in
+// src/lib/loans/overseasThresholds.ts, so prose, tables, the estimator and the
+// FAQ JSON-LD can never disagree with each other.
 
-export const govUkOverseasThresholdsLink =
-  "https://www.gov.uk/government/publications/overseas-earnings-thresholds-for-plan-2-student-loans";
+/** Anchor id on the estimator's section heading — the in-page link's target. */
+export const ESTIMATOR_ANCHOR_ID = "overseas-estimator";
 
-export type OverseasThreshold = {
-  country: string;
-  threshold: number;
+export const govUkHowYouRepayLink =
+  "https://www.gov.uk/repaying-your-student-loan/how-you-repay";
+export const govUkUpdateEmploymentDetailsLink =
+  "https://www.gov.uk/repaying-your-student-loan/update-your-employment-details";
+export const govUkOverseasThresholdsLink = OVERSEAS_PUBLICATION_URLS.PLAN_2;
+export const govUkArrearsGuidanceLink =
+  "https://www.gov.uk/guidance/how-arrears-can-accrue-on-your-student-loan-account-when-youre-overseas";
+export const SLC_ARREARS_PHONE = "+44 141 243 3970";
+
+/**
+ * One featured destination, keyed by the name GOV.UK prints. `label` is the
+ * shorter form tables and prose use, e.g. "UAE (Dubai)".
+ */
+function describe(name: string, label: string = name) {
+  const territory = requireTerritory(name);
+  const band = getOverseasBand(territory);
+  return {
+    label,
+    territory,
+    multiplier: band.multiplier,
+    plan2Threshold: band.thresholds.PLAN_2,
+    plan2UpperThreshold: band.plan2UpperThreshold,
+    plan5Threshold: band.thresholds.PLAN_5,
+    postgraduateThreshold: band.thresholds.POSTGRADUATE,
+    plan2FixedMonthly: band.fixedMonthly.PLAN_2,
+  };
+}
+
+export const featured = {
+  spain: describe("Spain"),
+  uae: describe("United Arab Emirates", "UAE (Dubai)"),
+  australia: describe("Australia"),
+  usa: describe("United States of America", "United States"),
+  uk: describe("United Kingdom"),
 };
 
 // Ordered by band (lower → UK → higher) so the middle-earner story reads down
-// the table: a lower threshold pulls more of a mid-range salary into the 9% band.
-export const overseasThresholds: OverseasThreshold[] = [
-  { country: "Spain", threshold: LOWER_BAND_THRESHOLD },
-  { country: "UAE (Dubai)", threshold: LOWER_BAND_THRESHOLD },
-  { country: "Australia", threshold: UK_PLAN2_THRESHOLD },
-  { country: "Canada", threshold: UK_PLAN2_THRESHOLD },
-  { country: "New Zealand", threshold: UK_PLAN2_THRESHOLD },
-  { country: "United States", threshold: HIGHER_BAND_THRESHOLD },
+// the table: a lower threshold pulls more of a mid-range income into the 9% band.
+export const featuredDestinations = [
+  featured.spain,
+  featured.uae,
+  featured.australia,
+  describe("Canada"),
+  describe("New Zealand"),
+  featured.usa,
 ];
 
-// How each country's threshold compares to the UK band, derived from the figures
-// above so the label can never drift from the number shown next to it.
-export function overseasComparisonLabel(threshold: number): string {
-  if (threshold === UK_PLAN2_THRESHOLD) {
-    return "Matches the UK threshold";
-  }
-  const multiplier = (threshold / UK_PLAN2_THRESHOLD).toFixed(1);
-  return threshold > UK_PLAN2_THRESHOLD
-    ? `Higher — about ${multiplier}× the UK band`
-    : `Lower — about ${multiplier}× the UK band`;
+/** Recognisable members of each band, for the ladder table. */
+const BAND_EXAMPLES: Record<OverseasBandId, string> = {
+  A: "India, Pakistan, Nigeria, Egypt",
+  B: "South Africa, Thailand, Turkey, Malaysia",
+  C: "Portugal, Poland, Brazil, Singapore",
+  D: "Spain, France, Germany, Japan, UAE",
+  E: "Australia, Canada, Ireland, Netherlands",
+  F: "United States, Switzerland, Iceland",
+  G: "Bermuda, Cayman Islands",
+};
+
+const TERRITORY_COUNTS: Record<OverseasBandId, number> = {
+  A: 0,
+  B: 0,
+  C: 0,
+  D: 0,
+  E: 0,
+  F: 0,
+  G: 0,
+};
+for (const territory of OVERSEAS_TERRITORIES) {
+  TERRITORY_COUNTS[territory.band]++;
 }
 
-export type MovingAbroadFaq = {
-  question: string;
-  answer: string;
-};
+export const bandLadder = OVERSEAS_BANDS.map((band) => ({
+  id: band.id,
+  multiplier: band.multiplier,
+  plan2Threshold: band.thresholds.PLAN_2,
+  plan2FixedMonthly: band.fixedMonthly.PLAN_2,
+  territoryCount: TERRITORY_COUNTS[band.id],
+  examples: BAND_EXAMPLES[band.id],
+}));
+
+export const lowestBand = bandLadder[0];
+export const highestBand = bandLadder[bandLadder.length - 1];
+export const bandCount = bandLadder.length;
+
+/** How many territories sit in a band below Spain's. */
+export const territoriesBelowSpain = bandLadder
+  .filter((row) => row.multiplier < featured.spain.multiplier)
+  .reduce((sum, row) => sum + row.territoryCount, 0);
+
+const year = OVERSEAS_TAX_YEAR;
+const ukPlan2 = formatGBP(featured.uk.plan2Threshold);
+const spainPlan2 = formatGBP(featured.spain.plan2Threshold);
+const usaPlan2 = formatGBP(featured.usa.plan2Threshold);
 
 // Single source of truth for the visible FAQ and the FAQPage JSON-LD in
 // layout.tsx, so the structured data can never drift from what the page shows.
 // The country-specific questions lead because they mirror real search queries.
-export const movingAbroadFaqs: MovingAbroadFaq[] = [
+export const movingAbroadFaqs = [
   {
     question: "Does your student loan get wiped if you move abroad?",
-    answer: `No. Moving abroad does not cancel your student loan or wipe the balance, and there is no rule that writes it off after three years overseas. Your loan is only written off at the end of your plan's term — typically 25, 30 or 40 years depending on your plan — and that clock keeps ticking wherever you live, whether or not you make repayments. Living abroad changes how much you repay, not whether the balance still exists.`,
+    answer: `No. Moving abroad does not cancel your student loan or wipe the balance, and there is no rule that writes it off after three years overseas. Your loan is only written off at the end of your plan's term — 25, 30 or 40 years depending on your plan — and that clock keeps running wherever you live. Write-off may not apply if you are in breach of your repayment obligations, and SLC can still recover repayments that were due before the write-off date.`,
   },
   {
     question:
       "What happens to my student loan if I move to Canada, Australia or New Zealand?",
-    answer: `You must tell the Student Loans Company within three months of leaving and complete the overseas income assessment. Australia, Canada and New Zealand currently sit in the same price band as the UK, so your repayment threshold stays close to the UK figure (${formatGBP(UK_PLAN2_THRESHOLD)} for Plan 2 in 2026/27). You then repay 9% of income above that threshold, with your overseas earnings converted into pounds.`,
+    answer: `You must tell the Student Loans Company before you leave if you will be away for more than 3 months, then update your employment details online. Australia, Canada and New Zealand sit in the same price band as the UK, so your repayment threshold is identical to the UK figure (${ukPlan2} for Plan 2 in ${year}). You repay 9% of income above it directly to SLC each month, with your payslips converted at HMRC's annual average exchange rate.`,
   },
   {
     question:
       "Do I still repay my student loan in Dubai if there's no income tax?",
-    answer: `Yes. UK student loan repayments are completely separate from local income tax, so a tax-free salary in the UAE does not exempt you. The UAE threshold is actually lower than the UK's (${formatGBP(LOWER_BAND_THRESHOLD)} versus ${formatGBP(UK_PLAN2_THRESHOLD)} for Plan 2 in 2026/27), so a Dubai salary can trigger repayments earlier than the same salary would at home.`,
+    answer: `Yes. UK student loan repayments are separate from local income tax, so a tax-free income in the UAE does not exempt you. The UAE sits in a lower band than the UK — ${formatGBP(featured.uae.plan2Threshold)} versus ${ukPlan2} for Plan 2 in ${year} — so the same income starts repayments earlier than it would at home. If you do not update your details, SLC charges the UAE's fixed monthly repayment of ${formatGBPPence(featured.uae.plan2FixedMonthly)} instead.`,
   },
   {
     question: "Which countries have a lower student loan repayment threshold?",
-    answer: `Countries with a lower cost of living than the UK are placed in a lower price band, which reduces the salary at which repayments begin. For Plan 2 in 2026/27, Spain and the UAE sit around ${formatGBP(LOWER_BAND_THRESHOLD)} — below the UK's ${formatGBP(UK_PLAN2_THRESHOLD)} — while higher-cost countries such as the United States are higher, at ${formatGBP(HIGHER_BAND_THRESHOLD)}. A lower threshold hits middle earners hardest, because more of a mid-range salary falls into the 9% repayment band.`,
+    answer: `SLC places every territory in one of seven bands from ${formatMultiplier(lowestBand.multiplier)} to ${formatMultiplier(highestBand.multiplier)} the UK threshold, using the World Bank's Price Level Index. For Plan 2 in ${year}, Spain and the UAE sit at ${spainPlan2} (${formatMultiplier(featured.spain.multiplier)}); India, Pakistan and Nigeria at ${formatGBP(lowestBand.plan2Threshold)} (${formatMultiplier(lowestBand.multiplier)}); the United States at ${usaPlan2} (${formatMultiplier(featured.usa.multiplier)}); and only Bermuda and the Cayman Islands at ${formatGBP(highestBand.plan2Threshold)} (${formatMultiplier(highestBand.multiplier)}). A lower threshold pulls more of a mid-range income into the 9% repayment band, so the same income repays more than it would in the UK.`,
   },
   {
     question: "Do I still pay my student loan if I move abroad?",
-    answer:
-      "Yes. Moving abroad does not cancel your student loan. You must notify the Student Loans Company within three months of leaving the UK, provide evidence of your overseas income, and make repayments based on country-specific thresholds set by SLC.",
+    answer: `Yes. Moving abroad does not cancel your student loan. You must tell the Student Loans Company before you leave if you will be away for more than 3 months, update your employment details with evidence of your income, and repay 9% (6% for Postgraduate loans) of income above your country's threshold directly to SLC. If your income is below the threshold, SLC can defer repayments for 12 months.`,
   },
   {
     question: "What happens if I don't tell SLC I've moved abroad?",
-    answer:
-      "If you fail to provide income evidence, SLC will apply fixed repayment amounts that can be significantly higher than what you would pay based on your actual income. They may also take legal action, pass your debt to collection agencies, or apply penalties and additional interest.",
+    answer: `SLC charges the fixed monthly repayment for your country — ${formatGBPPence(featured.spain.plan2FixedMonthly)} a month in Spain or ${formatGBPPence(featured.australia.plan2FixedMonthly)} in Australia for Plan 2 in ${year} — which may be higher than an income-based amount. Unpaid amounts become arrears, Plan 2 interest goes to the highest rate (RPI + 3%), and SLC can charge a penalty, demand the whole loan in one lump sum, and take court action. Student loans still do not appear on your credit report.`,
   },
   {
     question:
       "How are student loan repayments calculated when living overseas?",
-    answer:
-      "SLC sets country-specific repayment thresholds based on the cost of living in your country of residence. You still repay 9% of income above the threshold (6% for Postgraduate loans), but the threshold itself varies by country rather than using the standard UK figure.",
+    answer: `SLC converts your gross annual income into pounds at HMRC's annual average exchange rate, usually from your last three months' payslips, and subtracts your country's repayment threshold. You repay 9% of the remainder (6% for Postgraduate loans), split over 12 months and rounded down to whole pounds. For example, €33,000 in Spain converts to about £28,164, which gives £34 a month for Plan 2 in ${year}.`,
+  },
+  {
+    question: "What exchange rate does SLC use for overseas repayments?",
+    answer: `SLC converts your income into pounds using the average exchange rate for the most recent calendar year published by HMRC, reviewed every 6 April; it does not track month-to-month movements. For ${year}, 1 Australian dollar is ${formatExchangeRate(featured.australia.territory.exchangeRateToGBP)}, 1 euro is ${formatExchangeRate(featured.spain.territory.exchangeRateToGBP)} and 1 US dollar is ${formatExchangeRate(featured.usa.territory.exchangeRateToGBP)}. You then repay in pounds sterling and bear any currency-conversion and bank-transfer fees yourself.`,
+  },
+  {
+    question:
+      "Do the overseas thresholds apply to Plan 5 and Postgraduate loans?",
+    answer: `Yes. SLC publishes a separate overseas table for every plan, and each uses the same country bands. For ${year}, Spain's threshold is ${formatGBP(featured.spain.plan5Threshold)} for Plan 5 and ${formatGBP(featured.spain.postgraduateThreshold)} for a Postgraduate loan, against ${formatGBP(featured.uk.plan5Threshold)} and ${formatGBP(featured.uk.postgraduateThreshold)} in the UK; the United States is ${formatGBP(featured.usa.plan5Threshold)} and ${formatGBP(featured.usa.postgraduateThreshold)}. You repay 9% above the Plan 5 threshold and 6% above the Postgraduate one — both at once if you hold both loans.`,
+  },
+  {
+    question:
+      "Do I have to repay my student loan if I'm travelling or not working abroad?",
+    answer: `You still have to tell SLC before you leave if you will be away for more than 3 months, even if you are not earning. Update your employment details online — you can record that you are unemployed — and give proof such as a recent bank statement. If your income is below your country's threshold, SLC defers repayments for 12 months. If you say nothing, your country's fixed monthly repayment applies instead.`,
+  },
+  {
+    question: "Does moving abroad affect my credit score?",
+    answer: `No. GOV.UK states that student loans do not appear on credit reports and do not affect your credit score, and moving abroad does not change that. The consequences of ignoring SLC are different: arrears on your loan account, the highest interest rate, a penalty charge and, ultimately, a court order — and only a court judgment could reach your credit file. Lenders may still consider your student loan in affordability checks for other borrowing.`,
   },
   {
     question: "What happens to my student loan if I emigrate from the UK?",
-    answer:
-      "Your loan remains active regardless of where you live. When you emigrate, you must contact the Student Loans Company within three months, complete an overseas income assessment, and switch to country-specific repayment thresholds. The write-off date stays the same — emigrating does not reset or extend it.",
+    answer: `Your loan remains active regardless of where you live. Before you leave, tell the Student Loans Company and update your employment details; SLC then sets a repayment schedule from your country's threshold for up to 12 months at a time, reassessed each year. The write-off date stays the same — emigrating does not reset or extend it — although write-off may not apply if you are in breach of your repayment obligations.`,
+  },
+  {
+    question: "What happens to my student loan when I come back to the UK?",
+    answer: `Update your employment details as soon as you return after more than 3 months away. If you do not, SLC keeps charging you at the rate for the country you left, possibly at a higher interest rate, while PAYE deductions restart once you are employed. PAYE repayments do not clear any overseas arrears — arrange those separately with SLC's arrears line on ${SLC_ARREARS_PHONE}. Visits under 3 months do not change your status.`,
   },
   {
     question: "Can I avoid paying my student loan by moving abroad?",
-    answer:
-      "No. The Student Loans Company actively tracks overseas borrowers and has legal powers to pursue repayment internationally. If you do not respond to income assessments, SLC will impose fixed repayment amounts that are often much higher than income-based repayments. They may also refer your account to debt collection agencies or take court action.",
+    answer: `No. SLC can recover the debt through the courts as a civil debt whether you are in the UK or abroad, and can add the cost of tracing your address and income to your loan. If you do not respond to income requests, SLC charges your country's fixed monthly repayment — from ${formatGBPPence(lowestBand.plan2FixedMonthly)} to ${formatGBPPence(highestBand.plan2FixedMonthly)} a month for Plan 2 in ${year} — applies the highest interest rate to a Plan 2 loan, and can demand the whole loan in one lump sum.`,
   },
 ];

--- a/src/components/guides/pay-upfront-or-take-loan/PayUpfrontGuide.tsx
+++ b/src/components/guides/pay-upfront-or-take-loan/PayUpfrontGuide.tsx
@@ -7,12 +7,8 @@ import {
   PLAN_DISPLAY_INFO,
   TUITION_FEE_CAP,
 } from "@/lib/loans/plans";
-import {
-  GuideArticle,
-  guideBreakout,
-  guideLink,
-  KeyTakeaways,
-} from "../guide-parts";
+import { GuideArticle, guideBreakout, KeyTakeaways } from "../guide-parts";
+import { guideLink } from "../guide-primitives";
 import { CostComparisonChart } from "./CostComparisonChart";
 
 const tuitionTotal = TUITION_FEE_CAP * 3;

--- a/src/components/guides/plan-2-vs-plan-5/BalanceComparisonChart.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/BalanceComparisonChart.tsx
@@ -6,6 +6,7 @@ import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
 import type { ChartConfig } from "@/components/ui/chart";
 import { simulate } from "@/lib/loans/engine";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
+import { segmentToggle } from "../guide-primitives";
 
 const SALARY_OPTIONS = [30000, 50000, 70000] as const;
 type SalaryOption = (typeof SALARY_OPTIONS)[number];
@@ -110,11 +111,7 @@ export function BalanceComparisonChart() {
               onClick={() => {
                 setSalary(option);
               }}
-              className={`rounded-md px-3 py-1 text-sm font-medium transition-colors ${
-                salary === option
-                  ? "bg-foreground text-background"
-                  : "bg-muted text-muted-foreground hover:bg-muted/80"
-              }`}
+              className={segmentToggle(salary === option)}
             >
               {formatSalaryLabel(option)}
             </button>

--- a/src/components/guides/plan-2-vs-plan-5/Plan2VsPlan5Guide.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/Plan2VsPlan5Guide.tsx
@@ -3,12 +3,8 @@ import { ChartFrame } from "@/components/instrument/ChartFrame";
 import { Heading } from "@/components/typography/Heading";
 import { formatGBP } from "@/lib/format";
 import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
-import {
-  GuideArticle,
-  guideBreakout,
-  guideLink,
-  KeyTakeaways,
-} from "../guide-parts";
+import { GuideArticle, guideBreakout, KeyTakeaways } from "../guide-parts";
+import { guideLink } from "../guide-primitives";
 import { BalanceComparisonChart } from "./BalanceComparisonChart";
 import { ComparisonTable } from "./ComparisonTable";
 import { TotalRepaymentBySalaryChart } from "./TotalRepaymentBySalaryChart";

--- a/src/components/guides/rpi-vs-cpi/InflationComparisonChart.tsx
+++ b/src/components/guides/rpi-vs-cpi/InflationComparisonChart.tsx
@@ -6,6 +6,7 @@ import type { ChartConfig } from "@/components/ui/chart";
 import { simulate } from "@/lib/loans/engine";
 import { CURRENT_RATES } from "@/lib/loans/plans";
 import { toPresent } from "@/utils/presentValue";
+import { segmentToggle } from "../guide-primitives";
 
 const SALARY_OPTIONS = [30000, 50000, 70000] as const;
 type SalaryOption = (typeof SALARY_OPTIONS)[number];
@@ -94,11 +95,7 @@ export function InflationComparisonChart() {
               onClick={() => {
                 setSalary(option);
               }}
-              className={`rounded-md px-3 py-1 text-sm font-medium transition-colors ${
-                salary === option
-                  ? "bg-foreground text-background"
-                  : "bg-muted text-muted-foreground hover:bg-muted/80"
-              }`}
+              className={segmentToggle(salary === option)}
             >
               {formatSalaryLabel(option)}
             </button>

--- a/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
+++ b/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
@@ -3,12 +3,8 @@ import { ChartFrame } from "@/components/instrument/ChartFrame";
 import { Heading } from "@/components/typography/Heading";
 import { formatPercent } from "@/lib/format";
 import { CURRENT_RATES } from "@/lib/loans/plans";
-import {
-  GuideArticle,
-  guideBreakout,
-  guideLink,
-  KeyTakeaways,
-} from "../guide-parts";
+import { GuideArticle, guideBreakout, KeyTakeaways } from "../guide-parts";
+import { guideLink } from "../guide-primitives";
 import { InflationComparisonChart } from "./InflationComparisonChart";
 
 const rpi = CURRENT_RATES.rpi;

--- a/src/components/guides/self-employment/SelfEmploymentGuide.tsx
+++ b/src/components/guides/self-employment/SelfEmploymentGuide.tsx
@@ -9,18 +9,16 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { Heading } from "@/components/typography/Heading";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
+import { GuideArticle, KeyTakeaways } from "../guide-parts";
 import {
-  GuideArticle,
+  ExternalLink,
   guideLink,
-  KeyTakeaways,
   SeamCell,
   SeamGrid,
-} from "../guide-parts";
+} from "../guide-primitives";
 
 const undergradRate = `${String(PLAN_CONFIGS.PLAN_2.repaymentRate * 100)}%`;
 const postgradRate = `${String(PLAN_CONFIGS.POSTGRADUATE.repaymentRate * 100)}%`;
-
-const linkClasses = guideLink;
 
 export function SelfEmploymentGuide() {
   return (
@@ -32,14 +30,9 @@ export function SelfEmploymentGuide() {
           If you&rsquo;re self-employed, your student loan repayments work
           differently from PAYE. Instead of automatic monthly deductions from
           your payslip, you repay through your annual{" "}
-          <a
-            href="https://www.gov.uk/self-assessment-tax-returns"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={linkClasses}
-          >
+          <ExternalLink href="https://www.gov.uk/self-assessment-tax-returns">
             Self Assessment tax return
-          </a>{" "}
+          </ExternalLink>{" "}
           — and that changes how you need to plan your finances.
         </>
       }
@@ -83,28 +76,18 @@ export function SelfEmploymentGuide() {
             repayments from your salary each month via PAYE. When you&rsquo;re
             self-employed, there is no employer to do this — HMRC calculates
             your repayment based on your{" "}
-            <a
-              href="https://www.gov.uk/self-assessment-tax-returns"
-              target="_blank"
-              rel="noopener noreferrer"
-              className={linkClasses}
-            >
+            <ExternalLink href="https://www.gov.uk/self-assessment-tax-returns">
               Self Assessment tax return
-            </a>{" "}
+            </ExternalLink>{" "}
             instead.
           </p>
           <p>
             This means your repayments are <strong>annual</strong>, not monthly.
             You typically pay in two lump sums: one in January and one in July
             (as part of HMRC&rsquo;s{" "}
-            <a
-              href="https://www.gov.uk/understand-self-assessment-bill/payments-on-account"
-              target="_blank"
-              rel="noopener noreferrer"
-              className={linkClasses}
-            >
+            <ExternalLink href="https://www.gov.uk/understand-self-assessment-bill/payments-on-account">
               payment on account
-            </a>{" "}
+            </ExternalLink>{" "}
             system). The repayment is {undergradRate} of your net profit above
             the repayment threshold for Plan 2 and Plan 5, or {postgradRate} for
             Postgraduate Loans.
@@ -256,14 +239,9 @@ export function SelfEmploymentGuide() {
               description: (
                 <>
                   You must{" "}
-                  <a
-                    href="https://www.gov.uk/register-for-self-assessment"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={linkClasses}
-                  >
+                  <ExternalLink href="https://www.gov.uk/register-for-self-assessment">
                     register with HMRC by 5 October
-                  </a>{" "}
+                  </ExternalLink>{" "}
                   following the end of the tax year in which you became
                   self-employed. Registering late can result in penalties.
                 </>

--- a/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
+++ b/src/components/guides/student-loan-vs-mortgage/MortgageGuide.tsx
@@ -11,12 +11,8 @@ import { Panel } from "@/components/instrument/Panel";
 import { Heading } from "@/components/typography/Heading";
 import { formatGBP } from "@/lib/format";
 import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
-import {
-  GuideArticle,
-  guideBreakout,
-  guideLink,
-  KeyTakeaways,
-} from "../guide-parts";
+import { GuideArticle, guideBreakout, KeyTakeaways } from "../guide-parts";
+import { guideLink } from "../guide-primitives";
 import { RepaymentImpactChart } from "./RepaymentImpactChart";
 
 const plan2Threshold = PLAN_DISPLAY_INFO.PLAN_2.yearlyThreshold;

--- a/src/components/guides/threshold-freeze/ThresholdFreezeGuide.tsx
+++ b/src/components/guides/threshold-freeze/ThresholdFreezeGuide.tsx
@@ -7,7 +7,8 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { formatGBP } from "@/lib/format";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
 import { getCurrentTaxYearLabel } from "@/lib/taxYear";
-import { GuideArticle, guideBreakout, guideLink } from "../guide-parts";
+import { GuideArticle, guideBreakout } from "../guide-parts";
+import { guideLink } from "../guide-primitives";
 import { CurrentThresholdsTable } from "./CurrentThresholdsTable";
 import { ThresholdComparisonChart } from "./ThresholdComparisonChart";
 

--- a/src/components/home/CurrencyInput.tsx
+++ b/src/components/home/CurrencyInput.tsx
@@ -43,7 +43,11 @@ export function CurrencyInput({
   );
 }
 
-function CustomInput({
+/**
+ * `react-number-format`'s `customInput` slot: it owns the value and the ref, so
+ * the app's `<Input>` is wrapped rather than rendered directly.
+ */
+export function CustomInput({
   ref,
   ...props
 }: React.ComponentProps<"input"> & { ref?: React.Ref<HTMLInputElement> }) {

--- a/src/components/instrument/MetricReadout.tsx
+++ b/src/components/instrument/MetricReadout.tsx
@@ -97,11 +97,29 @@ function Chevron() {
 // the headline steps up to `fig-hero`, cost figures take the clay signal. Emphasis
 // keeps the value in ink and flips the *label* to spruce-ink (see CellInner) — the
 // homepage readout's headline treatment, now the shared standard.
-const VALUE_TONE: Record<"default" | "emphasis" | "cost", string> = {
+export type MetricTone = "default" | "emphasis" | "cost";
+
+const VALUE_TONE: Record<MetricTone, string> = {
   default: "text-fig-lg text-foreground",
   emphasis: "text-fig-hero text-foreground",
   cost: "text-fig-lg text-signal",
 };
+
+/**
+ * The readout figure treatment on its own, for surfaces that lay out their own
+ * cells (a guide's `SeamGrid`, say) but must set their figures the same way.
+ *
+ * `leading-none` trails the tone deliberately: a font-size utility overrides the
+ * line-height set before it, so the readout's 1.0 leading has to be the last
+ * word or the figure ramp would reintroduce normal leading.
+ */
+function metricValueClass(tone: MetricTone = "default"): string {
+  return cn(
+    "font-mono font-semibold tracking-tight tabular-nums",
+    VALUE_TONE[tone],
+    "leading-none",
+  );
+}
 
 type MetricCellProps = {
   /** Engraved sans label (the metric key). */
@@ -113,7 +131,7 @@ type MetricCellProps = {
    * and flips the label to spruce-ink, for the headline number) or `cost` (clay
    * signal, for interest/cost figures).
    */
-  tone?: "default" | "emphasis" | "cost";
+  tone?: MetricTone;
   /** Turns the whole cell into a drill-down link with hover + focus states. */
   href?: string;
   /** Marks the cell as the current page: no link, no chevron, spruce-ink label. */
@@ -149,14 +167,7 @@ function CellInner({
   children,
   hasViz,
 }: MetricCellProps & { chevron: boolean; hasViz: boolean }) {
-  // `leading-none` trails the tone deliberately: a font-size utility overrides
-  // the line-height set before it, so the readout's 1.0 leading has to be the
-  // last word or the figure ramp would reintroduce normal leading.
-  const valueClass = cn(
-    "font-mono font-semibold tracking-tight tabular-nums",
-    VALUE_TONE[tone],
-    "leading-none",
-  );
+  const valueClass = metricValueClass(tone);
   return (
     <>
       <div className="flex items-center justify-between gap-2">
@@ -270,4 +281,4 @@ function MetricCell({
   );
 }
 
-export { MetricReadout, MetricCell };
+export { MetricReadout, MetricCell, metricValueClass };

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatExchangeRate,
   formatGBP,
+  formatGBPPence,
+  formatMultiplier,
   formatPercent,
   formatYearFromMonth,
   percentagesSummingTo100,
@@ -97,5 +100,35 @@ describe("percentagesSummingTo100", () => {
     expect(percentagesSummingTo100([1, 1, 2]).reduce((a, b) => a + b, 0)).toBe(
       100,
     );
+  });
+});
+
+describe("formatGBPPence", () => {
+  it("always shows two decimal places", () => {
+    expect(formatGBPPence(327.2)).toBe("£327.20");
+    expect(formatGBPPence(409)).toBe("£409.00");
+  });
+
+  it("keeps the thousands separator", () => {
+    expect(formatGBPPence(1234.5)).toBe("£1,234.50");
+  });
+});
+
+describe("formatMultiplier", () => {
+  it("shows one decimal place and the times sign", () => {
+    expect(formatMultiplier(0.8)).toBe("0.8×");
+    expect(formatMultiplier(1)).toBe("1.0×");
+  });
+});
+
+describe("formatExchangeRate", () => {
+  it("keeps the six decimal places HMRC publishes", () => {
+    expect(formatExchangeRate(0.489572)).toBe("£0.489572");
+    expect(formatExchangeRate(0.000029)).toBe("£0.000029");
+  });
+
+  it("drops trailing zeros, including the whole fraction", () => {
+    expect(formatExchangeRate(0.85)).toBe("£0.85");
+    expect(formatExchangeRate(1)).toBe("£1");
   });
 });

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,9 +1,17 @@
+// Reused formatters — building one per call costs ~25x more, and the overseas
+// estimator formats a dozen figures on every keystroke.
+const POUNDS = new Intl.NumberFormat("en-GB");
+const POUNDS_AND_PENCE = new Intl.NumberFormat("en-GB", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
 /**
  * Format a number as a GBP currency string with thousands separators.
  * @example formatGBP(28470) → "£28,470"
  */
 export function formatGBP(value: number): string {
-  return `£${value.toLocaleString("en-GB")}`;
+  return `£${POUNDS.format(value)}`;
 }
 
 /**
@@ -45,4 +53,30 @@ export function percentagesSummingTo100(ratios: number[]): number[] {
     result[byFraction[k].index]++;
   }
   return result;
+}
+
+/**
+ * Format a number as a GBP currency string to the penny.
+ * @example formatGBPPence(327.2) → "£327.20"
+ */
+export function formatGBPPence(value: number): string {
+  return `£${POUNDS_AND_PENCE.format(value)}`;
+}
+
+/**
+ * Format a band multiplier against the UK threshold.
+ * @example formatMultiplier(0.8) → "0.8×"
+ */
+export function formatMultiplier(value: number): string {
+  return `${value.toFixed(1)}×`;
+}
+
+/**
+ * Format an HMRC exchange rate: what one unit of a currency is worth in GBP,
+ * to the six decimal places HMRC publishes, trailing zeros dropped.
+ * @example formatExchangeRate(0.489572) → "£0.489572"
+ * @example formatExchangeRate(1) → "£1"
+ */
+export function formatExchangeRate(rateToGBP: number): string {
+  return `£${rateToGBP.toFixed(6).replace(/\.?0+$/, "")}`;
 }

--- a/src/lib/guides.ts
+++ b/src/lib/guides.ts
@@ -77,7 +77,7 @@ export const GUIDES: GuideEntry[] = [
     slug: "moving-abroad",
     title: "Moving Abroad",
     description:
-      "Country-specific thresholds, SLC obligations, and what happens if you don’t comply.",
+      "Estimate your repayment in any country, what to tell SLC before you leave, and what happens if you don’t.",
     topic: "Rules",
   },
   {

--- a/src/lib/loans/overseas.test.ts
+++ b/src/lib/loans/overseas.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+import {
+  estimateOverseasRepayment,
+  fromGBP,
+  getOverseasBand,
+  getTerritory,
+  monthlyRepaymentAboveThreshold,
+  requireTerritory,
+  toGBP,
+  usesSterling,
+} from "./overseas";
+import {
+  OVERSEAS_BANDS,
+  OVERSEAS_TERRITORIES,
+  OVERSEAS_UK_THRESHOLDS,
+  type OverseasBandId,
+} from "./overseasThresholds";
+
+const territory = requireTerritory;
+
+describe("overseas dataset", () => {
+  it("maps every one of the 248 GOV.UK territories to a band", () => {
+    expect(OVERSEAS_TERRITORIES).toHaveLength(248);
+    const bandIds = new Set(OVERSEAS_BANDS.map((band) => band.id));
+    for (const t of OVERSEAS_TERRITORIES) {
+      expect(bandIds.has(t.band)).toBe(true);
+      expect(t.exchangeRateToGBP).toBeGreaterThan(0);
+    }
+  });
+
+  it("uses every band letter", () => {
+    const letters: OverseasBandId[] = ["A", "B", "C", "D", "E", "F", "G"];
+    expect(OVERSEAS_BANDS.map((band) => band.id)).toEqual(letters);
+    const used = new Set(OVERSEAS_TERRITORIES.map((t) => t.band));
+    for (const letter of letters) {
+      expect(used.has(letter)).toBe(true);
+    }
+  });
+
+  it("has unique territory names sorted A–Z", () => {
+    const names = OVERSEAS_TERRITORIES.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+    const sorted = [...names].sort((a, b) =>
+      a.toLowerCase().localeCompare(b.toLowerCase()),
+    );
+    expect(names).toEqual(sorted);
+  });
+
+  it("band E is the UK band: multiplier 1 and the SLC-published UK figures", () => {
+    const bandE = OVERSEAS_BANDS.find((band) => band.id === "E");
+    expect(bandE?.multiplier).toBe(1);
+    expect(bandE?.thresholds).toEqual({
+      PLAN_1: 26_900,
+      PLAN_2: 29_385,
+      PLAN_4: 33_795,
+      PLAN_5: 25_000,
+      POSTGRADUATE: 21_000,
+    });
+    expect(OVERSEAS_UK_THRESHOLDS).toBe(bandE?.thresholds);
+    expect(territory("United Kingdom").band).toBe("E");
+  });
+
+  it("corrects the GOV.UK data defects", () => {
+    expect(
+      getOverseasBand(territory("Korea, Democratic People’s Republic of"))
+        .fixedMonthly.PLAN_5,
+    ).toBe(176.8);
+    expect(territory("Bulgaria").currency).toBe("Euro");
+    expect(territory("Bulgaria").exchangeRateToGBP).toBe(
+      territory("Spain").exchangeRateToGBP,
+    );
+  });
+});
+
+describe("Plan 2 thresholds and fixed monthly repayments for the named countries", () => {
+  it.each([
+    ["Spain", 23_510, 327.2],
+    ["United Arab Emirates", 23_510, 327.2],
+    ["Australia", 29_385, 409],
+    ["Canada", 29_385, 409],
+    ["New Zealand", 29_385, 409],
+    ["United States of America", 35_260, 490.8],
+  ])("%s → £%i threshold, £%s fixed monthly", (name, threshold, fixed) => {
+    const estimate = estimateOverseasRepayment({
+      plan: "PLAN_2",
+      territory: territory(name),
+      annualIncomeGBP: 40_000,
+    });
+    expect(estimate.threshold).toBe(threshold);
+    expect(estimate.fixedMonthlyRepayment).toBe(fixed);
+    expect(estimate.ukThreshold).toBe(29_385);
+  });
+
+  it("reports the band multiplier against the UK", () => {
+    expect(
+      estimateOverseasRepayment({
+        plan: "PLAN_2",
+        territory: territory("Spain"),
+        annualIncomeGBP: 40_000,
+      }).band.multiplier,
+    ).toBe(0.8);
+    expect(
+      estimateOverseasRepayment({
+        plan: "PLAN_2",
+        territory: territory("United States of America"),
+        annualIncomeGBP: 40_000,
+      }).band.multiplier,
+    ).toBe(1.2);
+    expect(
+      estimateOverseasRepayment({
+        plan: "PLAN_2",
+        territory: territory("Australia"),
+        annualIncomeGBP: 40_000,
+      }).band.multiplier,
+    ).toBe(1);
+  });
+});
+
+describe("other plans", () => {
+  it("Plan 5 Spain threshold is £20,000", () => {
+    const estimate = estimateOverseasRepayment({
+      plan: "PLAN_5",
+      territory: territory("Spain"),
+      annualIncomeGBP: 30_000,
+    });
+    expect(estimate.threshold).toBe(20_000);
+    expect(estimate.ukThreshold).toBe(25_000);
+    expect(estimate.repaymentRate).toBe(0.09);
+    expect(estimate.plan2InterestAboveRpi).toBeUndefined();
+  });
+
+  it("Postgraduate Spain threshold is £16,800 at 6%", () => {
+    const estimate = estimateOverseasRepayment({
+      plan: "POSTGRADUATE",
+      territory: territory("Spain"),
+      annualIncomeGBP: 30_000,
+    });
+    expect(estimate.threshold).toBe(16_800);
+    expect(estimate.repaymentRate).toBe(0.06);
+    // 6% of £13,200 = £792 a year → £66 a month
+    expect(estimate.annualRepayment).toBe(792);
+    expect(estimate.monthlyRepayment).toBe(66);
+  });
+});
+
+describe("monthly repayment rounding", () => {
+  it("rounds the monthly instalment down to whole pounds", () => {
+    // GOV.UK's own 2026/27 worked example: €33,000 in Spain → £34 a month.
+    const spain = territory("Spain");
+    const income = toGBP(33_000, spain);
+    expect(income).toBeCloseTo(28_164.21, 2);
+    const estimate = estimateOverseasRepayment({
+      plan: "PLAN_2",
+      territory: spain,
+      annualIncomeGBP: income,
+    });
+    expect(estimate.annualRepayment).toBeCloseTo(418.88, 2);
+    expect(estimate.monthlyRepayment).toBe(34);
+  });
+
+  it("does not lose a pound to float noise at an exact multiple", () => {
+    // £1,200 a year is exactly £100 a month.
+    expect(monthlyRepaymentAboveThreshold(29_385 + 13_334, 29_385, 0.09)).toBe(
+      100,
+    );
+  });
+
+  it("gives £0 below the threshold", () => {
+    const estimate = estimateOverseasRepayment({
+      plan: "PLAN_2",
+      territory: territory("Spain"),
+      annualIncomeGBP: 20_000,
+    });
+    expect(estimate.incomeAboveThreshold).toBe(0);
+    expect(estimate.annualRepayment).toBe(0);
+    expect(estimate.monthlyRepayment).toBe(0);
+  });
+
+  it("compares against the UK at the same income", () => {
+    const estimate = estimateOverseasRepayment({
+      plan: "PLAN_2",
+      territory: territory("Spain"),
+      annualIncomeGBP: 40_000,
+    });
+    // Spain: 9% of £16,490 = £1,484.10 → £123; UK: 9% of £10,615 = £955.35 → £79
+    expect(estimate.monthlyRepayment).toBe(123);
+    expect(estimate.ukMonthlyRepayment).toBe(79);
+  });
+});
+
+describe("Plan 2 interest abroad", () => {
+  it("uses the territory's lower and upper interest thresholds", () => {
+    const spain = territory("Spain");
+    const band = getOverseasBand(spain);
+    expect(band.plan2UpperThreshold).toBe(42_310);
+
+    const atLower = estimateOverseasRepayment({
+      plan: "PLAN_2",
+      territory: spain,
+      annualIncomeGBP: 23_510,
+    });
+    expect(atLower.plan2InterestAboveRpi).toBe(0);
+
+    const atUpper = estimateOverseasRepayment({
+      plan: "PLAN_2",
+      territory: spain,
+      annualIncomeGBP: 42_310,
+    });
+    expect(atUpper.plan2InterestAboveRpi).toBe(3);
+
+    const midway = estimateOverseasRepayment({
+      plan: "PLAN_2",
+      territory: spain,
+      annualIncomeGBP: (23_510 + 42_310) / 2,
+    });
+    expect(midway.plan2InterestAboveRpi).toBeCloseTo(1.5, 5);
+  });
+
+  it("differs from the UK scale at the same income", () => {
+    const income = 40_000;
+    const spain = estimateOverseasRepayment({
+      plan: "PLAN_2",
+      territory: territory("Spain"),
+      annualIncomeGBP: income,
+    });
+    const uk = estimateOverseasRepayment({
+      plan: "PLAN_2",
+      territory: territory("United Kingdom"),
+      annualIncomeGBP: income,
+    });
+    expect(spain.plan2InterestAboveRpi).toBeGreaterThan(
+      uk.plan2InterestAboveRpi ?? Number.NaN,
+    );
+  });
+});
+
+describe("currency conversion", () => {
+  it("round-trips through the HMRC rate", () => {
+    const australia = territory("Australia");
+    expect(toGBP(10_000, australia)).toBeCloseTo(4_895.72, 2);
+    expect(fromGBP(toGBP(60_000, australia), australia)).toBeCloseTo(60_000, 6);
+  });
+
+  it("recognises sterling territories", () => {
+    expect(usesSterling(territory("Channel Islands"))).toBe(true);
+    expect(usesSterling(territory("Gibraltar"))).toBe(true);
+    expect(usesSterling(territory("Spain"))).toBe(false);
+  });
+
+  it("returns undefined for an unknown territory", () => {
+    expect(getTerritory("Atlantis")).toBeUndefined();
+    expect(() => requireTerritory("Atlantis")).toThrow("Atlantis");
+  });
+});

--- a/src/lib/loans/overseas.ts
+++ b/src/lib/loans/overseas.ts
@@ -1,0 +1,144 @@
+import { getAnnualInterestRate } from "./interest";
+import {
+  OVERSEAS_BANDS_BY_ID,
+  OVERSEAS_TERRITORIES,
+  OVERSEAS_UK_THRESHOLDS,
+  type OverseasBand,
+  type OverseasTerritory,
+} from "./overseasThresholds";
+import { PLAN_CONFIGS } from "./plans";
+import type { PlanType } from "./types";
+
+const TERRITORIES_BY_NAME: ReadonlyMap<string, OverseasTerritory> = new Map(
+  OVERSEAS_TERRITORIES.map((territory) => [territory.name, territory]),
+);
+
+/** Look up a territory by the exact name GOV.UK prints. */
+export function getTerritory(name: string): OverseasTerritory | undefined {
+  return TERRITORIES_BY_NAME.get(name);
+}
+
+/**
+ * Look up a territory by the name GOV.UK prints, for a name the caller knows is
+ * in the dataset. The guide prerenders, so a renamed GOV.UK row fails the
+ * build, not the reader.
+ */
+export function requireTerritory(name: string): OverseasTerritory {
+  const territory = getTerritory(name);
+  if (!territory) {
+    throw new Error(`Overseas dataset has no territory named "${name}"`);
+  }
+  return territory;
+}
+
+export function getOverseasBand(territory: OverseasTerritory): OverseasBand {
+  return OVERSEAS_BANDS_BY_ID[territory.band];
+}
+
+/** True where the HMRC rate is 1, so no conversion applies. */
+export function usesSterling(territory: OverseasTerritory): boolean {
+  return territory.exchangeRateToGBP === 1;
+}
+
+/** Convert a local-currency amount to GBP at the HMRC rate SLC uses. */
+export function toGBP(
+  localAmount: number,
+  territory: OverseasTerritory,
+): number {
+  return localAmount * territory.exchangeRateToGBP;
+}
+
+/** Convert a GBP amount to the local currency at the HMRC rate SLC uses. */
+export function fromGBP(
+  gbpAmount: number,
+  territory: OverseasTerritory,
+): number {
+  return gbpAmount / territory.exchangeRateToGBP;
+}
+
+/**
+ * SLC's monthly instalment: the repayment rate on income above the threshold,
+ * split over 12 months and rounded down to whole pounds.
+ */
+export function monthlyRepaymentAboveThreshold(
+  annualIncomeGBP: number,
+  threshold: number,
+  repaymentRate: number,
+): number {
+  const incomeAboveThreshold = Math.max(0, annualIncomeGBP - threshold);
+  // Round to pence first so a float such as 899.9999 does not lose a pound.
+  const annualPence = Math.round(incomeAboveThreshold * repaymentRate * 100);
+  return Math.floor(annualPence / 1200);
+}
+
+export interface OverseasRepaymentEstimate {
+  plan: PlanType;
+  territory: OverseasTerritory;
+  band: OverseasBand;
+  /** Annual repayment threshold in the territory, GBP. */
+  threshold: number;
+  /** The UK threshold for the same plan, GBP. */
+  ukThreshold: number;
+  repaymentRate: number;
+  /** Income above the territory's threshold, GBP. */
+  incomeAboveThreshold: number;
+  /** The repayment rate applied to that excess for a year, GBP, to the penny. */
+  annualRepayment: number;
+  /** Monthly instalment, rounded down to whole pounds. */
+  monthlyRepayment: number;
+  /** What the same income would repay each month in the UK. */
+  ukMonthlyRepayment: number;
+  /** What SLC charges each month if details are not kept up to date. */
+  fixedMonthlyRepayment: number;
+  /** Plan 2 only: percentage points above RPI from the territory's interest thresholds. */
+  plan2InterestAboveRpi: number | undefined;
+}
+
+export function estimateOverseasRepayment({
+  plan,
+  territory,
+  annualIncomeGBP,
+}: {
+  plan: PlanType;
+  territory: OverseasTerritory;
+  annualIncomeGBP: number;
+}): OverseasRepaymentEstimate {
+  const band = getOverseasBand(territory);
+  const { repaymentRate } = PLAN_CONFIGS[plan];
+  const threshold = band.thresholds[plan];
+  const ukThreshold = OVERSEAS_UK_THRESHOLDS[plan];
+  const incomeAboveThreshold = Math.max(0, annualIncomeGBP - threshold);
+
+  // An RPI of 0 makes the sliding scale return only the points above RPI.
+  const plan2InterestAboveRpi =
+    plan === "PLAN_2"
+      ? getAnnualInterestRate("PLAN_2", annualIncomeGBP, 0, 0, {
+          interestLowerThreshold: threshold,
+          interestUpperThreshold: band.plan2UpperThreshold,
+        })
+      : undefined;
+
+  return {
+    plan,
+    territory,
+    band,
+    threshold,
+    ukThreshold,
+    repaymentRate,
+    incomeAboveThreshold,
+    annualRepayment:
+      Math.round(incomeAboveThreshold * repaymentRate * 100) / 100,
+    monthlyRepayment: monthlyRepaymentAboveThreshold(
+      annualIncomeGBP,
+      threshold,
+      repaymentRate,
+    ),
+    ukMonthlyRepayment: monthlyRepaymentAboveThreshold(
+      annualIncomeGBP,
+      ukThreshold,
+      repaymentRate,
+    ),
+    fixedMonthlyRepayment: band.fixedMonthly[plan],
+    plan2InterestAboveRpi,
+  };
+}

--- a/src/lib/loans/overseasThresholds.ts
+++ b/src/lib/loans/overseasThresholds.ts
@@ -1,0 +1,500 @@
+import { formatTaxYearLabel, getCurrentTaxYearStartYear } from "../taxYear";
+import type { PlanType } from "./types";
+
+/**
+ * SLC overseas repayment thresholds for the 2026/27 tax year
+ * (2026-04-06 to 2027-04-05).
+ *
+ * SLC revises every figure in this file on 6 April each year: the thresholds,
+ * the fixed monthly repayments and the HMRC exchange rates. Refresh the whole
+ * file from the five GOV.UK tables when the next tax year is published:
+ *   Plan 1: https://www.gov.uk/government/publications/overseas-earnings-thresholds-for-plan-1-student-loans/overseas-earnings-thresholds-for-plan-1-student-loans-2026-27
+ *   Plan 2: https://www.gov.uk/government/publications/overseas-earnings-thresholds-for-plan-2-student-loans/overseas-earnings-thresholds-for-plan-2-student-loans-2026-27
+ *   Plan 4: https://www.gov.uk/government/publications/overseas-earnings-thresholds-for-plan-4-student-loans/overseas-earnings-thresholds-for-plan-4-student-loans-2026-27
+ *   Plan 5: https://www.gov.uk/government/publications/overseas-earnings-thresholds-for-plan-5-student-loans/overseas-earnings-thresholds-for-plan-5-student-loans-2026-to-2027
+ *   Postgraduate: https://www.gov.uk/government/publications/overseas-earnings-thresholds-for-postgraduate-student-loans/overseas-earnings-thresholds-for-postgraduate-student-loans-2026-27
+ *
+ * GOV.UK prints no band letters — it lists one row per territory. The seven
+ * bands A–G are ours, ordered from the lowest multiplier (0.2×) to the
+ * highest (1.4×). The territory-to-band mapping and the exchange rates are
+ * identical across all five publications.
+ *
+ * Two GOV.UK data defects are corrected here. The Plan 5 table gives North
+ * Korea a fixed monthly repayment of £76.80 where every other 0.4× territory
+ * shows £176.80 — treated as a typo, so band B carries £176.80. Bulgaria is
+ * labelled "Bulgarian Lev" on three tables although all five apply the euro
+ * rate (Bulgaria adopted the euro on 1 January 2026), so it is labelled
+ * "Euro" throughout.
+ */
+
+/** ISO date the figures took effect. */
+export const OVERSEAS_APPLIES_FROM = "2026-04-06";
+
+/** The tax year the figures belong to, e.g. "2026/27". */
+export const OVERSEAS_TAX_YEAR = formatTaxYearLabel(
+  // Parsed as local time: a UTC midnight falls on 5 April west of Greenwich and
+  // would read as the previous tax year.
+  getCurrentTaxYearStartYear(new Date(`${OVERSEAS_APPLIES_FROM}T00:00:00`)),
+);
+
+/** The GOV.UK country tables for this tax year, per plan. */
+export const OVERSEAS_SOURCE_URLS: Record<PlanType, string> = {
+  PLAN_1:
+    "https://www.gov.uk/government/publications/overseas-earnings-thresholds-for-plan-1-student-loans/overseas-earnings-thresholds-for-plan-1-student-loans-2026-27",
+  PLAN_2:
+    "https://www.gov.uk/government/publications/overseas-earnings-thresholds-for-plan-2-student-loans/overseas-earnings-thresholds-for-plan-2-student-loans-2026-27",
+  PLAN_4:
+    "https://www.gov.uk/government/publications/overseas-earnings-thresholds-for-plan-4-student-loans/overseas-earnings-thresholds-for-plan-4-student-loans-2026-27",
+  PLAN_5:
+    "https://www.gov.uk/government/publications/overseas-earnings-thresholds-for-plan-5-student-loans/overseas-earnings-thresholds-for-plan-5-student-loans-2026-to-2027",
+  POSTGRADUATE:
+    "https://www.gov.uk/government/publications/overseas-earnings-thresholds-for-postgraduate-student-loans/overseas-earnings-thresholds-for-postgraduate-student-loans-2026-27",
+};
+
+/** The parent GOV.UK publications (methodology and worked examples), per plan. */
+export const OVERSEAS_PUBLICATION_URLS: Record<PlanType, string> = {
+  PLAN_1:
+    "https://www.gov.uk/government/publications/overseas-earnings-thresholds-for-plan-1-student-loans",
+  PLAN_2:
+    "https://www.gov.uk/government/publications/overseas-earnings-thresholds-for-plan-2-student-loans",
+  PLAN_4:
+    "https://www.gov.uk/government/publications/overseas-earnings-thresholds-for-plan-4-student-loans",
+  PLAN_5:
+    "https://www.gov.uk/government/publications/overseas-earnings-thresholds-for-plan-5-student-loans",
+  POSTGRADUATE:
+    "https://www.gov.uk/government/publications/overseas-earnings-thresholds-for-postgraduate-student-loans",
+};
+
+export type OverseasBandId = "A" | "B" | "C" | "D" | "E" | "F" | "G";
+
+export interface OverseasBand {
+  id: OverseasBandId;
+  /** Multiple of the UK repayment threshold, 0.2 to 1.4. */
+  multiplier: number;
+  /** Annual repayment threshold in GBP, per plan. */
+  thresholds: Record<PlanType, number>;
+  /** Fixed monthly repayment in GBP charged when details are not kept up to date, per plan. */
+  fixedMonthly: Record<PlanType, number>;
+  /** Plan 2 upper interest threshold in GBP — only Plan 2 publishes one. */
+  plan2UpperThreshold: number;
+}
+
+export interface OverseasTerritory {
+  name: string;
+  band: OverseasBandId;
+  /** Currency name as GOV.UK prints it. */
+  currency: string;
+  /** HMRC annual-average rate: what one unit of the currency is worth in GBP. */
+  exchangeRateToGBP: number;
+}
+
+export const OVERSEAS_BANDS_BY_ID: Record<OverseasBandId, OverseasBand> = {
+  A: {
+    id: "A",
+    multiplier: 0.2,
+    thresholds: {
+      PLAN_1: 5380,
+      PLAN_2: 5875,
+      PLAN_4: 6770,
+      PLAN_5: 5000,
+      POSTGRADUATE: 4200,
+    },
+    fixedMonthly: {
+      PLAN_1: 85.6,
+      PLAN_2: 81.8,
+      PLAN_4: 40.2,
+      PLAN_5: 88.4,
+      POSTGRADUATE: 63,
+    },
+    plan2UpperThreshold: 10575,
+  },
+  B: {
+    id: "B",
+    multiplier: 0.4,
+    thresholds: {
+      PLAN_1: 10760,
+      PLAN_2: 11755,
+      PLAN_4: 13525,
+      PLAN_5: 10000,
+      POSTGRADUATE: 8400,
+    },
+    fixedMonthly: {
+      PLAN_1: 171.2,
+      PLAN_2: 163.6,
+      PLAN_4: 80.4,
+      PLAN_5: 176.8,
+      POSTGRADUATE: 126,
+    },
+    plan2UpperThreshold: 21155,
+  },
+  C: {
+    id: "C",
+    multiplier: 0.6,
+    thresholds: {
+      PLAN_1: 16140,
+      PLAN_2: 17630,
+      PLAN_4: 20290,
+      PLAN_5: 15000,
+      POSTGRADUATE: 12600,
+    },
+    fixedMonthly: {
+      PLAN_1: 256.8,
+      PLAN_2: 245.4,
+      PLAN_4: 120.6,
+      PLAN_5: 265.2,
+      POSTGRADUATE: 189,
+    },
+    plan2UpperThreshold: 31730,
+  },
+  D: {
+    id: "D",
+    multiplier: 0.8,
+    thresholds: {
+      PLAN_1: 21520,
+      PLAN_2: 23510,
+      PLAN_4: 27045,
+      PLAN_5: 20000,
+      POSTGRADUATE: 16800,
+    },
+    fixedMonthly: {
+      PLAN_1: 342,
+      PLAN_2: 327.2,
+      PLAN_4: 160.8,
+      PLAN_5: 353.6,
+      POSTGRADUATE: 252,
+    },
+    plan2UpperThreshold: 42310,
+  },
+  E: {
+    id: "E",
+    multiplier: 1,
+    thresholds: {
+      PLAN_1: 26900,
+      PLAN_2: 29385,
+      PLAN_4: 33795,
+      PLAN_5: 25000,
+      POSTGRADUATE: 21000,
+    },
+    fixedMonthly: {
+      PLAN_1: 428,
+      PLAN_2: 409,
+      PLAN_4: 201,
+      PLAN_5: 442,
+      POSTGRADUATE: 315,
+    },
+    plan2UpperThreshold: 52885,
+  },
+  F: {
+    id: "F",
+    multiplier: 1.2,
+    thresholds: {
+      PLAN_1: 32280,
+      PLAN_2: 35260,
+      PLAN_4: 40565,
+      PLAN_5: 30000,
+      POSTGRADUATE: 25200,
+    },
+    fixedMonthly: {
+      PLAN_1: 513.6,
+      PLAN_2: 490.8,
+      PLAN_4: 241,
+      PLAN_5: 530.4,
+      POSTGRADUATE: 378,
+    },
+    plan2UpperThreshold: 63460,
+  },
+  G: {
+    id: "G",
+    multiplier: 1.4,
+    thresholds: {
+      PLAN_1: 37660,
+      PLAN_2: 41140,
+      PLAN_4: 47320,
+      PLAN_5: 35000,
+      POSTGRADUATE: 29400,
+    },
+    fixedMonthly: {
+      PLAN_1: 599.2,
+      PLAN_2: 572.6,
+      PLAN_4: 281.4,
+      PLAN_5: 618.8,
+      POSTGRADUATE: 441,
+    },
+    plan2UpperThreshold: 74040,
+  },
+};
+
+/** The bands in ladder order, lowest multiplier first. */
+export const OVERSEAS_BANDS: readonly OverseasBand[] =
+  Object.values(OVERSEAS_BANDS_BY_ID);
+
+/** The UK thresholds the bands multiply — band E is the 1.0× band. */
+export const OVERSEAS_UK_THRESHOLDS: Record<PlanType, number> =
+  OVERSEAS_BANDS_BY_ID.E.thresholds;
+
+// Tuple rows keep the 248-territory table compact: [name, band, currency, rate].
+type TerritoryRow = readonly [string, OverseasBandId, string, number];
+
+/** Every territory GOV.UK lists, A–Z by name. */
+export const OVERSEAS_TERRITORIES: readonly OverseasTerritory[] = (
+  [
+    ["Afghanistan", "A", "Afghanis", 0.010752],
+    ["Aland Islands", "E", "Euro", 0.853461],
+    ["Albania", "B", "Leke", 0.008712],
+    ["Algeria", "B", "Algerian Dinar", 0.005765],
+    ["American Samoa", "F", "U.S. Dollar", 0.760109],
+    ["Andorra", "D", "Euro", 0.853461],
+    ["Angola", "B", "Kwanza", 0.000828],
+    ["Anguilla", "E", "East Caribbean Dollar", 0.280812],
+    ["Antarctica", "E", "U.S. Dollar", 0.760109],
+    ["Antigua and Barbuda", "D", "East Caribbean Dollar", 0.280812],
+    ["Argentina", "C", "Argentine Peso", 0.000623],
+    ["Armenia", "B", "Dram", 0.001963],
+    ["Aruba", "E", "Aruban Guilder", 0.424628],
+    ["Australia", "E", "Australian Dollar", 0.489572],
+    ["Austria", "E", "Euro", 0.853461],
+    ["Azerbaijan", "B", "Azerbaijanian Manat", 0.447107],
+    ["Bahamas", "F", "Bahamian Dollar", 0.760109],
+    ["Bahrain", "C", "Bahrain Dinar", 2.021427],
+    ["Bangladesh", "B", "Taka", 0.006252],
+    ["Barbados", "F", "Barbados Dollar", 0.38004],
+    ["Belarus", "A", "Belarusian Ruble", 0.229484],
+    ["Belgium", "D", "Euro", 0.853461],
+    ["Belize", "C", "Belizean Dollar", 0.3779],
+    ["Benin", "B", "CFA Franc (BEAC)", 0.001301],
+    ["Bermuda", "G", "Bermudian Dollar", 0.760109],
+    ["Bhutan", "A", "Bhutanese Ngultrum", 0.00877],
+    ["Bolivia", "B", "Boliviano", 0.110016],
+    ["Bonaire, Saint Eustatius and Saba", "E", "U.S. Dollar", 0.760109],
+    ["Bosnia and Herzegovina", "B", "Convertible Marka", 0.436357],
+    ["Botswana", "B", "Pula", 0.055907],
+    ["Bouvet Island", "E", "Norwegian Krone", 0.072895],
+    ["Brazil", "C", "Brazilian Real", 0.134876],
+    ["British Indian Ocean Territory", "E", "U.S. Dollar", 0.760109],
+    ["Brunei", "B", "Brunei Dollar", 0.580889],
+    ["Bulgaria", "B", "Euro", 0.853461],
+    ["Burkina Faso", "B", "CFA Franc (BEAC)", 0.001301],
+    ["Burundi", "A", "Burundi Franc", 0.000256],
+    ["Cambodia", "B", "Riel", 0.000189],
+    ["Cameroon", "B", "CFA Franc (BEAC)", 0.001301],
+    ["Canada", "E", "Canadian Dollar", 0.543508],
+    ["Cape Verde", "C", "Cape Verde Escudo", 0.00774],
+    ["Cayman Islands", "G", "Cayman Islands Dollar", 0.916254],
+    ["Central African Republic", "B", "CFA Franc (BEAC)", 0.001301],
+    ["Chad", "B", "CFA Franc (BEAC)", 0.001301],
+    ["Channel Islands", "E", "British Pound", 1],
+    ["Chile", "C", "Chilean Peso", 0.000797],
+    ["China", "C", "Yuan Renminbi", 0.105538],
+    ["Christmas Island", "E", "Australian Dollar", 0.489572],
+    ["Cocos (Keeling) Islands", "E", "Australian Dollar", 0.489572],
+    ["Colombia", "B", "Colombian Peso", 0.000186],
+    ["Comoros", "B", "Comorian Franc", 0.001735],
+    ["Congo", "B", "Congolese Franc", 0.000274],
+    ["Congo, Democratic Republic of", "B", "Congolese Franc", 0.000274],
+    ["Cook Islands", "E", "New Zealand Dollar", 0.44342],
+    ["Costa Rica", "D", "Costa Rican Colon", 0.001509],
+    ["Cote d’Ivoire", "B", "CFA Franc (BEAC)", 0.001301],
+    ["Croatia", "C", "Euro", 0.853461],
+    ["Cuba", "C", "Cuban Peso", 0.0317],
+    ["Curacao", "E", "Antillean Guilder", 0.437573],
+    ["Cyprus", "D", "Euro", 0.853461],
+    ["Czech Republic", "C", "Czech Koruna", 0.034473],
+    ["Denmark", "E", "Danish Krone", 0.114356],
+    ["Djibouti", "C", "Djiboutian Franc", 0.00427],
+    ["Dominica", "C", "East Caribbean Dollar", 0.280812],
+    ["Dominican Republic", "B", "Dominican Peso", 0.012352],
+    ["Ecuador", "B", "U.S. Dollar", 0.760109],
+    ["Egypt", "A", "Egyptian Pound", 0.015344],
+    ["El Salvador", "B", "U.S. Dollar", 0.760109],
+    ["Equatorial Guinea", "B", "CFA Franc (BEAC)", 0.001301],
+    ["Eritrea", "B", "Nafka", 0.050673],
+    ["Estonia", "D", "Euro", 0.853461],
+    ["Ethiopia", "B", "Ethiopian Birr", 0.005566],
+    ["Faeroe Islands", "E", "Danish Krone", 0.114356],
+    ["Falkland Islands", "E", "Falkland Pound", 1],
+    ["Federated States of Micronesia", "F", "U.S. Dollar", 0.760109],
+    ["Fiji", "B", "Fiji Dollar", 0.333912],
+    ["Finland", "E", "Euro", 0.853461],
+    ["France", "D", "Euro", 0.853461],
+    ["French Guiana", "D", "Euro", 0.853461],
+    ["French Polynesia", "E", "CFP Franc", 0.007152],
+    ["French Southern Territories", "D", "Euro", 0.853461],
+    ["Gabon", "B", "CFA Franc (BEAC)", 0.001301],
+    ["Gambia", "A", "Dalasi", 0.010492],
+    ["Georgia", "B", "Lari", 0.276564],
+    ["Germany", "D", "Euro", 0.853461],
+    ["Ghana", "B", "Ghanaian Cedi", 0.05949],
+    ["Gibraltar", "E", "British Pound", 1],
+    ["Greece", "C", "Euro", 0.853461],
+    ["Greenland", "E", "Danish Krone", 0.114356],
+    ["Grenada", "C", "East Caribbean Dollar", 0.280812],
+    ["Guadeloupe", "D", "Euro", 0.853461],
+    ["Guam", "F", "U.S. Dollar", 0.760109],
+    ["Guatemala", "B", "Quetzal", 0.098923],
+    ["Guinea", "B", "Guinean Franc", 0.000088],
+    ["Guinea-Bissau", "B", "CFA Franc (BCEAO)", 0.001301],
+    ["Guyana", "B", "Guyanese Dollar", 0.003635],
+    ["Haiti", "D", "Gourde", 0.005808],
+    ["Heard and McDonald Islands", "E", "Australian Dollar", 0.489572],
+    ["Holy See (Vatican City State)", "D", "Euro", 0.853461],
+    ["Honduras", "C", "Lempira", 0.029297],
+    ["Hong Kong", "D", "Hong Kong Dollar", 0.097498],
+    ["Hungary", "C", "Forint", 0.002137],
+    ["Iceland", "F", "Icelandic Krona", 0.005906],
+    ["India", "A", "Indian Rupee", 0.00877],
+    ["Indonesia", "B", "Indonesian Rupiah", 0.000046],
+    ["Iran", "B", "Iranian Rial", 0.000025],
+    ["Iraq", "B", "Iraqi Dinar", 0.000581],
+    ["Ireland", "E", "Euro", 0.853461],
+    ["Isle of Man", "E", "British Pound", 1],
+    ["Israel", "F", "New Israeli Shekel", 0.218756],
+    ["Italy", "D", "Euro", 0.853461],
+    ["Jamaica", "C", "Jamaican Dollar", 0.004784],
+    ["Japan", "D", "Yen", 0.005097],
+    ["Jordan", "B", "Jordanian Dinar", 1.072041],
+    ["Kazakhstan", "B", "Tenge", 0.001452],
+    ["Kenya", "B", "Kenya Schilling", 0.005877],
+    ["Kiribati", "D", "Australian Dollar", 0.489572],
+    [
+      "Korea, Democratic People’s Republic of",
+      "B",
+      "Won Korea Dem. Rep",
+      0.466523,
+    ],
+    ["Korea, Republic of", "D", "Won Korea Rep", 0.000537],
+    ["Kosovo", "B", "Euro", 0.853461],
+    ["Kuwait", "D", "Kuwaiti Dinar", 2.477701],
+    ["Kyrgyztan Republic", "B", "Kyrgyzstan Som", 0.008693],
+    ["Lao PDR", "A", "Kip", 0.000035],
+    ["Latvia", "C", "Euro", 0.853461],
+    ["Lebanon", "B", "Lebanese Pound", 0.000008],
+    ["Lesotho", "B", "Loti", 0.042393],
+    ["Liberia", "C", "Liberian Dollar (US Dollar in use)", 0.003937],
+    ["Libya", "C", "Libyan Dinar", 0.144215],
+    ["Liechtenstein", "E", "Swiss Franc", 0.911079],
+    ["Lithuania", "C", "Euro", 0.853461],
+    ["Luxembourg", "E", "Euro", 0.853461],
+    ["Macau", "C", "Patacas", 0.094658],
+    ["Macedonia (Former Yugoslav Republic)", "B", "Macedonian Denar", 0.013871],
+    ["Madagascar", "B", "Malagasy Ariary", 0.000167],
+    ["Malawi", "B", "Malawi Kwacha", 0.000439],
+    ["Malaysia", "B", "Ringgit", 0.176395],
+    ["Maldives", "C", "Rufiyaa", 0.049235],
+    ["Mali", "B", "CFA Franc (BCEAO)", 0.001301],
+    ["Malta", "D", "Euro", 0.853461],
+    ["Marshall Islands", "E", "U.S. Dollar", 0.760109],
+    ["Martinique", "D", "Euro", 0.853461],
+    ["Mauritania", "B", "Ouguiyas", 0.019128],
+    ["Mauritius", "B", "Mauritius Rupee", 0.016633],
+    ["Mayotte", "D", "Euro", 0.853461],
+    ["Mexico", "C", "Mexican Peso", 0.039402],
+    ["Moldova", "B", "Moldovan Leu", 0.04342],
+    ["Monaco", "E", "Euro", 0.853461],
+    ["Mongolia", "B", "Tugrik", 0.000215],
+    ["Montenegro", "B", "Euro", 0.853461],
+    ["Montserrat", "E", "East Caribbean Dollar", 0.280812],
+    ["Morocco", "B", "Moroccan Dirham", 0.080992],
+    ["Mozambique", "B", "Metical", 0.011894],
+    ["Myanmar", "A", "Kyat", 0.000362],
+    ["Namibia", "B", "Namibian Dollar", 0.042393],
+    ["Nauru", "F", "Australian Dollar", 0.489572],
+    ["Nepal", "A", "Nepalese Rupee", 0.005479],
+    ["Netherlands", "E", "Euro", 0.853461],
+    ["New Caledonia", "E", "CFP Franc", 0.007152],
+    ["New Zealand", "E", "New Zealand Dollar", 0.44342],
+    ["Nicaragua", "B", "Gold Cordoba", 0.020664],
+    ["Niger", "B", "CFA Franc (BCEAO)", 0.001301],
+    ["Nigeria", "A", "Nigerian Naira", 0.000497],
+    ["Niue", "E", "New Zealand Dollar", 0.44342],
+    ["Norfolk Island", "E", "Australian Dollar", 0.489572],
+    ["Northern Mariana Islands", "F", "U.S. Dollar", 0.760109],
+    ["Norway", "E", "Norwegian Krone", 0.072895],
+    ["Oman", "C", "Rial Omani", 1.974724],
+    ["Pakistan", "A", "Pakistan Rupee", 0.002699],
+    ["Palau", "E", "U.S. Dollar", 0.760109],
+    ["Palestine (Occupied Territory)", "C", "New Israeli Shekel", 0.218756],
+    ["Panama", "C", "Balboas", 0.760109],
+    ["Papua New Guinea", "D", "Kina", 0.183871],
+    ["Paraguay", "B", "Guarani", 0.0001],
+    ["Peru", "C", "New Sol", 0.211443],
+    ["Philippines", "B", "Philippine Peso", 0.013217],
+    ["Pitcairn", "E", "New Zealand Dollar", 0.44342],
+    ["Poland", "C", "Zloty", 0.201268],
+    ["Portugal", "C", "Euro", 0.853461],
+    ["Puerto Rico", "F", "U.S. Dollar", 0.760109],
+    ["Qatar", "D", "Qatar Riyal", 0.208816],
+    ["Reunion", "D", "Euro", 0.853461],
+    ["Romania", "B", "Romanian Leu", 0.16971],
+    ["Russian Federation", "B", "Russian Ruble", 0.00896],
+    ["Rwanda", "B", "Rwanda Franc", 0.000533],
+    ["Saint Helena", "E", "Saint Helena Pound", 1],
+    ["Saint Kitts and Nevis", "D", "East Caribbean Dollar", 0.280812],
+    ["Saint Lucia", "C", "East Caribbean Dollar", 0.280812],
+    ["Saint Martin (French part)", "D", "Euro", 0.853461],
+    ["Saint Pierre and Miquelon", "D", "Euro", 0.853461],
+    ["Saint Vincent and Grenadines", "C", "East Caribbean Dollar", 0.280812],
+    ["Saint-Barthelemy", "D", "Euro", 0.853461],
+    ["Samoa", "D", "Tala", 0.27552],
+    ["San Marino", "D", "Euro", 0.853461],
+    ["Sao Tome and Principe", "C", "Dobras", 0.000035],
+    ["Saudi Arabia", "C", "Saudi Riyal", 0.202692],
+    ["Senegal", "B", "CFA Franc (BEAC)", 0.001301],
+    ["Serbia", "B", "Serbian Dinar", 0.007283],
+    ["Seychelles", "C", "Seychelles Rupee", 0.052698],
+    ["Sierra Leone", "A", "Leone", 0.000063],
+    ["Singapore", "C", "Singapore Dollar", 0.580889],
+    ["Sint Maarten (Dutch part)", "E", "Antilles Guilder", 0.437573],
+    ["Slovakia", "C", "Euro", 0.853461],
+    ["Slovenia", "C", "Euro", 0.853461],
+    ["Solomon Islands", "D", "Solomon Islands Dollar", 0.089709],
+    ["Somalia", "B", "Somali Shilling", 0.001332],
+    ["South Africa", "B", "Rand", 0.042393],
+    ["South Georgia and the South Sandwich Islands", "E", "British Pound", 1],
+    ["South Sudan", "B", "Sudanese Pound", 0.001265],
+    ["Spain", "D", "Euro", 0.853461],
+    ["Sri Lanka", "B", "Sri Lankan Rupee", 0.002536],
+    ["Sudan", "C", "Sudanese Pound", 0.001265],
+    ["Suriname", "B", "Surinam Dollar", 0.020442],
+    ["Svalbard and Jan Mayen Islands", "E", "Norwegian Krone", 0.072895],
+    ["Swaziland", "B", "Lilangeni", 0.042393],
+    ["Sweden", "E", "Swedish Krona", 0.076765],
+    ["Switzerland", "F", "Swiss Franc", 0.911079],
+    ["Syria", "A", "Syrian Pound", 0.00399],
+    ["Taiwan", "E", "Taiwan Dollar", 0.02437],
+    ["Tajikistan", "A", "Somoni", 0.12336],
+    ["Thailand", "B", "Thai Baht", 0.02306],
+    ["Timor-Leste", "B", "U.S. Dollar", 0.760109],
+    ["Togo", "B", "CFA Franc (BEAC)", 0.001301],
+    ["Tokelau", "E", "New Zealand Dollar", 0.44342],
+    ["Tonga", "D", "Pa’anga", 0.315746],
+    ["Trinidad and Tobago", "C", "Trinidad & Tobago Dollar", 0.112032],
+    ["Tunisia", "B", "Tunisian Dinar", 0.253197],
+    ["Turkey", "B", "Turkish New Lira", 0.019438],
+    ["Turkmenistan", "B", "Turkmenistan New Manat", 0.217089],
+    ["Turks and Caicos Islands", "F", "U.S. Dollar", 0.760109],
+    ["Tuvalu", "F", "Australian Dollar", 0.489572],
+    ["Uganda", "B", "Ugandan New Shilling", 0.00021],
+    ["Ukraine", "B", "Hryvnia", 0.018251],
+    ["United Arab Emirates", "D", "U.A.E. Dirham", 0.206966],
+    ["United Kingdom", "E", "British Pound", 1],
+    ["United republic of Tanzania", "B", "Tanzanian Shilling", 0.000297],
+    ["United States of America", "F", "U.S. Dollar", 0.760109],
+    ["Uruguay", "D", "Uruguayan Peso", 0.018293],
+    ["Uzbekistan", "B", "Uzbekistan Sum", 0.00006],
+    ["Vanuatu", "E", "Vatu", 0.006265],
+    ["Venezuela", "C", "Bolivar Fuerte", 0.002352],
+    ["Vietnam", "B", "Dong", 0.000029],
+    ["Virgin Islands (British)", "E", "U.S. Dollar", 0.760109],
+    ["Virgin Islands (US)", "F", "U.S. Dollar", 0.760109],
+    ["Wallis and Futuna Islands", "B", "CFP Franc", 0.007152],
+    ["Western Sahara", "B", "Moroccan Dirham", 0.080992],
+    ["Yemen", "B", "Yemeni Rial", 0.003121],
+    ["Zambia", "B", "Zambian Kwacha", 0.029697],
+    ["Zimbabwe", "B", "Zimbabwean Gold", 0.028502],
+  ] satisfies readonly TerritoryRow[]
+).map(([name, band, currency, exchangeRateToGBP]) => ({
+  name,
+  band,
+  currency,
+  exchangeRateToGBP,
+}));


### PR DESCRIPTION
A claim-by-claim audit of `/guides/moving-abroad` against GOV.UK, SLC's terms and conditions, and the Repayment Regulations found its £ figures right but several of its legal and consequence claims wrong, and revealed it only ever modelled a two-band, Plan 2-only version of overseas repayment. This is the site's best-performing page — over half of all guide traffic, more views than the homepage, most of it landing straight from search, and around 40% of readers already outside the UK — so getting it wrong, and leaving it thin, costs the most.

| Before (production) | After (this branch) |
|---|---|
| <img src="https://raw.githubusercontent.com/QingqiShi/uk-student-loan-study/pr-assets/feat/moving-abroad-accuracy-estimator/before-1440-light.jpg" width="450"> | <img src="https://raw.githubusercontent.com/QingqiShi/uk-student-loan-study/pr-assets/feat/moving-abroad-accuracy-estimator/after-1440-light.jpg" width="450"> |

## Accuracy fixes

Six claims were corrected. Tell SLC *before you leave* if you'll be abroad for *more than* 3 months — not "within three months of moving", which appeared six times. Student loans never appear on a credit record, contradicting the old "could affect your credit record" line. Missed payments risk arrears, the highest interest rate on Plan 2, a penalty charge, a demand for the whole loan, recovery costs added to the loan, and court action — not "collection agencies", a phrase that appears in no GOV.UK borrower guidance. A fixed monthly repayment "may be higher" than an income-based one and is not an additional penalty, replacing "usually/significantly higher" and "effectively a penalty". The page's single most-clicked outbound link, to a GOV.UK sub-page that now redirects away, is replaced with three working GOV.UK links. The old "lower £23,510 / higher £35,260" two-band story is replaced with SLC's real seven-band ladder (0.2× to 1.4× of the UK threshold, across 248 territories), and coverage extends from Plan 2 only to every plan.

New sections, also sourced from GOV.UK, cover how SLC assesses overseas income (last three months' payslips × 12, HMRC's annual average exchange rate, who pays the conversion and bank fees), interest while abroad, returning to the UK (PAYE doesn't clear overseas arrears), and that write-off may not apply if you're in breach.

## Overseas repayment estimator

Only about 5% of the page's sessions ever reach a calculator, against roughly 20% for other top guides, and median scroll depth is 43% — most readers get their "does it get wiped?" answer in the first screen and leave. A new in-page estimator lets a reader choose any of the 248 territories and any plan, enter a salary in GBP or the local currency, and see their threshold there, their monthly repayment against the UK figure, the fixed fallback amount SLC charges if they don't update their details, and (Plan 2) the interest-rate effect of that country's own thresholds — with a link into the main calculator prefilled with their plan and salary.

The six-destination table and the new seven-band ladder table are both generated from the same dataset that drives the estimator and the prose, so the three can't drift apart. The FAQ grew from 9 to 14 questions (credit score, travelling without working, exchange rates, Plan 5/Postgraduate, returning to the UK), and that list is now the single source for both the visible FAQ and its FAQPage structured data.

## Keeping the overseas dataset in sync

The 2026/27 overseas dataset is hand-maintained separately from the live UK repayment-threshold config, because SLC revises it every 6 April on its own schedule and every band in it is a multiple of the UK threshold — it must not silently go stale when the UK figures are next uprated. Rather than add a test for that, which would block the daily GOV.UK figure-automation workflow's own test run the next time a UK threshold moves, the automation's classifier now routes any UK threshold change to human review with a note to refresh the overseas dataset from GOV.UK.