### PR TITLE
fix: apply the interest cap and keep the default salary on the peak

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ Figure captions read `Fig. N: Title · Subtitle`.
 - `any` type or unsafe assertions (`as unknown as X`)
 - `useMemo`, `useCallback`, `React.memo` — React Compiler handles this (exception: shadcn/ui)
 - Barrel files — import from source modules directly
-- Default exports (exception: `page.tsx` / `layout.tsx`)
+- Default exports (exception: `page.tsx` / `layout.tsx` / `src/test/environment.ts`, which vitest loads by default export)
 - `Context.Provider` / `useContext` — use `<Context value={...}>` and `use(Context)` (React 19)
 - Manually fix lint error that could have been fixed with `--fix`.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -76,6 +76,10 @@ The lower/upper income bands that bound Plan 2's sliding scale (`interestLowerTh
 The Bank of England base rate, used to cap Plan 1/Plan 4 interest. Spelled "BoE".
 _Avoid_: BOE, Boe
 
+**Interest cap**:
+The ceiling GOV.UK places on the headline interest rate ("RPI plus up to 3%, but there's currently a limit (or 'cap') of 6%"). It applies to every plan's computed rate and binds on the upper part of Plan 2's sliding scale and on Postgraduate. Held as `CURRENT_RATES.interestCap`, scraped daily with the other figures.
+_Avoid_: rate cap, PMR cap, prevailing market rate cap
+
 **Effective rate**:
 The true annualised cost of the loan as an internal rate of return (IRR) — lower than the headline rate because it accounts for write-off. The Readout quadrant and the `/effective-rate` tool.
 _Avoid_: effective interest rate, true rate, true cost, true annualized cost

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -33,10 +33,10 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 
 - [UK Student Loan Plans Explained](https://studentloanstudy.uk/plans): Every UK student loan plan compared at a glance: thresholds, repayment rates, interest and write-off periods
 - [Plan 1 Explained](https://studentloanstudy.uk/plans/plan-1): Plan 1 threshold, capped interest and 25-year write-off for pre-2012 England/Wales and all Northern Irish students
-- [Plan 2 Explained](https://studentloanstudy.uk/plans/plan-2): Plan 2 threshold, RPI + 3% sliding-scale interest and why middle earners repay the most over 30 years
+- [Plan 2 Explained](https://studentloanstudy.uk/plans/plan-2): Plan 2 threshold, RPI + 3% sliding-scale interest capped at 6% and why middle earners repay the most over 30 years
 - [Plan 4 Explained](https://studentloanstudy.uk/plans/plan-4): Plan 4 for Scottish students, with the highest threshold of any plan, capped interest and a 30-year write-off
 - [Plan 5 Explained](https://studentloanstudy.uk/plans/plan-5): Plan 5 threshold, RPI-only interest and the longest 40-year write-off
-- [Postgraduate Loan Explained](https://studentloanstudy.uk/plans/postgraduate): Postgraduate Master's and Doctoral loan at a 6% repayment rate, RPI + 3% interest, repaid alongside any undergraduate loan
+- [Postgraduate Loan Explained](https://studentloanstudy.uk/plans/postgraduate): Postgraduate Master's and Doctoral loan at a 6% repayment rate, RPI + 3% interest capped at 6%, repaid alongside any undergraduate loan
 
 ## Key Facts
 
@@ -54,34 +54,35 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - Monthly threshold: £2,241 (£26,900/year)
 - Repayment rate: 9% of income above threshold
 - 25-year write-off period
-- Interest rate: RPI or Bank of England base rate + 1%, whichever is lower (currently RPI 3.2%, base rate 3.75%)
+- Interest rate: RPI or Bank of England base rate + 1%, whichever is lower (currently RPI 4.1%, base rate 3.75%)
 
 ### Plan 2
 - For students who started between September 2012 and July 2023 (England/Wales)
 - Monthly threshold: £2,448 (£29,385/year)
 - Repayment rate: 9% of income above threshold
 - 30-year write-off period
-- Interest rate: RPI + 0-3% depending on income (income scale: £29,385 to £52,885)
+- Interest rate: RPI + 0-3% depending on income, capped at 6% (income scale: £29,385 to £52,885)
 
 ### Plan 4
 - For Scottish students who started after September 1998
 - Monthly threshold: £2,816 (£33,795/year)
 - Repayment rate: 9% of income above threshold
 - 30-year write-off period
-- Interest rate: RPI or Bank of England base rate + 1%, whichever is lower (currently RPI 3.2%, base rate 3.75%)
+- Interest rate: RPI or Bank of England base rate + 1%, whichever is lower (currently RPI 4.1%, base rate 3.75%)
 
 ### Plan 5
 - For students starting August 2023 or later (England)
 - Monthly threshold: £2,083 (£25,000/year)
 - Repayment rate: 9% of income above threshold
 - 40-year write-off period
-- Interest rate: RPI only (no additional percentage, currently 3.2%)
+- Interest rate: RPI only (no additional percentage, currently 4.1%)
 
 ### Postgraduate Loan
 - For Master's or Doctoral study from 2016 onwards
 - Monthly threshold: £1,750 (£21,000/year)
 - Repayment rate: 6% of income above threshold
 - 30-year write-off period
+- Interest rate: RPI + 3%, capped at 6% (currently 6%)
 
 ## Contact
 

--- a/scripts/check-govuk-figures/classify.test.ts
+++ b/scripts/check-govuk-figures/classify.test.ts
@@ -28,6 +28,44 @@ describe("classifyChange", () => {
     );
   });
 
+  it("auto-merges an interest-cap move within bounds", () => {
+    expect(
+      classifyChange(
+        [{ field: "CURRENT_RATES.interestCap", current: 6, scraped: 7 }],
+        [],
+      ),
+    ).toEqual({ decision: "auto", reviewReasons: [] });
+  });
+
+  it("reviews an interest-cap move beyond 2 points", () => {
+    const result = classifyChange(
+      [{ field: "CURRENT_RATES.interestCap", current: 6, scraped: 9 }],
+      [],
+    );
+    expect(result.decision).toBe("review");
+    expect(result.reviewReasons[0]).toContain("CURRENT_RATES.interestCap");
+    expect(result.reviewReasons[0]).toContain("moved 3.00 points");
+  });
+
+  it("auto-merges a small move in the derived default salary", () => {
+    expect(
+      classifyChange(
+        [{ field: "DEFAULT_SALARY", current: 45_000, scraped: 48_000 }],
+        [],
+      ),
+    ).toEqual({ decision: "auto", reviewReasons: [] });
+  });
+
+  it("reviews a large move in the derived default salary", () => {
+    const result = classifyChange(
+      [{ field: "DEFAULT_SALARY", current: 45_000, scraped: 60_000 }],
+      [],
+    );
+    expect(result.decision).toBe("review");
+    expect(result.reviewReasons[0]).toContain("DEFAULT_SALARY");
+    expect(result.reviewReasons[0]).toContain("moved 33.3%");
+  });
+
   it("reviews a routine repayment-threshold uprating so the overseas dataset is refreshed", () => {
     // ~4% annual uprating, in bounds and internally consistent — but every
     // overseas band multiplies the UK threshold, and that dataset is hand-copied.

--- a/scripts/check-govuk-figures/classify.ts
+++ b/scripts/check-govuk-figures/classify.ts
@@ -1,3 +1,5 @@
+import { MAX_SALARY, MIN_SALARY } from "../../src/constants";
+
 import type { Mismatch, ScrapedPlanThreshold } from "./types";
 
 /**
@@ -31,7 +33,8 @@ interface FieldBound {
   increaseOnly?: boolean;
 }
 
-// Bounds for the fields the scrape can move routinely. Every other field —
+// Bounds for the fields the scrape can move routinely, plus DEFAULT_SALARY,
+// which the codegen derives from them. Every other field —
 // repayment rate, write-off period, the Plan 2 interest thresholds — is
 // structural and legislative: a change there is rare and always deserves human
 // review, so it is deliberately absent from this map (an unknown field reviews).
@@ -72,9 +75,10 @@ const AUTO_MERGE_BOUNDS: Record<string, FieldBound> = {
     maxRelDelta: 0.15,
     increaseOnly: true,
   },
-  // Market rates, as percentages. Plausible 0–20%; a single daily check rarely
-  // sees a move beyond 2 points, and a bigger swing should be looked at. A zero
-  // is almost always a placeholder from a failed parse, so it is rejected.
+  // Market rates and the GOV.UK interest cap, as percentages. Plausible 0–20%;
+  // a single daily check rarely sees a move beyond 2 points, and a bigger swing
+  // should be looked at. A zero is almost always a placeholder from a failed
+  // parse, so it is rejected.
   "CURRENT_RATES.rpi": {
     min: 0,
     max: 20,
@@ -92,6 +96,21 @@ const AUTO_MERGE_BOUNDS: Record<string, FieldBound> = {
     max: 20,
     maxAbsDelta: 2,
     rejectNonPositive: true,
+  },
+  "CURRENT_RATES.interestCap": {
+    min: 0,
+    max: 20,
+    maxAbsDelta: 2,
+    rejectNonPositive: true,
+  },
+  // The default salary is the peak of the home page curve, derived from the
+  // figures above rather than scraped. A rate move usually shifts the peak by a
+  // few thousand pounds, so a small move is routine; a large jump points to a
+  // bad rate. The peak can only be a point on the chart's salary axis.
+  DEFAULT_SALARY: {
+    min: MIN_SALARY,
+    max: MAX_SALARY,
+    maxRelDelta: 0.15,
   },
 };
 

--- a/scripts/check-govuk-figures/default-salary.test.ts
+++ b/scripts/check-govuk-figures/default-salary.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { MAX_SALARY, MIN_SALARY, SALARY_STEP } from "../../src/constants";
+
+import { computeDefaultSalary } from "./default-salary";
+import type { ScrapedGovUkData } from "./types";
+
+/** A scrape of the GOV.UK and market figures, with no network access. */
+function scrapedFixture(
+  overrides: Partial<ScrapedGovUkData> = {},
+): ScrapedGovUkData {
+  return {
+    thresholds: [
+      { plan: "PLAN_1", monthlyThreshold: 2241, yearlyThreshold: 26900 },
+      { plan: "PLAN_2", monthlyThreshold: 2448, yearlyThreshold: 29385 },
+      { plan: "PLAN_4", monthlyThreshold: 2816, yearlyThreshold: 33795 },
+      { plan: "PLAN_5", monthlyThreshold: 2083, yearlyThreshold: 25000 },
+      { plan: "POSTGRADUATE", monthlyThreshold: 1750, yearlyThreshold: 21000 },
+    ],
+    repaymentRates: [
+      { plans: ["PLAN_1", "PLAN_2", "PLAN_4", "PLAN_5"], rate: 9 },
+      { plans: ["POSTGRADUATE"], rate: 6 },
+    ],
+    interestRates: [
+      { plans: ["PLAN_5"], rate: 4.1, description: "4.1% (RPI) on Plan 5" },
+    ],
+    plan2InterestScale: { lowerThreshold: 29385, upperThreshold: 52885 },
+    interestCap: 6,
+    writeOffs: [
+      { plan: "PLAN_1", years: 25 },
+      { plan: "PLAN_2", years: 30 },
+      { plan: "PLAN_4", years: 30 },
+      { plan: "PLAN_5", years: 40 },
+      { plan: "POSTGRADUATE", years: 30 },
+    ],
+    boeBaseRate: 3.75,
+    cpi: 2.9,
+    scrapedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("computeDefaultSalary", () => {
+  it("returns an income on the chart's salary grid", () => {
+    const salary = computeDefaultSalary(scrapedFixture());
+
+    expect(salary).toBeGreaterThanOrEqual(MIN_SALARY);
+    expect(salary).toBeLessThanOrEqual(MAX_SALARY);
+    expect((salary - MIN_SALARY) % SALARY_STEP).toBe(0);
+  });
+
+  it("moves the peak down when RPI falls", () => {
+    const current = computeDefaultSalary(scrapedFixture());
+    const noInflation = computeDefaultSalary(
+      scrapedFixture({
+        interestRates: [
+          { plans: ["PLAN_5"], rate: 0, description: "0% (RPI) on Plan 5" },
+        ],
+      }),
+    );
+
+    expect(noInflation).toBeLessThan(current);
+  });
+});

--- a/scripts/check-govuk-figures/default-salary.ts
+++ b/scripts/check-govuk-figures/default-salary.ts
@@ -1,0 +1,34 @@
+import { initialState } from "../../src/context/loanReducer";
+import { computePlan2FreezeSchedule } from "../../src/lib/loans/plan2Freeze";
+import { DEFAULT_PRESET } from "../../src/lib/presets";
+import {
+  findPeakSalary,
+  generateSalaryDataSeries,
+} from "../../src/utils/loanCalculations";
+
+import { findRpi } from "./types";
+import type { ScrapedGovUkData } from "./types";
+
+/**
+ * Computes the income at which total repaid peaks for the default preset, under
+ * the home page's default assumptions. The home page marker starts at this
+ * income, so it sits on the peak of the curve that the page draws.
+ *
+ * The rates come from the scrape, but the repayment thresholds come from
+ * src/lib/loans/plans.ts as it is on disk. Thus a threshold change moves the
+ * default salary one run later, when the new thresholds are in that file. The
+ * drift check finds the difference on the next run.
+ */
+export function computeDefaultSalary(scraped: ScrapedGovUkData): number {
+  const series = generateSalaryDataSeries(
+    DEFAULT_PRESET.loans,
+    findRpi(scraped),
+    initialState.salaryGrowthRate,
+    initialState.thresholdGrowthRate,
+    scraped.boeBaseRate,
+    initialState.applyPlan2Freeze ? computePlan2FreezeSchedule() : undefined,
+    scraped.interestCap,
+  );
+
+  return findPeakSalary(series);
+}

--- a/scripts/check-govuk-figures/pr-body.test.ts
+++ b/scripts/check-govuk-figures/pr-body.test.ts
@@ -16,6 +16,14 @@ describe("formatFieldValue", () => {
     expect(formatFieldValue("CURRENT_RATES.rpi", 3.2)).toBe("3.2%");
   });
 
+  it("formats the interest cap as a percent", () => {
+    expect(formatFieldValue("CURRENT_RATES.interestCap", 6)).toBe("6%");
+  });
+
+  it("formats the derived default salary as pounds", () => {
+    expect(formatFieldValue("DEFAULT_SALARY", 48000)).toBe("£48,000");
+  });
+
   it("formats a threshold as pounds with separators", () => {
     expect(formatFieldValue("PLAN_2.monthlyThreshold", 2448)).toBe("£2,448");
   });

--- a/scripts/check-govuk-figures/scrape-govuk.ts
+++ b/scripts/check-govuk-figures/scrape-govuk.ts
@@ -213,6 +213,24 @@ async function scrapeInterestRates(page: Page): Promise<ScrapedInterestRate[]> {
   return rates;
 }
 
+/**
+ * Read the interest cap from the sentence "RPI plus up to 3%, but there's
+ * currently a limit (or 'cap') of 6%.". GOV.UK writes the apostrophes as curly
+ * quotes, so the pattern accepts both forms.
+ */
+async function scrapeInterestCap(page: Page): Promise<number> {
+  const text = await page.evaluate(() => document.body.innerText);
+  const match = text.match(
+    /limit \(or [\u2018\u2019']cap[\u2018\u2019']\) of (\d+(?:\.\d+)?)%/i,
+  );
+  if (!match) {
+    throw new Error(
+      "Could not find the interest cap sentence on the what-you-pay page",
+    );
+  }
+  return Number(match[1]);
+}
+
 async function scrapeWriteOffs(page: Page): Promise<ScrapedWriteOff[]> {
   await page.goto(
     "https://www.gov.uk/repaying-your-student-loan/when-your-student-loan-gets-written-off-or-cancelled",
@@ -283,6 +301,7 @@ export async function scrapeGovUk(page: Page): Promise<ScrapedGovUkData> {
   const { thresholds, plan2InterestScale } = await scrapeThresholds(page);
   const repaymentRates = await scrapeRepaymentRates(page);
   const interestRates = await scrapeInterestRates(page);
+  const interestCap = await scrapeInterestCap(page);
 
   // Page 2: Write-off periods
   const writeOffs = await scrapeWriteOffs(page);
@@ -292,6 +311,7 @@ export async function scrapeGovUk(page: Page): Promise<ScrapedGovUkData> {
     repaymentRates,
     interestRates,
     plan2InterestScale,
+    interestCap,
     writeOffs,
     boeBaseRate: 0, // Filled in later by the updater agent via fetch()
     cpi: 0, // Filled in later by the updater agent via fetch()

--- a/scripts/check-govuk-figures/templates.ts
+++ b/scripts/check-govuk-figures/templates.ts
@@ -17,6 +17,12 @@ function findThreshold(
   };
 }
 
+/** Format a whole pound amount as a 9_250 style numeric literal. */
+function formatUnderscoreLiteral(value: number): string {
+  if (value < 1000) return String(value);
+  return `${Math.floor(value / 1000)}_${String(value % 1000).padStart(3, "0")}`;
+}
+
 function formatRate(rate: number): string {
   // Convert 0.09 → "9%", 0.06 → "6%"
   const pct = rate * 100;
@@ -27,6 +33,7 @@ export function generatePlansTs(
   scraped: ScrapedGovUkData,
   existingTuitionCap: number,
   lastUpdated: string,
+  defaultSalary: number,
 ): string {
   const plan1 = findThreshold(scraped, "PLAN_1");
   const plan1Rate = findRepaymentRate(scraped, "PLAN_1");
@@ -51,12 +58,10 @@ export function generatePlansTs(
   const rpi = findRpi(scraped);
   const boeBaseRate = scraped.boeBaseRate;
   const cpi = scraped.cpi;
+  const interestCap = scraped.interestCap;
 
-  // Format as 9_250 style
-  const tuitionCapLiteral =
-    existingTuitionCap >= 1000
-      ? `${Math.floor(existingTuitionCap / 1000)}_${String(existingTuitionCap % 1000).padStart(3, "0")}`
-      : String(existingTuitionCap);
+  const tuitionCapLiteral = formatUnderscoreLiteral(existingTuitionCap);
+  const defaultSalaryLiteral = formatUnderscoreLiteral(defaultSalary);
 
   return `// =============================================================================
 // ANNUAL UPDATE SECTION - Update these values when GOV.UK announces changes
@@ -106,12 +111,21 @@ export const PLAN_CONFIGS = {
 /**
  * Current interest rates for loan calculations.
  * Update these when new rates are announced.
+ * interestCap is the GOV.UK ceiling on every plan's headline interest rate.
  */
 export const CURRENT_RATES = {
   rpi: ${rpi},
   boeBaseRate: ${boeBaseRate},
   cpi: ${cpi},
+  interestCap: ${interestCap},
 } as const;
+
+/**
+ * The income at which total repaid peaks for the default preset, under the
+ * home page's default assumptions. The automation derives it from the figures
+ * above, so the home page marker starts on the peak of the curve it is drawn on.
+ */
+export const DEFAULT_SALARY = ${defaultSalaryLiteral};
 
 /**
  * User-friendly display information for each undergraduate plan type.
@@ -206,6 +220,11 @@ export function generateLlmsTxt(scraped: ScrapedGovUkData): string {
   const postgradWriteOff = findWriteOffYears(scraped, "POSTGRADUATE");
 
   const rpi = findRpi(scraped);
+  const interestCap = scraped.interestCap;
+  const postgradInterest = Math.min(
+    Math.round((rpi + 3) * 100) / 100,
+    interestCap,
+  );
 
   const fmtRate = (r: number) => `${Math.round(r * 100)}%`;
 
@@ -244,10 +263,10 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 
 - [UK Student Loan Plans Explained](https://studentloanstudy.uk/plans): Every UK student loan plan compared at a glance: thresholds, repayment rates, interest and write-off periods
 - [Plan 1 Explained](https://studentloanstudy.uk/plans/plan-1): Plan 1 threshold, capped interest and ${plan1WriteOff}-year write-off for pre-2012 England/Wales and all Northern Irish students
-- [Plan 2 Explained](https://studentloanstudy.uk/plans/plan-2): Plan 2 threshold, RPI + 3% sliding-scale interest and why middle earners repay the most over ${plan2WriteOff} years
+- [Plan 2 Explained](https://studentloanstudy.uk/plans/plan-2): Plan 2 threshold, RPI + 3% sliding-scale interest capped at ${interestCap}% and why middle earners repay the most over ${plan2WriteOff} years
 - [Plan 4 Explained](https://studentloanstudy.uk/plans/plan-4): Plan 4 for Scottish students, with the highest threshold of any plan, capped interest and a ${plan4WriteOff}-year write-off
 - [Plan 5 Explained](https://studentloanstudy.uk/plans/plan-5): Plan 5 threshold, RPI-only interest and the longest ${plan5WriteOff}-year write-off
-- [Postgraduate Loan Explained](https://studentloanstudy.uk/plans/postgraduate): Postgraduate Master's and Doctoral loan at a ${fmtRate(postgradRate)} repayment rate, RPI + 3% interest, repaid alongside any undergraduate loan
+- [Postgraduate Loan Explained](https://studentloanstudy.uk/plans/postgraduate): Postgraduate Master's and Doctoral loan at a ${fmtRate(postgradRate)} repayment rate, RPI + 3% interest capped at ${interestCap}%, repaid alongside any undergraduate loan
 
 ## Key Facts
 
@@ -272,7 +291,7 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - Monthly threshold: \u00a3${formatNumber(plan2.monthlyThreshold)} (\u00a3${formatNumber(plan2.yearlyThreshold)}/year)
 - Repayment rate: ${fmtRate(plan2Rate)} of income above threshold
 - ${plan2WriteOff}-year write-off period
-- Interest rate: RPI + 0-3% depending on income (income scale: \u00a3${formatNumber(scraped.plan2InterestScale.lowerThreshold)} to \u00a3${formatNumber(scraped.plan2InterestScale.upperThreshold)})
+- Interest rate: RPI + 0-3% depending on income, capped at ${interestCap}% (income scale: \u00a3${formatNumber(scraped.plan2InterestScale.lowerThreshold)} to \u00a3${formatNumber(scraped.plan2InterestScale.upperThreshold)})
 
 ### Plan 4
 - For Scottish students who started after September 1998
@@ -293,6 +312,7 @@ UK student loans are often misunderstood. Middle earners typically repay the mos
 - Monthly threshold: \u00a3${formatNumber(postgrad.monthlyThreshold)} (\u00a3${formatNumber(postgrad.yearlyThreshold)}/year)
 - Repayment rate: ${fmtRate(postgradRate)} of income above threshold
 - ${postgradWriteOff}-year write-off period
+- Interest rate: RPI + 3%, capped at ${interestCap}% (currently ${postgradInterest}%)
 
 ## Contact
 

--- a/scripts/check-govuk-figures/types.ts
+++ b/scripts/check-govuk-figures/types.ts
@@ -30,6 +30,8 @@ export interface ScrapedGovUkData {
   repaymentRates: ScrapedRepaymentRate[];
   interestRates: ScrapedInterestRate[];
   plan2InterestScale: ScrapedPlan2InterestScale;
+  /** The GOV.UK ceiling on every plan's interest rate, as a percentage. */
+  interestCap: number;
   writeOffs: ScrapedWriteOff[];
   boeBaseRate: number;
   cpi: number;

--- a/scripts/check-govuk-figures/update-files.ts
+++ b/scripts/check-govuk-figures/update-files.ts
@@ -5,11 +5,13 @@ import { fileURLToPath } from "node:url";
 import {
   PLAN_CONFIGS,
   CURRENT_RATES,
+  DEFAULT_SALARY,
   TUITION_FEE_CAP,
   LAST_UPDATED,
 } from "../../src/lib/loans/plans";
 
 import { classifyChange } from "./classify";
+import { computeDefaultSalary } from "./default-salary";
 import { renderPrBody } from "./pr-body";
 import { generateLlmsTxt, generatePlansTs } from "./templates";
 import { findRepaymentRate, findRpi, findWriteOffYears } from "./types";
@@ -86,7 +88,10 @@ async function fetchBoeBaseRate(): Promise<number> {
   throw new Error("Could not extract BoE base rate from response");
 }
 
-function comparePlans(scraped: ScrapedGovUkData): Mismatch[] {
+function comparePlans(
+  scraped: ScrapedGovUkData,
+  defaultSalary: number,
+): Mismatch[] {
   const mismatches: Mismatch[] = [];
 
   const planKeys = [
@@ -177,6 +182,22 @@ function comparePlans(scraped: ScrapedGovUkData): Mismatch[] {
     });
   }
 
+  if (CURRENT_RATES.interestCap !== scraped.interestCap) {
+    mismatches.push({
+      field: "CURRENT_RATES.interestCap",
+      current: CURRENT_RATES.interestCap,
+      scraped: scraped.interestCap,
+    });
+  }
+
+  if (DEFAULT_SALARY !== defaultSalary) {
+    mismatches.push({
+      field: "DEFAULT_SALARY",
+      current: DEFAULT_SALARY,
+      scraped: defaultSalary,
+    });
+  }
+
   return mismatches;
 }
 
@@ -202,7 +223,12 @@ async function main(): Promise<void> {
   writeFileSync(scrapedPath, JSON.stringify(scraped, null, 2) + "\n");
 
   // 3. Compare scraped vs current values
-  const mismatches = comparePlans(scraped);
+  const defaultSalary = computeDefaultSalary(scraped);
+  console.log(
+    `Default salary (repayment peak): \u00a3${defaultSalary.toLocaleString("en-GB")}`,
+  );
+
+  const mismatches = comparePlans(scraped, defaultSalary);
 
   if (mismatches.length > 0) {
     console.log(`Found ${mismatches.length} figure mismatch(es):`);
@@ -221,7 +247,12 @@ async function main(): Promise<void> {
     {
       path: path.join(projectRoot, "src/lib/loans/plans.ts"),
       label: "src/lib/loans/plans.ts",
-      content: generatePlansTs(scraped, TUITION_FEE_CAP, lastUpdated),
+      content: generatePlansTs(
+        scraped,
+        TUITION_FEE_CAP,
+        lastUpdated,
+        defaultSalary,
+      ),
     },
     {
       path: path.join(projectRoot, "public/llms.txt"),

--- a/src/app/balance/layout.tsx
+++ b/src/app/balance/layout.tsx
@@ -1,4 +1,8 @@
 import type { Metadata } from "next";
+import { formatPercent } from "@/lib/format";
+import { getMaxAnnualInterestRate } from "@/lib/loans/interest";
+
+const plan2MaxRatePct = formatPercent(getMaxAnnualInterestRate("PLAN_2"));
 
 export const metadata: Metadata = {
   title: "How Long to Pay Off Your Student Loan: Payoff Timeline",
@@ -68,7 +72,7 @@ const faqSchema = {
       name: "Why is my student loan balance going up?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Your balance grows when interest added each month exceeds your repayments. This is common in the early years when your salary is lower and repayments are small. For Plan 2 borrowers, interest can be as high as RPI + 3%, meaning the balance may rise for several years before repayments start to outpace interest.",
+        text: `Your balance grows when interest added each month exceeds your repayments. This is common in the early years when your salary is lower and repayments are small. For Plan 2 borrowers, interest can be as high as ${plan2MaxRatePct} (a cap holds the sliding scale below RPI + 3%), meaning the balance may rise for several years before repayments start to outpace interest.`,
       },
     },
   ],

--- a/src/app/guides/how-interest-works/layout.tsx
+++ b/src/app/guides/how-interest-works/layout.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
-import { formatGBP } from "@/lib/format";
+import { formatGBP, formatPercent } from "@/lib/format";
+import { getMaxAnnualInterestRate } from "@/lib/loans/interest";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
+
+const plan2MaxRatePct = formatPercent(getMaxAnnualInterestRate("PLAN_2"));
 
 export const metadata: Metadata = {
   title: "Why Your Student Loan Balance Keeps Growing",
@@ -60,7 +63,7 @@ const faqSchema = {
       name: "How is interest calculated on Plan 2 student loans?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: `Plan 2 uses a sliding scale based on your income. If you earn below ${formatGBP(PLAN_CONFIGS.PLAN_2.interestLowerThreshold)}, you pay RPI only. If you earn above ${formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}, you pay RPI plus 3%. Between the two thresholds, the rate scales linearly.`,
+        text: `Plan 2 uses a sliding scale based on your income. If you earn below ${formatGBP(PLAN_CONFIGS.PLAN_2.interestLowerThreshold)}, you pay RPI only. If you earn above ${formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}, you pay RPI plus up to 3%, capped at ${plan2MaxRatePct}. Between the two thresholds, the rate scales linearly.`,
       },
     },
     {

--- a/src/app/guides/interest-rate-cap/layout.tsx
+++ b/src/app/guides/interest-rate-cap/layout.tsx
@@ -3,14 +3,19 @@ import {
   TOTAL_YEARS,
   YEARS_ABOVE_CAP,
 } from "@/components/guides/interest-rate-cap/historical-rates";
+import { formatPercent } from "@/lib/format";
+import { CURRENT_RATES } from "@/lib/loans/plans";
+
+const capPct = formatPercent(CURRENT_RATES.interestCap);
+const title = `Plan 2 Interest Rate Capped at ${capPct}: What It Means for You`;
+const description = `Plan 2 student loan interest has been capped at ${capPct} since 1 September 2026. See how this affects your balance, who benefits most, and how often rates have exceeded ${capPct} historically.`;
 
 export const metadata: Metadata = {
-  title: "Plan 2 Interest Rate Capped at 6%: What It Means for You",
-  description:
-    "The government is capping Plan 2 student loan interest at 6% from September 2026. See how this affects your balance, who benefits most, and how often rates have exceeded 6% historically.",
+  title,
+  description,
   keywords: [
     "Plan 2 interest rate cap",
-    "student loan 6% cap",
+    `student loan ${capPct} cap`,
     "Plan 2 interest rate 2026",
     "student loan interest cap UK",
     "Plan 3 interest rate cap",
@@ -20,9 +25,8 @@ export const metadata: Metadata = {
     canonical: "/guides/interest-rate-cap",
   },
   openGraph: {
-    title: "Plan 2 Interest Rate Capped at 6%: What It Means for You",
-    description:
-      "The government is capping Plan 2 student loan interest at 6% from September 2026. See how this affects your balance, who benefits most, and how often rates have exceeded 6% historically.",
+    title,
+    description,
     url: "https://studentloanstudy.uk/guides/interest-rate-cap",
     type: "article",
   },
@@ -62,20 +66,20 @@ const faqSchema = {
       name: "What is the Plan 2 student loan interest rate cap?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "From 1 September 2026, the maximum interest rate on Plan 2 and Plan 3 student loans will be capped at 6% for the 2026/27 academic year, regardless of what the RPI + 3% formula produces.",
+        text: `Since 1 September 2026, the maximum interest rate on Plan 2 and Plan 3 student loans has been capped at ${capPct} for the 2026/27 academic year, regardless of what the RPI + 3% formula produces.`,
       },
     },
     {
       "@type": "Question",
-      name: "How often has the Plan 2 interest rate exceeded 6%?",
+      name: `How often has the Plan 2 interest rate exceeded ${capPct}?`,
       acceptedAnswer: {
         "@type": "Answer",
-        text: `The maximum Plan 2 interest rate has exceeded 6% in ${String(YEARS_ABOVE_CAP)} out of ${String(TOTAL_YEARS)} academic years since Plan 2 was introduced in 2012. During the 2022-2024 inflation crisis, rates reached 7.7% even after prevailing market rate interventions.`,
+        text: `The maximum Plan 2 interest rate has exceeded ${capPct} in ${String(YEARS_ABOVE_CAP)} out of ${String(TOTAL_YEARS)} academic years since Plan 2 was introduced in 2012. During the 2022-2024 inflation crisis, rates reached 7.7% even after prevailing market rate interventions.`,
       },
     },
     {
       "@type": "Question",
-      name: "Does the 6% cap change my monthly student loan repayments?",
+      name: `Does the ${capPct} cap change my monthly student loan repayments?`,
       acceptedAnswer: {
         "@type": "Answer",
         text: "No. Monthly repayments are based on your income (9% of income above the threshold), not the interest rate. The cap only affects how fast your balance grows.",
@@ -87,9 +91,8 @@ const faqSchema = {
 const articleSchema = {
   "@context": "https://schema.org",
   "@type": "Article",
-  headline: "Plan 2 Interest Rate Capped at 6%: What It Means for You",
-  description:
-    "The government is capping Plan 2 student loan interest at 6% from September 2026. See how this affects your balance, who benefits most, and how often rates have exceeded 6% historically.",
+  headline: title,
+  description,
   url: "https://studentloanstudy.uk/guides/interest-rate-cap",
   author: {
     "@type": "Organization",
@@ -102,7 +105,7 @@ const articleSchema = {
     url: "https://studentloanstudy.uk",
   },
   datePublished: "2026-04-08",
-  dateModified: "2026-04-08",
+  dateModified: "2026-09-05",
 };
 
 export default function InterestRateCapLayout({

--- a/src/app/guides/plan-2-vs-plan-5/layout.tsx
+++ b/src/app/guides/plan-2-vs-plan-5/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
-import { formatGBP } from "@/lib/format";
+import { formatGBP, formatPercent } from "@/lib/format";
+import { getMaxAnnualInterestRate } from "@/lib/loans/interest";
 import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
 
 const description =
@@ -57,6 +58,7 @@ const plan2Threshold = formatGBP(PLAN_DISPLAY_INFO.PLAN_2.yearlyThreshold);
 const plan5Threshold = formatGBP(PLAN_DISPLAY_INFO.PLAN_5.yearlyThreshold);
 const plan2WriteOff = PLAN_CONFIGS.PLAN_2.writeOffYears;
 const plan5WriteOff = PLAN_CONFIGS.PLAN_5.writeOffYears;
+const plan2MaxRatePct = formatPercent(getMaxAnnualInterestRate("PLAN_2"));
 
 const faqSchema = {
   "@context": "https://schema.org",
@@ -67,7 +69,7 @@ const faqSchema = {
       name: "What is the difference between Plan 2 and Plan 5?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: `Plan 2 applies to English and Welsh students who started between 2012 and 2023, with a repayment threshold of ${plan2Threshold} and ${String(plan2WriteOff)}-year write-off. Plan 5 applies to English students starting from 2023 onwards, with a lower threshold of ${plan5Threshold} but a longer ${String(plan5WriteOff)}-year write-off period. Plan 2 charges interest on a sliding scale up to RPI + 3%, while Plan 5 charges RPI only.`,
+        text: `Plan 2 applies to English and Welsh students who started between 2012 and 2023, with a repayment threshold of ${plan2Threshold} and ${String(plan2WriteOff)}-year write-off. Plan 5 applies to English students starting from 2023 onwards, with a lower threshold of ${plan5Threshold} but a longer ${String(plan5WriteOff)}-year write-off period. Plan 2 charges interest on a sliding scale up to RPI + 3%, capped at ${plan2MaxRatePct}, while Plan 5 charges RPI only.`,
       },
     },
     {
@@ -75,7 +77,7 @@ const faqSchema = {
       name: "Which student loan plan costs more overall?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: `It depends on your salary. Lower earners often repay less on Plan 2 because it writes off after ${String(plan2WriteOff)} years, while Plan 5's ${String(plan5WriteOff)}-year term means more payments despite the lower interest rate. Middle earners may repay more on Plan 2 because they earn too much for write-off to help but not enough to pay off the balance quickly before interest (up to RPI + 3%) compounds significantly.`,
+        text: `It depends on your salary. Lower earners often repay less on Plan 2 because it writes off after ${String(plan2WriteOff)} years, while Plan 5's ${String(plan5WriteOff)}-year term means more payments despite the lower interest rate. Middle earners may repay more on Plan 2 because they earn too much for write-off to help but not enough to pay off the balance quickly before interest (capped at ${plan2MaxRatePct}) compounds significantly.`,
       },
     },
     {
@@ -83,7 +85,7 @@ const faqSchema = {
       name: "Does Plan 5 have lower interest than Plan 2?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: `Yes. Plan 5 charges interest at RPI only, while Plan 2 uses a sliding scale from RPI up to RPI + 3% depending on your income. However, Plan 5's longer ${String(plan5WriteOff)}-year repayment window and lower threshold mean you may still pay more in total despite the lower rate.`,
+        text: `Yes. Plan 5 charges interest at RPI only, while Plan 2 uses a sliding scale from RPI up to RPI + 3%, capped at ${plan2MaxRatePct}, depending on your income. However, Plan 5's longer ${String(plan5WriteOff)}-year repayment window and lower threshold mean you may still pay more in total despite the lower rate.`,
       },
     },
     {

--- a/src/app/guides/rpi-vs-cpi/layout.tsx
+++ b/src/app/guides/rpi-vs-cpi/layout.tsx
@@ -65,7 +65,7 @@ const faqSchema = {
       name: "Why does my student loan interest seem higher than inflation?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Your loan interest is tied to RPI, which historically runs 0.5-1 percentage points higher than CPI (the measure most people think of as 'inflation'). On top of that, some plans add up to 3% on top of RPI. So even Plan 5's 'inflation-only' rate exceeds general inflation as measured by CPI.",
+        text: `Your loan interest is tied to RPI, which historically runs 0.5-1 percentage points higher than CPI (the measure most people think of as 'inflation'). On top of that, some plans add up to 3% on top of RPI, though an interest cap currently holds that ceiling at ${String(CURRENT_RATES.interestCap)}%. So even Plan 5's 'inflation-only' rate exceeds general inflation as measured by CPI.`,
       },
     },
     {

--- a/src/app/interest/layout.tsx
+++ b/src/app/interest/layout.tsx
@@ -1,4 +1,8 @@
 import type { Metadata } from "next";
+import { formatPercent } from "@/lib/format";
+import { getMaxAnnualInterestRate } from "@/lib/loans/interest";
+
+const plan2MaxRatePct = formatPercent(getMaxAnnualInterestRate("PLAN_2"));
 
 export const metadata: Metadata = {
   title: "Interest Paid: Student Loan Interest Breakdown",
@@ -58,7 +62,7 @@ const faqSchema = {
       name: "Why do I pay more in interest than my original loan?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Student loan interest accrues from the day your loan is paid out, including while you study. For Plan 2 borrowers, interest can be RPI + up to 3%, meaning your balance can grow faster than your repayments reduce it, especially in the early years when your salary is lower.",
+        text: `Student loan interest accrues from the day your loan is paid out, including while you study. For Plan 2 borrowers, interest can be as high as ${plan2MaxRatePct} (a cap holds the sliding scale below RPI + 3%), meaning your balance can grow faster than your repayments reduce it, especially in the early years when your salary is lower.`,
       },
     },
     {

--- a/src/app/repaid/layout.tsx
+++ b/src/app/repaid/layout.tsx
@@ -1,4 +1,8 @@
 import type { Metadata } from "next";
+import { formatPercent } from "@/lib/format";
+import { getMaxAnnualInterestRate } from "@/lib/loans/interest";
+
+const plan2MaxRatePct = formatPercent(getMaxAnnualInterestRate("PLAN_2"));
 
 export const metadata: Metadata = {
   title: "Total Repayments: Student Loan Repayment Calculator",
@@ -60,7 +64,7 @@ const faqSchema = {
       name: "Will I repay more than I borrowed?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Many graduates do repay more than they borrowed because interest accrues from day one. For Plan 2 borrowers, interest can be as high as RPI + 3%, meaning total repayments can exceed the original loan. However, if your salary stays low, you may repay less before the loan is written off.",
+        text: `Many graduates do repay more than they borrowed because interest accrues from day one. For Plan 2 borrowers, interest can be as high as ${plan2MaxRatePct} (a cap holds the sliding scale below RPI + 3%), meaning total repayments can exceed the original loan. However, if your salary stays low, you may repay less before the loan is written off.`,
       },
     },
     {

--- a/src/components/guides/how-interest-works/CurrentRatesTable.tsx
+++ b/src/components/guides/how-interest-works/CurrentRatesTable.tsx
@@ -8,13 +8,16 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { formatPercent } from "@/lib/format";
+import { getMaxAnnualInterestRate } from "@/lib/loans/interest";
 import { CURRENT_RATES } from "@/lib/loans/plans";
 import { surfaceCard } from "@/lib/surfaces";
 import { specHead, specHeadNum, specNum } from "../guide-parts";
 
 // All rates derive from plans.ts so they track the current GOV.UK / BoE figures.
 const rpi = CURRENT_RATES.rpi;
-const maxRate = rpi + 3;
+const capPct = formatPercent(CURRENT_RATES.interestCap);
+const plan2MaxRate = getMaxAnnualInterestRate("PLAN_2");
+const postgradMaxRate = getMaxAnnualInterestRate("POSTGRADUATE");
 const plan1And4Rate = Math.min(rpi, CURRENT_RATES.boeBaseRate + 1);
 
 const rows = [
@@ -25,8 +28,8 @@ const rows = [
   },
   {
     plan: "Plan 2",
-    formula: "RPI to RPI + 3% (sliding scale by income)",
-    rate: `${formatPercent(rpi)}–${formatPercent(maxRate)}`,
+    formula: `RPI to RPI + 3% (sliding scale by income), capped at ${capPct}`,
+    rate: `${formatPercent(rpi)}–${formatPercent(plan2MaxRate)}`,
   },
   {
     plan: "Plan 4",
@@ -40,8 +43,8 @@ const rows = [
   },
   {
     plan: "Postgraduate",
-    formula: "RPI + 3% (all incomes)",
-    rate: formatPercent(maxRate),
+    formula: `RPI + 3% (all incomes), capped at ${capPct}`,
+    rate: formatPercent(postgradMaxRate),
   },
 ];
 

--- a/src/components/guides/how-interest-works/InterestGuide.tsx
+++ b/src/components/guides/how-interest-works/InterestGuide.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { ChartFrame } from "@/components/instrument/ChartFrame";
 import { Heading } from "@/components/typography/Heading";
 import { formatGBP, formatPercent } from "@/lib/format";
+import { getMaxAnnualInterestRate } from "@/lib/loans/interest";
 import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
 import { getCurrentTaxYearLabel } from "@/lib/taxYear";
 import { GuideArticle, guideBreakout } from "../guide-parts";
@@ -11,10 +12,11 @@ import { InterestRateChart } from "./InterestRateChart";
 
 const EXAMPLE_BALANCE = 45_000;
 const rpi = CURRENT_RATES.rpi;
-const maxRate = rpi + 3;
+const plan2MaxRate = getMaxAnnualInterestRate("PLAN_2");
+const postgradMaxRate = getMaxAnnualInterestRate("POSTGRADUATE");
 const plan1Rate = Math.min(rpi, CURRENT_RATES.boeBaseRate + 1);
 const boeRatePlus1 = CURRENT_RATES.boeBaseRate + 1;
-const monthlyInterest = Math.round((EXAMPLE_BALANCE * maxRate) / 100 / 12);
+const monthlyInterest = Math.round((EXAMPLE_BALANCE * plan2MaxRate) / 100 / 12);
 
 // Derived from the current date so the label tracks the live plans.ts figures.
 const currentTaxYear = getCurrentTaxYearLabel();
@@ -46,8 +48,8 @@ export function InterestGuide() {
           <p>
             Plan 2 has the most complex interest calculation. It uses a sliding
             scale tied to your income, ranging from RPI (currently{" "}
-            {formatPercent(rpi)}) up to RPI + 3% (currently{" "}
-            {formatPercent(maxRate)}).
+            {formatPercent(rpi)}) up to RPI + 3%, though a cap currently holds
+            the ceiling at {formatPercent(plan2MaxRate)}.
           </p>
           <ul className="list-disc space-y-1 pl-6">
             <li>
@@ -58,17 +60,17 @@ export function InterestGuide() {
             <li>
               Earning above the upper threshold of{" "}
               {formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}: you pay
-              the maximum of RPI + 3% ({formatPercent(maxRate)})
+              the capped maximum ({formatPercent(plan2MaxRate)})
             </li>
             <li>
               Earning between the two: the rate scales linearly from{" "}
-              {formatPercent(rpi)} up to {formatPercent(maxRate)}
+              {formatPercent(rpi)} up to {formatPercent(plan2MaxRate)}
             </li>
           </ul>
           <p>
-            While studying, Plan 2 borrowers are charged the maximum rate of RPI
-            + 3%. This means your balance starts growing before you even
-            graduate.
+            While studying, Plan 2 borrowers are charged the sliding
+            scale&apos;s capped maximum rate. This means your balance starts
+            growing before you even graduate.
           </p>
         </div>
       </section>
@@ -85,8 +87,8 @@ export function InterestGuide() {
           </p>
           <p>
             This is a significant change from Plan 2. A high earner on Plan 2
-            could be paying {formatPercent(maxRate)} interest, while the same
-            earner on Plan 5 would pay only {formatPercent(rpi)}. The chart
+            could be paying {formatPercent(plan2MaxRate)} interest, while the
+            same earner on Plan 5 would pay only {formatPercent(rpi)}. The chart
             below illustrates this difference clearly.
           </p>
         </div>
@@ -95,7 +97,7 @@ export function InterestGuide() {
       <ChartFrame
         className={guideBreakout}
         caption="Fig. 1: Annual interest rate by salary · Plan 2 vs Plan 5"
-        figure={`${formatPercent(maxRate)} max`}
+        figure={`${formatPercent(plan2MaxRate)} max`}
         figureTone="cost"
       >
         <InterestRateChart />
@@ -128,9 +130,9 @@ export function InterestGuide() {
         <div className="space-y-2 text-muted-foreground">
           <p>
             Postgraduate (Master&apos;s and Doctoral) loans always charge RPI +
-            3%, regardless of your income. At current rates, that means{" "}
-            {formatPercent(maxRate)} interest per year, the highest rate of any
-            UK student loan plan.
+            3%, capped like every plan, regardless of your income. At current
+            rates, that means {formatPercent(postgradMaxRate)} interest per
+            year, the highest rate of any UK student loan plan.
           </p>
         </div>
       </section>
@@ -166,7 +168,7 @@ export function InterestGuide() {
           </p>
           <p>
             For example, on a {formatGBP(EXAMPLE_BALANCE)} balance at{" "}
-            {formatPercent(maxRate)} interest, you would accrue roughly{" "}
+            {formatPercent(plan2MaxRate)} interest, you would accrue roughly{" "}
             {formatGBP(monthlyInterest)} per month in interest alone. If your
             monthly repayment is less than that, the balance will keep growing.
           </p>

--- a/src/components/guides/interest-rate-cap/BalanceWithCapChart.tsx
+++ b/src/components/guides/interest-rate-cap/BalanceWithCapChart.tsx
@@ -4,10 +4,12 @@ import { useState } from "react";
 import type { ChartSeriesConfig } from "@/components/charts/ChartBase";
 import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
 import type { ChartConfig } from "@/components/ui/chart";
-import { getAnnualInterestRate } from "@/lib/loans/interest";
+import { formatPercent } from "@/lib/format";
+import { getAnnualInterestRate, NO_INTEREST_CAP } from "@/lib/loans/interest";
 import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
 import { segmentToggle } from "../guide-primitives";
-import { INTEREST_CAP } from "./historical-rates";
+
+const capPct = formatPercent(CURRENT_RATES.interestCap);
 
 const RPI_OPTIONS = [
   {
@@ -31,7 +33,7 @@ const chartConfig = {
     color: "var(--chart-2)", // costlier path — the cost clay
   },
   capped: {
-    label: "With 6% cap",
+    label: `With ${capPct} cap`,
     color: "var(--chart-1)", // better outcome — principal green
   },
 } satisfies ChartConfig;
@@ -41,7 +43,7 @@ const series: ChartSeriesConfig[] = [
   { dataKey: "capped" },
 ];
 
-function simulateBalance(rpi: number, capRate: number | null) {
+function simulateBalance(rpi: number, capRate: number) {
   const boe = CURRENT_RATES.boeBaseRate;
   const monthlyThreshold = PLAN_CONFIGS.PLAN_2.monthlyThreshold;
   const repaymentRate = PLAN_CONFIGS.PLAN_2.repaymentRate;
@@ -56,10 +58,14 @@ function simulateBalance(rpi: number, capRate: number | null) {
       salary *= 1 + SALARY_GROWTH;
     }
 
-    let annualRate = getAnnualInterestRate("PLAN_2", salary, rpi, boe);
-    if (capRate !== null) {
-      annualRate = Math.min(annualRate, capRate);
-    }
+    const annualRate = getAnnualInterestRate(
+      "PLAN_2",
+      salary,
+      rpi,
+      boe,
+      undefined,
+      capRate,
+    );
 
     const monthlyInterest = balance * (annualRate / 100 / 12);
     balance += monthlyInterest;
@@ -81,8 +87,8 @@ function simulateBalance(rpi: number, capRate: number | null) {
 }
 
 function buildData(rpi: RpiOption) {
-  const uncappedBalances = simulateBalance(rpi, null);
-  const cappedBalances = simulateBalance(rpi, INTEREST_CAP);
+  const uncappedBalances = simulateBalance(rpi, NO_INTEREST_CAP);
+  const cappedBalances = simulateBalance(rpi, CURRENT_RATES.interestCap);
 
   const maxYears = Math.max(uncappedBalances.length, cappedBalances.length);
   const data: Array<{ year: number; uncapped: number; capped: number }> = [];
@@ -144,7 +150,7 @@ export function BalanceWithCapChart() {
           xFormatter={formatYear}
           yLabel="Balance"
           yFormatter={formatCurrency}
-          ariaLabel="Area chart comparing loan balance over time with and without the 6% interest rate cap"
+          ariaLabel={`Area chart comparing loan balance over time with and without the ${capPct} interest rate cap`}
           chartConfig={chartConfig}
           series={series}
           showLegend

--- a/src/components/guides/interest-rate-cap/CurrentCapTable.tsx
+++ b/src/components/guides/interest-rate-cap/CurrentCapTable.tsx
@@ -8,16 +8,23 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { formatGBP, formatPercent } from "@/lib/format";
+import {
+  getMaxAnnualInterestRate,
+  NO_INTEREST_CAP,
+} from "@/lib/loans/interest";
 import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
 import { surfaceCard } from "@/lib/surfaces";
 import { specHead, specHeadNum, specNum } from "../guide-parts";
 
-// The 6% cap is a policy figure (Sept 2026), not something plans.ts supplies —
-// kept as a labelled constant, consistent with the rest of this guide.
-const INTEREST_CAP_RATE = 6;
-
 const rpi = CURRENT_RATES.rpi;
-const maxRate = rpi + 3;
+// The formula's ceiling with the cap lifted, shown alongside the cap in
+// force so the table reads as "before" versus "after".
+const uncappedMaxRate = getMaxAnnualInterestRate(
+  "PLAN_2",
+  rpi,
+  CURRENT_RATES.boeBaseRate,
+  NO_INTEREST_CAP,
+);
 
 const rows = [
   { figure: "Base RPI", value: formatPercent(rpi) },
@@ -26,16 +33,16 @@ const rows = [
     value: formatPercent(rpi),
   },
   {
-    figure: "Plan 2 maximum interest rate (RPI + 3%)",
-    value: formatPercent(maxRate),
+    figure: "Plan 2 maximum interest rate: RPI + 3% before the cap",
+    value: formatPercent(uncappedMaxRate),
   },
   {
     figure: "Income at which the maximum rate applies",
     value: `Above ${formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}`,
   },
   {
-    figure: "Interest rate cap (from 1 September 2026)",
-    value: formatPercent(INTEREST_CAP_RATE),
+    figure: "Interest cap (in force)",
+    value: formatPercent(CURRENT_RATES.interestCap),
   },
 ];
 

--- a/src/components/guides/interest-rate-cap/HistoricalRatesChart.tsx
+++ b/src/components/guides/interest-rate-cap/HistoricalRatesChart.tsx
@@ -3,12 +3,16 @@
 import type { ChartSeriesConfig } from "@/components/charts/ChartBase";
 import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
 import type { ChartConfig } from "@/components/ui/chart";
-import { HISTORICAL_RATES, INTEREST_CAP } from "./historical-rates";
+import { formatPercent } from "@/lib/format";
+import { CURRENT_RATES } from "@/lib/loans/plans";
+import { HISTORICAL_RATES } from "./historical-rates";
+
+const capPct = formatPercent(CURRENT_RATES.interestCap);
 
 const chartData = HISTORICAL_RATES.map((d) => ({
   ...d,
-  above: Math.max(0, d.maxRate - INTEREST_CAP),
-  below: Math.min(d.maxRate, INTEREST_CAP),
+  above: Math.max(0, d.maxRate - CURRENT_RATES.interestCap),
+  below: Math.min(d.maxRate, CURRENT_RATES.interestCap),
 }));
 
 const chartConfig = {
@@ -17,7 +21,7 @@ const chartConfig = {
     color: "var(--chart-5)", // within-cap portion — neutral baseline grey
   },
   above: {
-    label: "Above 6% cap",
+    label: `Above ${capPct} cap`,
     color: "var(--chart-2)", // the costly excess the cap removes — cost clay
   },
 } satisfies ChartConfig;
@@ -46,13 +50,13 @@ export function HistoricalRatesChart() {
         xFormatter={formatYear}
         yFormatter={formatRate}
         yDomain={[0, 9]}
-        ariaLabel="Bar chart showing maximum Plan 2 interest rate per academic year from 2012 to 2025, with bars coloured to show portions above and below the 6% cap"
+        ariaLabel={`Bar chart showing maximum Plan 2 interest rate per academic year from 2012 to 2025, with bars coloured to show portions above and below the ${capPct} cap`}
         chartConfig={chartConfig}
         series={series}
         horizontalAnnotations={[
           {
-            y: INTEREST_CAP,
-            label: "6% cap",
+            y: CURRENT_RATES.interestCap,
+            label: `${capPct} cap`,
             color: "var(--chart-1)",
             strokeDasharray: "6 4",
           },

--- a/src/components/guides/interest-rate-cap/InterestRateCapGuide.tsx
+++ b/src/components/guides/interest-rate-cap/InterestRateCapGuide.tsx
@@ -1,6 +1,10 @@
 import { ChartFrame } from "@/components/instrument/ChartFrame";
 import { Heading } from "@/components/typography/Heading";
 import { formatGBP, formatPercent } from "@/lib/format";
+import {
+  getMaxAnnualInterestRate,
+  NO_INTEREST_CAP,
+} from "@/lib/loans/interest";
 import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
 import { getCurrentTaxYearLabel } from "@/lib/taxYear";
 import { GuideArticle, guideBreakout, KeyTakeaways } from "../guide-parts";
@@ -11,7 +15,21 @@ import { HistoricalRatesChart } from "./HistoricalRatesChart";
 import { TotalCostComparisonChart } from "./TotalCostComparisonChart";
 
 const rpi = CURRENT_RATES.rpi;
-const currentMaxRate = rpi + 3;
+const rpiPct = formatPercent(rpi);
+const capPct = formatPercent(CURRENT_RATES.interestCap);
+// The formula's ceiling with the cap lifted, for the before/after comparison
+// this guide exists to explain.
+const uncappedMaxRate = getMaxAnnualInterestRate(
+  "PLAN_2",
+  rpi,
+  CURRENT_RATES.boeBaseRate,
+  NO_INTEREST_CAP,
+);
+const uncappedMaxRatePct = formatPercent(uncappedMaxRate);
+const gapAboveCap = Math.max(
+  0,
+  Math.round((uncappedMaxRate - CURRENT_RATES.interestCap) * 100) / 100,
+);
 
 // Derived from the current date so the label tracks the live plans.ts figures.
 const currentTaxYear = getCurrentTaxYearLabel();
@@ -20,13 +38,13 @@ export function InterestRateCapGuide() {
   return (
     <GuideArticle
       breadcrumbLabel="Interest Rate Cap"
-      title="Plan 2 interest rate capped at 6%: what it means for you"
+      title={`Plan 2 interest rate capped at ${capPct}: what it means for you`}
       intro={
         <>
-          On 7 April 2026, the government announced a 6% cap on Plan 2 and Plan
-          3 student loan interest rates from September 2026. At today&rsquo;s
-          RPI it changes almost nothing. Its value is in what it prevents if
-          inflation spikes again.
+          On 7 April 2026, the government announced a cap on Plan 2 and Plan 3
+          student loan interest rates. Since 1 September 2026, that cap has held
+          the maximum rate at {capPct}. At today&rsquo;s RPI it changes almost
+          nothing. Its value is in what it prevents if inflation spikes again.
         </>
       }
       related={{
@@ -42,22 +60,22 @@ export function InterestRateCapGuide() {
         <div className="space-y-2 text-muted-foreground">
           <p>
             Plan 2 loans charge interest on a sliding scale: from RPI (currently{" "}
-            {formatPercent(rpi)}) for lower earners up to RPI + 3% (currently{" "}
-            {formatPercent(currentMaxRate)}) for those earning above{" "}
-            {formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}. While
-            studying, borrowers are charged the full RPI + 3%.
+            {rpiPct}) for lower earners up to RPI + 3% for those earning above{" "}
+            {formatGBP(PLAN_CONFIGS.PLAN_2.interestUpperThreshold)}. A cap holds
+            that ceiling at {capPct} rather than the {uncappedMaxRatePct} the
+            formula would otherwise produce. While studying, borrowers are
+            charged that capped maximum.
           </p>
           <p>
-            From 1 September 2026, the maximum interest rate on Plan 2 and Plan
-            3 loans will be capped at 6%, regardless of what the RPI + 3%
+            Since 1 September 2026, the maximum interest rate on Plan 2 and Plan
+            3 loans has been capped at {capPct}, regardless of what the RPI + 3%
             formula produces. This cap applies for the 2026/27 academic year.
           </p>
           <p>
-            At current rates, this barely bites: the maximum is{" "}
-            {formatPercent(currentMaxRate)}, only{" "}
-            {formatPercent(Math.round((currentMaxRate - 6) * 100) / 100)} above
-            the cap. But the cap is designed as insurance: if inflation surges
-            again, your interest rate will not follow it above 6%.
+            At current rates, this barely bites: the uncapped formula would
+            produce {uncappedMaxRatePct}, only {formatPercent(gapAboveCap)}{" "}
+            above the cap. But the cap is designed as insurance: if inflation
+            surges again, your interest rate will not follow it above {capPct}.
           </p>
         </div>
       </section>
@@ -69,7 +87,7 @@ export function InterestRateCapGuide() {
         <div className="space-y-2 text-muted-foreground">
           <p>
             The key Plan 2 interest figures for the {currentTaxYear} tax year,
-            alongside the 6% cap that applies from September 2026.
+            alongside the {capPct} cap that has applied since 1 September 2026.
           </p>
         </div>
       </section>
@@ -92,18 +110,18 @@ export function InterestRateCapGuide() {
           <p>
             The government had previously used the &ldquo;prevailing market
             rate&rdquo; (PMR) mechanism to intervene when rates became
-            unreasonable. The 6% cap formalises this protection with a clear,
-            predictable ceiling instead of ad-hoc adjustments.
+            unreasonable. The {capPct} cap formalises this protection with a
+            clear, predictable ceiling instead of ad-hoc adjustments.
           </p>
         </div>
       </section>
 
       <section className="space-y-4">
         <Heading as="h2" size="section">
-          How Often Has the Rate Exceeded 6%?
+          {`How Often Has the Rate Exceeded ${capPct}?`}
         </Heading>
         <p className="text-muted-foreground">
-          The maximum Plan 2 interest rate has exceeded 6% in{" "}
+          The maximum Plan 2 interest rate has exceeded {capPct} in{" "}
           {String(YEARS_ABOVE_CAP)} out of {String(TOTAL_YEARS)} academic years{" "}
           since Plan 2 was introduced in 2012. During the inflation crisis of
           2022&ndash;2024, rates hit 7.7% even after the PMR cap was applied.
@@ -111,14 +129,14 @@ export function InterestRateCapGuide() {
         </p>
         <p className="text-sm text-muted-foreground">
           The bars show the maximum rate actually charged each year (after any
-          PMR intervention). The dashed line marks the new 6% cap.
+          PMR intervention). The dashed line marks the {capPct} cap.
         </p>
       </section>
 
       <ChartFrame
         className={guideBreakout}
         caption="Fig. 1: Maximum Plan 2 rate charged by year"
-        figure="Cap 6%"
+        figure={`Cap ${capPct}`}
         figureTone="cost"
       >
         <HistoricalRatesChart />
@@ -147,14 +165,14 @@ export function InterestRateCapGuide() {
         <p className="text-sm text-muted-foreground">
           At higher RPI values, the gap between the capped and uncapped balance
           widens significantly. At 7% RPI, the uncapped rate would be 10%, and
-          the cap saves borrowers from that compounding.
+          the cap holds it at {capPct} instead.
         </p>
       </section>
 
       <ChartFrame
         className={guideBreakout}
-        caption="Fig. 2: Balance with and without the 6% cap"
-        figure="Cap 6%"
+        caption={`Fig. 2: Balance with and without the ${capPct} cap`}
+        figure={`Cap ${capPct}`}
         figureTone="cost"
         bodyClassName="h-80 sm:h-100"
       >
@@ -198,8 +216,9 @@ export function InterestRateCapGuide() {
               <strong className="text-foreground">
                 Current students on Plan 2 or Plan 3
               </strong>
-              : while studying, you are charged the maximum rate (RPI + 3%). The
-              cap means this will not exceed 6%, slowing the growth of your
+              : while studying, you are charged the maximum rate. The cap holds
+              this at {capPct} rather than the {uncappedMaxRatePct} the RPI + 3%
+              formula would otherwise produce, slowing the growth of your
               balance before you even start repaying.
             </li>
             <li>
@@ -244,11 +263,12 @@ export function InterestRateCapGuide() {
             </li>
             <li>
               <strong className="text-foreground">
-                Plan 1, 4, and 5 are not affected
+                Plan 1, 4, and 5 rarely feel it
               </strong>
               : Plan 1 and 4 rates are already capped at the lower of RPI or
-              Bank of England base rate + 1%. Plan 5 charges RPI only, with no
-              +3% component.
+              Bank of England base rate + 1%, which sits below the interest cap
+              at current figures. Plan 5 charges RPI only, with no +3%
+              component, also below the cap today.
             </li>
             <li>
               <strong className="text-foreground">
@@ -263,11 +283,12 @@ export function InterestRateCapGuide() {
 
       <KeyTakeaways>
         <li>
-          Plan 2 and Plan 3 interest will be capped at 6% from September 2026.
+          Plan 2 and Plan 3 interest is capped at {capPct}, in force since 1
+          September 2026.
         </li>
         <li>
-          The maximum rate has exceeded 6% in {String(YEARS_ABOVE_CAP)} of the{" "}
-          {String(TOTAL_YEARS)} years since Plan 2 was introduced.
+          The maximum rate has exceeded {capPct} in {String(YEARS_ABOVE_CAP)} of
+          the {String(TOTAL_YEARS)} years since Plan 2 was introduced.
         </li>
         <li>
           The biggest beneficiaries are higher earners and current students,
@@ -277,7 +298,7 @@ export function InterestRateCapGuide() {
           Monthly repayments do not change; the cap only slows balance growth.
         </li>
         <li>
-          The cap is announced for one year only (2026/27), though it may be
+          The cap applies for one year only (2026/27), though it may be
           extended.
         </li>
       </KeyTakeaways>

--- a/src/components/guides/interest-rate-cap/TotalCostComparisonChart.tsx
+++ b/src/components/guides/interest-rate-cap/TotalCostComparisonChart.tsx
@@ -3,13 +3,14 @@
 import type { ChartSeriesConfig } from "@/components/charts/ChartBase";
 import { LazyChartBase as ChartBase } from "@/components/charts/LazyChartBase";
 import type { ChartConfig } from "@/components/ui/chart";
-import { getAnnualInterestRate } from "@/lib/loans/interest";
+import { formatPercent } from "@/lib/format";
+import { getAnnualInterestRate, NO_INTEREST_CAP } from "@/lib/loans/interest";
 import { CURRENT_RATES, PLAN_CONFIGS } from "@/lib/loans/plans";
-import { INTEREST_CAP } from "./historical-rates";
 
 const STARTING_BALANCE = 45_000;
 const SALARY_GROWTH = 0.03;
 const HIGH_RPI = 7;
+const capPct = formatPercent(CURRENT_RATES.interestCap);
 
 const chartConfig = {
   uncapped: {
@@ -17,7 +18,7 @@ const chartConfig = {
     color: "var(--chart-2)", // costlier path — the cost clay
   },
   capped: {
-    label: "With 6% cap",
+    label: `With ${capPct} cap`,
     color: "var(--chart-1)", // better outcome — principal green
   },
 } satisfies ChartConfig;
@@ -27,10 +28,7 @@ const series: ChartSeriesConfig[] = [
   { dataKey: "capped" },
 ];
 
-function simulateTotalPaid(
-  startingSalary: number,
-  capRate: number | null,
-): number {
+function simulateTotalPaid(startingSalary: number, capRate: number): number {
   const boe = CURRENT_RATES.boeBaseRate;
   const monthlyThreshold = PLAN_CONFIGS.PLAN_2.monthlyThreshold;
   const repaymentRate = PLAN_CONFIGS.PLAN_2.repaymentRate;
@@ -45,10 +43,14 @@ function simulateTotalPaid(
       salary *= 1 + SALARY_GROWTH;
     }
 
-    let annualRate = getAnnualInterestRate("PLAN_2", salary, HIGH_RPI, boe);
-    if (capRate !== null) {
-      annualRate = Math.min(annualRate, capRate);
-    }
+    const annualRate = getAnnualInterestRate(
+      "PLAN_2",
+      salary,
+      HIGH_RPI,
+      boe,
+      undefined,
+      capRate,
+    );
 
     const monthlyInterest = balance * (annualRate / 100 / 12);
     balance += monthlyInterest;
@@ -73,8 +75,8 @@ function buildData() {
   for (let salary = 25000; salary <= 80000; salary += 1000) {
     points.push({
       salary,
-      uncapped: simulateTotalPaid(salary, null),
-      capped: simulateTotalPaid(salary, INTEREST_CAP),
+      uncapped: simulateTotalPaid(salary, NO_INTEREST_CAP),
+      capped: simulateTotalPaid(salary, CURRENT_RATES.interestCap),
     });
   }
 
@@ -102,7 +104,7 @@ export function TotalCostComparisonChart() {
         xFormatter={formatSalary}
         yLabel="Total repaid"
         yFormatter={formatCurrency}
-        ariaLabel="Line chart comparing total repayment by salary with and without the 6% interest rate cap, assuming 7% RPI"
+        ariaLabel={`Line chart comparing total repayment by salary with and without the ${capPct} interest rate cap, assuming 7% RPI`}
         chartConfig={chartConfig}
         series={series}
         showLegend

--- a/src/components/guides/interest-rate-cap/historical-rates.ts
+++ b/src/components/guides/interest-rate-cap/historical-rates.ts
@@ -1,3 +1,5 @@
+import { CURRENT_RATES } from "@/lib/loans/plans";
+
 /**
  * Maximum Plan 2 interest rate actually charged each academic year.
  * For years where the prevailing market rate (PMR) cap was applied,
@@ -20,10 +22,8 @@ export const HISTORICAL_RATES = [
   { year: 2025, label: "25/26", maxRate: 6.2 },
 ] as const;
 
-export const INTEREST_CAP = 6;
-
 export const YEARS_ABOVE_CAP = HISTORICAL_RATES.filter(
-  (d) => d.maxRate > INTEREST_CAP,
+  (d) => d.maxRate > CURRENT_RATES.interestCap,
 ).length;
 
 export const TOTAL_YEARS = HISTORICAL_RATES.length;

--- a/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
+++ b/src/components/guides/moving-abroad/MovingAbroadGuide.tsx
@@ -15,6 +15,7 @@ import {
   formatMultiplier,
   formatPercent,
 } from "@/lib/format";
+import { getMaxAnnualInterestRate } from "@/lib/loans/interest";
 import { OVERSEAS_TAX_YEAR } from "@/lib/loans/overseasThresholds";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
 import {
@@ -52,6 +53,7 @@ const undergradRate = formatPercent(PLAN_CONFIGS.PLAN_2.repaymentRate * 100);
 const postgradRate = formatPercent(
   PLAN_CONFIGS.POSTGRADUATE.repaymentRate * 100,
 );
+const plan2MaxRatePct = formatPercent(getMaxAnnualInterestRate("PLAN_2"));
 
 export function MovingAbroadGuide() {
   return (
@@ -359,10 +361,10 @@ export function MovingAbroadGuide() {
         </p>
         <p className="text-muted-foreground">
           If you don&rsquo;t keep your employment details up to date, Plan 2
-          interest goes to the highest rate, RPI + 3%, whatever your income, for
-          as long as your details are out of date. Plan 1, Plan 4, Plan 5 and
-          Postgraduate interest rates are not income-based, so an overseas
-          assessment does not change them.
+          interest goes to the highest rate, capped at {plan2MaxRatePct},
+          whatever your income, for as long as your details are out of date.
+          Plan 1, Plan 4, Plan 5 and Postgraduate interest rates are not
+          income-based, so an overseas assessment does not change them.
         </p>
       </section>
 
@@ -396,8 +398,8 @@ export function MovingAbroadGuide() {
                 .
               </li>
               <li>
-                Plan 2 interest moves to the highest rate, RPI + 3%, for as long
-                as your details are out of date.
+                Plan 2 interest moves to the highest rate, capped at{" "}
+                {plan2MaxRatePct}, for as long as your details are out of date.
               </li>
               <li>
                 SLC can charge a penalty, demand the whole loan plus interest

--- a/src/components/guides/moving-abroad/OverseasRepaymentEstimator.tsx
+++ b/src/components/guides/moving-abroad/OverseasRepaymentEstimator.tsx
@@ -22,6 +22,7 @@ import {
   formatMultiplier,
   formatPercent,
 } from "@/lib/format";
+import { getMaxAnnualInterestRate } from "@/lib/loans/interest";
 import {
   estimateOverseasRepayment,
   fromGBP,
@@ -220,7 +221,7 @@ function interestReadout(estimate: OverseasRepaymentEstimate): {
     case "POSTGRADUATE":
       return {
         figure: "RPI + 3%",
-        note: "Postgraduate interest is RPI + 3% wherever you live.",
+        note: `Postgraduate interest is a flat RPI + 3%, capped at ${formatPercent(getMaxAnnualInterestRate("POSTGRADUATE"))}, wherever you live.`,
       };
   }
 }

--- a/src/components/guides/moving-abroad/overseas-data.ts
+++ b/src/components/guides/moving-abroad/overseas-data.ts
@@ -3,7 +3,9 @@ import {
   formatGBP,
   formatGBPPence,
   formatMultiplier,
+  formatPercent,
 } from "@/lib/format";
+import { getMaxAnnualInterestRate } from "@/lib/loans/interest";
 import { getOverseasBand, requireTerritory } from "@/lib/loans/overseas";
 import {
   OVERSEAS_BANDS,
@@ -113,6 +115,7 @@ const year = OVERSEAS_TAX_YEAR;
 const ukPlan2 = formatGBP(featured.uk.plan2Threshold);
 const spainPlan2 = formatGBP(featured.spain.plan2Threshold);
 const usaPlan2 = formatGBP(featured.usa.plan2Threshold);
+const plan2MaxRatePct = formatPercent(getMaxAnnualInterestRate("PLAN_2"));
 
 // Single source of truth for the visible FAQ and the FAQPage JSON-LD in
 // layout.tsx, so the structured data can never drift from what the page shows.
@@ -142,7 +145,7 @@ export const movingAbroadFaqs = [
   },
   {
     question: "What happens if I don't tell SLC I've moved abroad?",
-    answer: `SLC charges the fixed monthly repayment for your country: ${formatGBPPence(featured.spain.plan2FixedMonthly)} a month in Spain, or ${formatGBPPence(featured.australia.plan2FixedMonthly)} in Australia for Plan 2 in ${year}. That can be higher than an income-based amount. Unpaid amounts become arrears, Plan 2 interest goes to the highest rate (RPI + 3%), and SLC can charge a penalty, demand the whole loan in one lump sum, and take court action. Student loans still do not appear on your credit report.`,
+    answer: `SLC charges the fixed monthly repayment for your country: ${formatGBPPence(featured.spain.plan2FixedMonthly)} a month in Spain, or ${formatGBPPence(featured.australia.plan2FixedMonthly)} in Australia for Plan 2 in ${year}. That can be higher than an income-based amount. Unpaid amounts become arrears, Plan 2 interest goes to the highest rate (capped at ${plan2MaxRatePct}), and SLC can charge a penalty, demand the whole loan in one lump sum, and take court action. Student loans still do not appear on your credit report.`,
   },
   {
     question:

--- a/src/components/guides/plan-2-vs-plan-5/ComparisonTable.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/ComparisonTable.tsx
@@ -7,8 +7,12 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { formatGBP } from "@/lib/format";
-import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
+import { formatGBP, formatPercent } from "@/lib/format";
+import {
+  CURRENT_RATES,
+  PLAN_CONFIGS,
+  PLAN_DISPLAY_INFO,
+} from "@/lib/loans/plans";
 import { surfaceCard } from "@/lib/surfaces";
 import { specHead } from "../guide-parts";
 
@@ -18,6 +22,7 @@ const plan5 = PLAN_DISPLAY_INFO.PLAN_5;
 const plan2Threshold = formatGBP(PLAN_CONFIGS.PLAN_2.monthlyThreshold * 12);
 const plan5Threshold = formatGBP(PLAN_CONFIGS.PLAN_5.monthlyThreshold * 12);
 const repaymentRate = String(plan2.repaymentRate * 100);
+const capPct = formatPercent(CURRENT_RATES.interestCap);
 
 const rows = [
   {
@@ -37,7 +42,7 @@ const rows = [
   },
   {
     label: "Interest rate",
-    plan2: "RPI to RPI + 3% (sliding scale)",
+    plan2: `RPI to RPI + 3% (sliding scale), capped at ${capPct}`,
     plan5: "RPI only",
   },
   {

--- a/src/components/guides/plan-2-vs-plan-5/Plan2VsPlan5Guide.tsx
+++ b/src/components/guides/plan-2-vs-plan-5/Plan2VsPlan5Guide.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import { ChartFrame } from "@/components/instrument/ChartFrame";
 import { Heading } from "@/components/typography/Heading";
-import { formatGBP } from "@/lib/format";
+import { formatGBP, formatPercent } from "@/lib/format";
+import { getMaxAnnualInterestRate } from "@/lib/loans/interest";
 import { PLAN_CONFIGS, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
 import { GuideArticle, guideBreakout, KeyTakeaways } from "../guide-parts";
 import { guideLink } from "../guide-primitives";
@@ -11,6 +12,7 @@ import { TotalRepaymentBySalaryChart } from "./TotalRepaymentBySalaryChart";
 
 const EXAMPLE_BALANCE = 45_000;
 const EXAMPLE_SALARY = 30_000;
+const plan2MaxRate = getMaxAnnualInterestRate("PLAN_2");
 const plan2Threshold = PLAN_DISPLAY_INFO.PLAN_2.yearlyThreshold;
 const plan5Threshold = PLAN_DISPLAY_INFO.PLAN_5.yearlyThreshold;
 const repaymentRate = PLAN_CONFIGS.PLAN_2.repaymentRate;
@@ -193,8 +195,9 @@ export function Plan2VsPlan5Guide() {
             <Link href="/guides/how-interest-works" className={guideLink}>
               interest
             </Link>{" "}
-            (up to RPI + 3%) compounds over decades. These borrowers often end
-            up repaying more in total than Plan 5 borrowers on the same salary.
+            (up to RPI + 3%, capped at {formatPercent(plan2MaxRate)}) compounds
+            over decades. These borrowers often end up repaying more in total
+            than Plan 5 borrowers on the same salary.
           </p>
           <p>
             Use the{" "}
@@ -213,9 +216,10 @@ export function Plan2VsPlan5Guide() {
           lower threshold mean more months of repayments.
         </li>
         <li>
-          Middle earners may pay more on Plan 2 because interest can reach RPI +
-          3%, and they earn too much for write-off to help but not enough to pay
-          off the balance quickly.
+          Middle earners may pay more on Plan 2 because interest can reach its
+          capped ceiling of {formatPercent(plan2MaxRate)}, and they earn too
+          much for write-off to help but not enough to pay off the balance
+          quickly.
         </li>
         <li>
           Plan 5&rsquo;s simpler interest (RPI only) makes the balance more

--- a/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
+++ b/src/components/guides/rpi-vs-cpi/RpiVsCpiGuide.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { ChartFrame } from "@/components/instrument/ChartFrame";
 import { Heading } from "@/components/typography/Heading";
 import { formatPercent } from "@/lib/format";
+import { getMaxAnnualInterestRate } from "@/lib/loans/interest";
 import { CURRENT_RATES } from "@/lib/loans/plans";
 import { GuideArticle, guideBreakout, KeyTakeaways } from "../guide-parts";
 import { guideLink } from "../guide-primitives";
@@ -10,7 +11,8 @@ import { InflationComparisonChart } from "./InflationComparisonChart";
 const rpi = CURRENT_RATES.rpi;
 const cpiTarget = 2;
 const gap = +(rpi - cpiTarget).toFixed(1);
-const maxRate = rpi + 3;
+const plan2MaxRate = getMaxAnnualInterestRate("PLAN_2");
+const postgradMaxRate = getMaxAnnualInterestRate("POSTGRADUATE");
 const plan1Rate = Math.min(rpi, CURRENT_RATES.boeBaseRate + 1);
 
 export function RpiVsCpiGuide() {
@@ -93,8 +95,8 @@ export function RpiVsCpiGuide() {
             </li>
             <li>
               <strong className="text-foreground">Plan 2</strong>: RPI to RPI +
-              3% ({formatPercent(rpi)} &ndash; {formatPercent(maxRate)})
-              depending on income
+              3%, capped ({formatPercent(rpi)} &ndash;{" "}
+              {formatPercent(plan2MaxRate)}) depending on income
             </li>
             <li>
               <strong className="text-foreground">Plan 1 &amp; 4</strong>:
@@ -103,7 +105,7 @@ export function RpiVsCpiGuide() {
             </li>
             <li>
               <strong className="text-foreground">Postgraduate</strong>: RPI +
-              3% ({formatPercent(maxRate)})
+              3%, capped ({formatPercent(postgradMaxRate)})
             </li>
           </ul>
         </div>
@@ -197,8 +199,9 @@ export function RpiVsCpiGuide() {
             </li>
             <li>
               <strong className="text-foreground">Plan 2</strong>: the sliding
-              scale starts at RPI (already above CPI). High earners face RPI +
-              3%.
+              scale starts at RPI (already above CPI). High earners face the
+              interest cap, {formatPercent(plan2MaxRate)}, rather than the full
+              RPI + 3%.
             </li>
             <li>
               <strong className="text-foreground">Plan 1 &amp; 4</strong>:
@@ -206,8 +209,9 @@ export function RpiVsCpiGuide() {
               are somewhat shielded.
             </li>
             <li>
-              <strong className="text-foreground">Postgraduate</strong>: RPI +
-              3% means the largest gap above CPI of any plan.
+              <strong className="text-foreground">Postgraduate</strong>: capped
+              at {formatPercent(postgradMaxRate)}, still the largest gap above
+              CPI of any plan.
             </li>
           </ul>
           <p>

--- a/src/components/home/instrument/RulesSection.tsx
+++ b/src/components/home/instrument/RulesSection.tsx
@@ -1,5 +1,6 @@
 import { InstrumentSection } from "@/components/instrument/InstrumentSection";
-import { formatGBP } from "@/lib/format";
+import { formatGBP, formatPercent } from "@/lib/format";
+import { getMaxAnnualInterestRate } from "@/lib/loans/interest";
 import { PLAN_CONFIGS } from "@/lib/loans/plans";
 import { getCurrentTaxYearLabel } from "@/lib/taxYear";
 
@@ -10,6 +11,7 @@ const PLAN2 = PLAN_CONFIGS.PLAN_2;
 const PLAN2_THRESHOLD = formatGBP(PLAN2.monthlyThreshold * 12);
 const PLAN2_RATE = Math.round(PLAN2.repaymentRate * 100);
 const PLAN2_WRITEOFF = PLAN2.writeOffYears;
+const PLAN2_MAX_RATE = formatPercent(getMaxAnnualInterestRate("PLAN_2"));
 
 export function RulesSection() {
   return (
@@ -49,7 +51,8 @@ export function RulesSection() {
           </h3>
           <p className="col-start-2 text-body leading-[1.55] text-pretty text-muted-foreground">
             The balance grows with inflation. Interest runs from RPI up to RPI +
-            3%, and how much you earn sets where you land on that sliding scale.
+            3%, capped at {PLAN2_MAX_RATE}, and how much you earn sets where you
+            land on that sliding scale.
           </p>
           <span className="col-start-2 mt-[0.55rem] font-sans text-meta text-muted-foreground">
             RPI to RPI + 3%

--- a/src/components/our-data/OurDataPage.tsx
+++ b/src/components/our-data/OurDataPage.tsx
@@ -2,6 +2,7 @@ import {
   ArrowUpRight01Icon,
   BankIcon,
   ChartIncreaseIcon,
+  GaugeIcon,
   Globe02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -89,6 +90,12 @@ const RATES = [
     value: CURRENT_RATES.cpi,
     source: "ONS",
     icon: ChartIncreaseIcon,
+  },
+  {
+    label: "Interest cap",
+    value: CURRENT_RATES.interestCap,
+    source: "GOV.UK (via SLC)",
+    icon: GaugeIcon,
   },
 ];
 
@@ -214,12 +221,12 @@ export function OurDataPage() {
               The rates we track
             </Heading>
             <p className="max-w-[68ch] text-muted-foreground">
-              These three market figures feed every interest and present-value
+              These four figures feed every interest and present-value
               calculation on the site. They are the live values in use right
               now.
             </p>
           </div>
-          <MetricReadout columns={3}>
+          <MetricReadout columns={4}>
             {RATES.map((rate) => (
               <MetricCell
                 key={rate.label}

--- a/src/components/plans/PlanDetailPage.tsx
+++ b/src/components/plans/PlanDetailPage.tsx
@@ -17,6 +17,7 @@ import {
 import { currencyFormatter } from "@/constants";
 import { formatGBP, formatPercent } from "@/lib/format";
 import { PROSE_LINK } from "@/lib/layout";
+import { CURRENT_RATES } from "@/lib/loans/plans";
 import type { PlanPageKey } from "@/lib/planContent";
 import { PLAN_PAGES } from "@/lib/planContent";
 import { surfaceCard } from "@/lib/surfaces";
@@ -161,12 +162,12 @@ export function PlanDetailPage({ planKey }: PlanDetailPageProps) {
             ))}
             {planKey === "PLAN_2" && (
               <p>
-                From September 2026 the government is capping Plan 2 interest at
-                6%. See our{" "}
+                Since 1 September 2026, an interest cap has held Plan 2 interest
+                at {formatPercent(CURRENT_RATES.interestCap)}. See our{" "}
                 <Link href="/guides/interest-rate-cap" className={PROSE_LINK}>
                   Plan 2 interest rate cap guide
                 </Link>{" "}
-                for what changes.
+                for what it means.
               </p>
             )}
             <p>

--- a/src/components/wizard/RpiStep.test.tsx
+++ b/src/components/wizard/RpiStep.test.tsx
@@ -1,6 +1,7 @@
 import { render, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RPI_OPTIONS } from "@/constants";
 import { trackRpiRateSelected } from "@/lib/analytics";
 import { RpiStep } from "./RpiStep";
 
@@ -41,10 +42,9 @@ describe("RpiStep", () => {
     expect(radios).toHaveLength(4);
 
     const labels = radios.map((r) => r.textContent);
-    expect(labels.some((t) => t.includes("0%"))).toBe(true);
-    expect(labels.some((t) => t.includes("2%"))).toBe(true);
-    expect(labels.some((t) => t.includes("3.2%"))).toBe(true);
-    expect(labels.some((t) => t.includes("5%"))).toBe(true);
+    for (const option of RPI_OPTIONS) {
+      expect(labels.some((t) => t.includes(option.label))).toBe(true);
+    }
   });
 
   it("clicking a preset calls updateField and trackRpiRateSelected", async () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,6 @@ import { CURRENT_RATES, LAST_UPDATED } from "@/lib/loans/plans";
 // Chart salary range
 export const MIN_SALARY = 25_000;
 export const MAX_SALARY = 150_000;
-export const DEFAULT_SALARY = 45_000;
 export const SALARY_STEP = 1_000;
 
 // Overpay analysis constants

--- a/src/context/PersonalisedResultsContext.test.tsx
+++ b/src/context/PersonalisedResultsContext.test.tsx
@@ -342,7 +342,10 @@ describe("usePersonalisedResults (cards)", () => {
 
   it("balance sparkline starts at initial balance and decreases", async () => {
     const { result } = renderHook(() => usePersonalisedResults(), {
-      wrapper: createWrapper(),
+      wrapper: createWrapper({
+        loans: [{ planType: "PLAN_2", balance: 20_000 }],
+        salary: 60_000,
+      }),
     });
 
     await waitFor(() => {

--- a/src/context/loanReducer.test.ts
+++ b/src/context/loanReducer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { CURRENT_RATES } from "@/lib/loans/plans";
+import { CURRENT_RATES, DEFAULT_SALARY } from "@/lib/loans/plans";
 import { PRESETS } from "@/lib/presets";
 import {
   loanReducer,
@@ -14,7 +14,7 @@ describe("loanReducer", () => {
       expect(initialState.loans).toEqual([
         { planType: "PLAN_2", balance: 45_000 },
       ]);
-      expect(initialState.salary).toBe(45_000);
+      expect(initialState.salary).toBe(DEFAULT_SALARY);
     });
 
     it("should have rpiRate equal to CURRENT_RATES.rpi", () => {

--- a/src/context/loanReducer.ts
+++ b/src/context/loanReducer.ts
@@ -1,5 +1,4 @@
-import { DEFAULT_SALARY } from "@/constants";
-import { CURRENT_RATES } from "@/lib/loans/plans";
+import { CURRENT_RATES, DEFAULT_SALARY } from "@/lib/loans/plans";
 import { DEFAULT_PRESET, type Preset } from "@/lib/presets";
 import type { LoanState } from "@/types/store";
 
@@ -12,8 +11,8 @@ export const initialState: LoanState = {
   salaryGrowthRate: 0.04, // 4% - typical career progression
   thresholdGrowthRate: 0.02, // 2% - below-inflation growth
   applyPlan2Freeze: true, // Budget 2025: Plan 2 frozen until 2030
-  rpiRate: CURRENT_RATES.rpi, // 3.2% - Sept 2025–Aug 2026
-  boeBaseRate: CURRENT_RATES.boeBaseRate, // 3.75% - Feb 2026 MPC
+  rpiRate: CURRENT_RATES.rpi,
+  boeBaseRate: CURRENT_RATES.boeBaseRate,
   lumpSumPayment: 10_000,
 
   showPresentValue: false,

--- a/src/lib/guides.ts
+++ b/src/lib/guides.ts
@@ -1,3 +1,6 @@
+import { formatPercent } from "@/lib/format";
+import { CURRENT_RATES } from "@/lib/loans/plans";
+
 export type GuideSlug =
   | "threshold-freeze"
   | "plan-2-vs-plan-5"
@@ -25,8 +28,7 @@ export const GUIDES: GuideEntry[] = [
   {
     slug: "interest-rate-cap",
     title: "Plan 2 Interest Rate Cap",
-    description:
-      "The government is capping Plan 2 interest at 6% from September 2026. What it means for your loan.",
+    description: `Plan 2 interest has been capped at ${formatPercent(CURRENT_RATES.interestCap)} since 1 September 2026. What it means for your loan.`,
     topic: "Interest",
     newUntil: "2026-07-08",
   },

--- a/src/lib/loans/engine.test.ts
+++ b/src/lib/loans/engine.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { simulate } from "./engine";
+import { NO_INTEREST_CAP } from "./interest";
 import { PLAN_CONFIGS, CURRENT_RATES } from "./plans";
-import type { SimulationConfig } from "./types";
+import type { SimulationConfig, SimulationTimeSeries } from "./types";
 
 describe("simulate engine", () => {
   const defaultConfig: SimulationConfig = {
@@ -867,6 +868,38 @@ describe("simulate engine", () => {
         highSalary.snapshots[0]?.loans[0]?.interestApplied ?? 0;
 
       expect(highSalaryInterest).toBeGreaterThan(lowSalaryInterest);
+    });
+
+    it("holds a Plan 2 borrower above the upper interest threshold to the cap", () => {
+      const totalInterest = (result: SimulationTimeSeries) =>
+        result.snapshots.reduce(
+          (sum, snapshot) =>
+            sum +
+            snapshot.loans.reduce((s, loan) => s + loan.interestApplied, 0),
+          0,
+        );
+
+      const balance = 50000;
+      const config: SimulationConfig = {
+        ...defaultConfig,
+        loans: [{ planType: "PLAN_2", balance }],
+        annualSalary: PLAN_CONFIGS.PLAN_2.interestUpperThreshold + 10000,
+        // At this RPI, RPI + 3 is above the cap whatever the cap is.
+        rpiRate: CURRENT_RATES.interestCap,
+      };
+
+      const capped = simulate(config);
+      const uncapped = simulate({ ...config, interestCap: NO_INTEREST_CAP });
+
+      expect(capped.snapshots[0]?.loans[0]?.interestApplied).toBeCloseTo(
+        (balance * CURRENT_RATES.interestCap) / 100 / 12,
+        6,
+      );
+      expect(uncapped.snapshots[0]?.loans[0]?.interestApplied).toBeCloseTo(
+        (balance * (CURRENT_RATES.interestCap + 3)) / 100 / 12,
+        6,
+      );
+      expect(totalInterest(capped)).toBeLessThan(totalInterest(uncapped));
     });
   });
 

--- a/src/lib/loans/engine.ts
+++ b/src/lib/loans/engine.ts
@@ -35,11 +35,13 @@ export function simulate(config: SimulationConfig): SimulationTimeSeries {
     plan2ThresholdSchedule,
     rpiRate,
     boeBaseRate,
+    interestCap,
     careerBreak,
   } = config;
 
   const rpi = rpiRate ?? CURRENT_RATES.rpi;
   const boe = boeBaseRate ?? CURRENT_RATES.boeBaseRate;
+  const cap = interestCap ?? CURRENT_RATES.interestCap;
 
   // Filter to active loans (positive balance)
   const activeLoans = loans.filter((loan) => loan.balance > 0);
@@ -198,6 +200,7 @@ export function simulate(config: SimulationConfig): SimulationTimeSeries {
         rpi,
         boe,
         interestThresholdOverrides,
+        cap,
       );
       const monthlyInterestRate = annualInterest / 100 / 12;
       const interestApplied = state.balance * monthlyInterestRate;

--- a/src/lib/loans/interest.test.ts
+++ b/src/lib/loans/interest.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { getAnnualInterestRate } from "./interest";
-import { PLAN_CONFIGS } from "./plans";
+import {
+  getAnnualInterestRate,
+  getMaxAnnualInterestRate,
+  NO_INTEREST_CAP,
+} from "./interest";
+import { CURRENT_RATES, PLAN_CONFIGS } from "./plans";
 
 describe("getAnnualInterestRate", () => {
   describe("PLAN_1 - min(RPI, BoE+1%)", () => {
@@ -125,12 +129,28 @@ describe("getAnnualInterestRate", () => {
     });
 
     it("works with different RPI values", () => {
+      // An RPI this high is above the interest cap, so the cap is lifted to
+      // leave only the sliding scale under test.
       const highRpi = 8.0;
       expect(
-        getAnnualInterestRate("PLAN_2", interestLowerThreshold, highRpi, boe),
+        getAnnualInterestRate(
+          "PLAN_2",
+          interestLowerThreshold,
+          highRpi,
+          boe,
+          undefined,
+          NO_INTEREST_CAP,
+        ),
       ).toBe(highRpi);
       expect(
-        getAnnualInterestRate("PLAN_2", interestUpperThreshold, highRpi, boe),
+        getAnnualInterestRate(
+          "PLAN_2",
+          interestUpperThreshold,
+          highRpi,
+          boe,
+          undefined,
+          NO_INTEREST_CAP,
+        ),
       ).toBe(highRpi + 3);
     });
   });
@@ -160,22 +180,40 @@ describe("getAnnualInterestRate", () => {
   });
 
   describe("POSTGRADUATE - RPI+3%", () => {
+    // RPI + 3 is above the interest cap at this RPI, so these cases lift the
+    // cap to leave only the RPI + 3 rule under test.
     it("returns RPI + 3%", () => {
       const rpi = 3.5;
-      expect(getAnnualInterestRate("POSTGRADUATE", 50000, rpi, 4.0)).toBe(
-        rpi + 3,
-      );
+      expect(
+        getAnnualInterestRate(
+          "POSTGRADUATE",
+          50000,
+          rpi,
+          4.0,
+          undefined,
+          NO_INTEREST_CAP,
+        ),
+      ).toBe(rpi + 3);
     });
 
     it("is independent of salary", () => {
       const rpi = 3.5;
       const boe = 4.0;
-      const lowSalary = getAnnualInterestRate("POSTGRADUATE", 20000, rpi, boe);
+      const lowSalary = getAnnualInterestRate(
+        "POSTGRADUATE",
+        20000,
+        rpi,
+        boe,
+        undefined,
+        NO_INTEREST_CAP,
+      );
       const highSalary = getAnnualInterestRate(
         "POSTGRADUATE",
         150000,
         rpi,
         boe,
+        undefined,
+        NO_INTEREST_CAP,
       );
       expect(lowSalary).toBe(highSalary);
       expect(lowSalary).toBe(rpi + 3);
@@ -183,8 +221,22 @@ describe("getAnnualInterestRate", () => {
 
     it("is independent of BoE rate", () => {
       const rpi = 3.5;
-      const lowBoe = getAnnualInterestRate("POSTGRADUATE", 50000, rpi, 1.0);
-      const highBoe = getAnnualInterestRate("POSTGRADUATE", 50000, rpi, 10.0);
+      const lowBoe = getAnnualInterestRate(
+        "POSTGRADUATE",
+        50000,
+        rpi,
+        1.0,
+        undefined,
+        NO_INTEREST_CAP,
+      );
+      const highBoe = getAnnualInterestRate(
+        "POSTGRADUATE",
+        50000,
+        rpi,
+        10.0,
+        undefined,
+        NO_INTEREST_CAP,
+      );
       expect(lowBoe).toBe(highBoe);
       expect(lowBoe).toBe(rpi + 3);
     });
@@ -312,6 +364,107 @@ describe("getAnnualInterestRate", () => {
       expect(
         getAnnualInterestRate("PLAN_2", salary, rpi, boe, overrides),
       ).toBeCloseTo(rpi + 0.75, 5);
+    });
+  });
+
+  describe("interest cap", () => {
+    const boe = CURRENT_RATES.boeBaseRate;
+    const cap = CURRENT_RATES.interestCap;
+    const { interestLowerThreshold, interestUpperThreshold } =
+      PLAN_CONFIGS.PLAN_2;
+
+    it("holds PLAN_2 above the upper interest threshold to the cap", () => {
+      // At this RPI, RPI + 3 is above the cap whatever the cap is.
+      const rpi = cap;
+      expect(
+        getAnnualInterestRate(
+          "PLAN_2",
+          interestUpperThreshold + 10000,
+          rpi,
+          boe,
+        ),
+      ).toBe(cap);
+    });
+
+    it("caps the sliding scale at the salary where it crosses the cap", () => {
+      const rpi = cap - 1;
+      const crossing =
+        interestLowerThreshold +
+        ((cap - rpi) / 3) * (interestUpperThreshold - interestLowerThreshold);
+      expect(getAnnualInterestRate("PLAN_2", crossing + 100, rpi, boe)).toBe(
+        cap,
+      );
+      expect(
+        getAnnualInterestRate("PLAN_2", crossing - 100, rpi, boe),
+      ).toBeLessThan(cap);
+    });
+
+    it("holds POSTGRADUATE to the cap at the current figures", () => {
+      expect(
+        getAnnualInterestRate("POSTGRADUATE", 50000, CURRENT_RATES.rpi, boe),
+      ).toBe(Math.min(CURRENT_RATES.rpi + 3, cap));
+    });
+
+    it("returns the uncapped rate with NO_INTEREST_CAP", () => {
+      const rpi = cap;
+      expect(
+        getAnnualInterestRate(
+          "PLAN_2",
+          interestUpperThreshold + 10000,
+          rpi,
+          boe,
+          undefined,
+          NO_INTEREST_CAP,
+        ),
+      ).toBe(rpi + 3);
+      expect(
+        getAnnualInterestRate(
+          "POSTGRADUATE",
+          50000,
+          rpi,
+          boe,
+          undefined,
+          NO_INTEREST_CAP,
+        ),
+      ).toBe(rpi + 3);
+    });
+
+    it("leaves PLAN_1, PLAN_4 and PLAN_5 unchanged at the current figures", () => {
+      for (const plan of ["PLAN_1", "PLAN_4", "PLAN_5"] as const) {
+        expect(getAnnualInterestRate(plan, 60000, CURRENT_RATES.rpi, boe)).toBe(
+          getAnnualInterestRate(
+            plan,
+            60000,
+            CURRENT_RATES.rpi,
+            boe,
+            undefined,
+            NO_INTEREST_CAP,
+          ),
+        );
+      }
+    });
+  });
+
+  describe("getMaxAnnualInterestRate", () => {
+    it("returns the capped RPI + 3% ceiling for PLAN_2 at the current figures", () => {
+      expect(getMaxAnnualInterestRate("PLAN_2")).toBe(
+        Math.min(CURRENT_RATES.rpi + 3, CURRENT_RATES.interestCap),
+      );
+    });
+
+    it("returns the uncapped RPI + 3% ceiling for PLAN_2 with NO_INTEREST_CAP", () => {
+      expect(
+        getMaxAnnualInterestRate(
+          "PLAN_2",
+          CURRENT_RATES.rpi,
+          CURRENT_RATES.boeBaseRate,
+          NO_INTEREST_CAP,
+        ),
+      ).toBe(CURRENT_RATES.rpi + 3);
+    });
+
+    it("returns RPI for PLAN_5", () => {
+      expect(getMaxAnnualInterestRate("PLAN_5")).toBe(CURRENT_RATES.rpi);
     });
   });
 

--- a/src/lib/loans/interest.ts
+++ b/src/lib/loans/interest.ts
@@ -1,5 +1,11 @@
-import { PLAN_CONFIGS } from "./plans";
+import { CURRENT_RATES, PLAN_CONFIGS } from "./plans";
 import type { PlanType } from "./types";
+
+/**
+ * Interest cap value that leaves the computed rate untouched, for a comparison
+ * of the capped rate against the rate a borrower would pay without the cap.
+ */
+export const NO_INTEREST_CAP = Number.POSITIVE_INFINITY;
 
 /**
  * Optional overrides for Plan 2 interest threshold bands,
@@ -20,14 +26,38 @@ export interface InterestThresholdOverrides {
  * - Plan 5: RPI only
  * - Postgraduate: RPI + 3%
  *
+ * Every plan's rate is then held to the interest cap, the GOV.UK ceiling on the
+ * headline rate. It binds on the upper part of the Plan 2 sliding scale and on
+ * Postgraduate; Plan 1, Plan 4 and Plan 5 sit below it at the current figures.
+ *
  * @param planType - The loan plan type
  * @param annualSalary - Annual salary in GBP
  * @param rpi - Current RPI rate as percentage (e.g., 3.2 for 3.2%)
  * @param boeBaseRate - Bank of England base rate as percentage
  * @param interestOverrides - Optional overrides for Plan 2 interest thresholds
+ * @param interestCap - Ceiling on the rate as a percentage; pass
+ *   {@link NO_INTEREST_CAP} for the uncapped rate
  * @returns Annual interest rate as a percentage
  */
 export function getAnnualInterestRate(
+  planType: PlanType,
+  annualSalary: number,
+  rpi: number,
+  boeBaseRate: number,
+  interestOverrides?: InterestThresholdOverrides,
+  interestCap: number = CURRENT_RATES.interestCap,
+): number {
+  const uncappedRate = getUncappedRate(
+    planType,
+    annualSalary,
+    rpi,
+    boeBaseRate,
+    interestOverrides,
+  );
+  return Math.min(uncappedRate, interestCap);
+}
+
+function getUncappedRate(
   planType: PlanType,
   annualSalary: number,
   rpi: number,
@@ -79,4 +109,34 @@ function getSlidingScaleRate(
 
   const ratio = (salary - lower) / (upper - lower);
   return rpi + ratio * 3;
+}
+
+/**
+ * Calculates a plan's highest possible annual interest rate at given rates,
+ * for display as the printed ceiling. Reads the capped model rather than
+ * assuming RPI + 3%, so the figure always matches what borrowers are charged.
+ *
+ * @param planType - The loan plan type
+ * @param rpi - Current RPI rate as percentage
+ * @param boeBaseRate - Bank of England base rate as percentage
+ * @param interestCap - Ceiling on the rate as a percentage; pass
+ *   {@link NO_INTEREST_CAP} for the uncapped ceiling
+ * @returns The plan's highest annual interest rate as a percentage
+ */
+export function getMaxAnnualInterestRate(
+  planType: PlanType,
+  rpi: number = CURRENT_RATES.rpi,
+  boeBaseRate: number = CURRENT_RATES.boeBaseRate,
+  interestCap: number = CURRENT_RATES.interestCap,
+): number {
+  const maxSalary =
+    planType === "PLAN_2" ? PLAN_CONFIGS.PLAN_2.interestUpperThreshold : 0;
+  return getAnnualInterestRate(
+    planType,
+    maxSalary,
+    rpi,
+    boeBaseRate,
+    undefined,
+    interestCap,
+  );
 }

--- a/src/lib/loans/overpaySimulate.ts
+++ b/src/lib/loans/overpaySimulate.ts
@@ -54,11 +54,13 @@ export function simulateOverpayScenarios(
     plan2ThresholdSchedule,
     rpiRate,
     boeBaseRate,
+    interestCap,
     lumpSumPayment = 0,
   } = input;
 
   const rpi = rpiRate ?? CURRENT_RATES.rpi;
   const boe = boeBaseRate ?? CURRENT_RATES.boeBaseRate;
+  const cap = interestCap ?? CURRENT_RATES.interestCap;
 
   // Check for empty scenarios
   const validLoans = loans.filter((l) => l.balance > 0);
@@ -90,6 +92,7 @@ export function simulateOverpayScenarios(
     plan2ThresholdSchedule,
     rpiRate: rpi,
     boeBaseRate: boe,
+    interestCap: cap,
   });
 
   // Simulate with overpayment (lump sum applied + monthly overpayment)
@@ -106,6 +109,7 @@ export function simulateOverpayScenarios(
           plan2ThresholdSchedule,
           rpiRate: rpi,
           boeBaseRate: boe,
+          interestCap: cap,
         });
 
   // Convert simulations to scenario results

--- a/src/lib/loans/overpayTypes.ts
+++ b/src/lib/loans/overpayTypes.ts
@@ -16,6 +16,8 @@ export interface OverpayInput {
   plan2ThresholdSchedule?: number[];
   rpiRate?: number;
   boeBaseRate?: number;
+  /** Ceiling on every plan's annual interest rate, as a percentage. */
+  interestCap?: number;
   lumpSumPayment?: number;
 }
 

--- a/src/lib/loans/overseas.ts
+++ b/src/lib/loans/overseas.ts
@@ -1,4 +1,4 @@
-import { getAnnualInterestRate } from "./interest";
+import { getAnnualInterestRate, NO_INTEREST_CAP } from "./interest";
 import {
   OVERSEAS_BANDS_BY_ID,
   OVERSEAS_TERRITORIES,
@@ -109,13 +109,21 @@ export function estimateOverseasRepayment({
   const ukThreshold = OVERSEAS_UK_THRESHOLDS[plan];
   const incomeAboveThreshold = Math.max(0, annualIncomeGBP - threshold);
 
-  // An RPI of 0 makes the sliding scale return only the points above RPI.
+  // An RPI of 0 makes the sliding scale return only the points above RPI, and
+  // NO_INTEREST_CAP keeps the interest cap off that difference.
   const plan2InterestAboveRpi =
     plan === "PLAN_2"
-      ? getAnnualInterestRate("PLAN_2", annualIncomeGBP, 0, 0, {
-          interestLowerThreshold: threshold,
-          interestUpperThreshold: band.plan2UpperThreshold,
-        })
+      ? getAnnualInterestRate(
+          "PLAN_2",
+          annualIncomeGBP,
+          0,
+          0,
+          {
+            interestLowerThreshold: threshold,
+            interestUpperThreshold: band.plan2UpperThreshold,
+          },
+          NO_INTEREST_CAP,
+        )
       : undefined;
 
   return {

--- a/src/lib/loans/plans.test.ts
+++ b/src/lib/loans/plans.test.ts
@@ -82,6 +82,11 @@ describe("CURRENT_RATES", () => {
     expect(CURRENT_RATES.boeBaseRate).toBeGreaterThanOrEqual(0);
     expect(CURRENT_RATES.boeBaseRate).toBeLessThan(20);
   });
+
+  it("has an interest cap within sane range", () => {
+    expect(CURRENT_RATES.interestCap).toBeGreaterThan(0);
+    expect(CURRENT_RATES.interestCap).toBeLessThan(20);
+  });
 });
 
 describe("PLAN_DISPLAY_INFO", () => {

--- a/src/lib/loans/plans.ts
+++ b/src/lib/loans/plans.ts
@@ -7,7 +7,7 @@
  * ISO date of the last time figures were actually changed by the automation.
  * Only updates when GOV.UK/BoE figures differ from what we have.
  */
-export const LAST_UPDATED = "2026-08-19T07:43:53.450Z";
+export const LAST_UPDATED = "2026-09-05T12:43:11.244Z";
 
 /**
  * Plan configurations for all UK student loan types.
@@ -46,12 +46,21 @@ export const PLAN_CONFIGS = {
 /**
  * Current interest rates for loan calculations.
  * Update these when new rates are announced.
+ * interestCap is the GOV.UK ceiling on every plan's headline interest rate.
  */
 export const CURRENT_RATES = {
-  rpi: 3.2,
+  rpi: 4.1,
   boeBaseRate: 3.75,
   cpi: 2.9,
+  interestCap: 6,
 } as const;
+
+/**
+ * The income at which total repaid peaks for the default preset, under the
+ * home page's default assumptions. The automation derives it from the figures
+ * above, so the home page marker starts on the peak of the curve it is drawn on.
+ */
+export const DEFAULT_SALARY = 45_000;
 
 /**
  * User-friendly display information for each undergraduate plan type.

--- a/src/lib/loans/types.ts
+++ b/src/lib/loans/types.ts
@@ -78,6 +78,9 @@ export interface SimulationConfig {
   plan2ThresholdSchedule?: number[];
   rpiRate?: number;
   boeBaseRate?: number;
+  /** Ceiling on every plan's annual interest rate, as a percentage
+   *  (default CURRENT_RATES.interestCap; NO_INTEREST_CAP removes it). */
+  interestCap?: number;
   /** A period of reduced/zero income (e.g. a career break or parental leave).
    *  During the window, repayments follow the lower income and (on Plan 2) so
    *  does the interest rate; interest still accrues. Omit for no break. */

--- a/src/lib/metadata.test.ts
+++ b/src/lib/metadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { DEFAULT_SALARY } from "@/constants";
+import { DEFAULT_SALARY } from "@/lib/loans/plans";
 import { DEFAULT_PRESET } from "@/lib/presets";
 import { parseMetadataParams } from "./metadata";
 

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,5 +1,5 @@
-import { currencyFormatter, DEFAULT_SALARY } from "@/constants";
-import { PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
+import { currencyFormatter } from "@/constants";
+import { DEFAULT_SALARY, PLAN_DISPLAY_INFO } from "@/lib/loans/plans";
 import type { Loan, PlanType } from "@/lib/loans/types";
 import { DEFAULT_PRESET } from "@/lib/presets";
 import { decodeParamsToState } from "@/lib/shareUrl";

--- a/src/lib/planContent.ts
+++ b/src/lib/planContent.ts
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { formatGBP, formatPercent } from "@/lib/format";
+import { getMaxAnnualInterestRate } from "@/lib/loans/interest";
 import {
   CURRENT_RATES,
   PLAN_CONFIGS,
@@ -119,13 +120,13 @@ export function planFaqSchema(key: PlanPageKey) {
   };
 }
 
-const { rpi, boeBaseRate } = CURRENT_RATES;
+const { rpi, boeBaseRate, interestCap } = CURRENT_RATES;
 
 // Current effective rates derived from the live figures in plans.ts.
 const cappedRate = Math.min(rpi, boeBaseRate + 1); // Plan 1 & Plan 4
 const plan2LowRate = rpi;
-const plan2HighRate = rpi + 3;
-const postgradRate = rpi + 3;
+const plan2HighRate = getMaxAnnualInterestRate("PLAN_2");
+const postgradRate = getMaxAnnualInterestRate("POSTGRADUATE");
 
 const plan2InterestLower = PLAN_CONFIGS.PLAN_2.interestLowerThreshold;
 const plan2InterestUpper = PLAN_CONFIGS.PLAN_2.interestUpperThreshold;
@@ -136,6 +137,7 @@ const cappedPct = formatPercent(cappedRate);
 const plan2LowPct = formatPercent(plan2LowRate);
 const plan2HighPct = formatPercent(plan2HighRate);
 const postgradPct = formatPercent(postgradRate);
+const capPct = formatPercent(interestCap);
 
 const p1 = PLAN_DISPLAY_INFO.PLAN_1;
 const p2 = PLAN_DISPLAY_INFO.PLAN_2;
@@ -247,7 +249,7 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
       "plan 2 repayment threshold",
       "plan 2 write off",
     ],
-    heroIntro: `Plan 2 covers English and Welsh students who started university between September 2012 and July 2023, the £9,000-plus tuition fee generation. You repay ${p1Rate} of income above ${p2YearGBP} a year, and interest runs on a sliding scale up to RPI + 3%, which is exactly why Plan 2 middle earners so often repay more than anyone else.`,
+    heroIntro: `Plan 2 covers English and Welsh students who started university between September 2012 and July 2023, the £9,000-plus tuition fee generation. You repay ${p1Rate} of income above ${p2YearGBP} a year, and interest runs on a sliding scale up to RPI + 3%, though a cap currently holds it at ${plan2HighPct}, which is exactly why Plan 2 middle earners so often repay more than anyone else.`,
     whatItIs: [
       `A Plan 2 student loan is repaid at ${p1Rate} of your income above ${p2YearGBP} a year (${p2MonthlyGBP} a month). Unlike Plan 1, interest follows a sliding scale: it climbs from RPI up to RPI + 3% as your salary rises.`,
       `Any balance still outstanding ${p2WriteOff} years after you were first due to repay is written off. But because of the high interest, most Plan 2 borrowers never reach a zero balance through minimum repayments alone.`,
@@ -257,15 +259,15 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
       "English students who started from September 2023 onwards are on Plan 5 instead. Welsh students who started after August 2023 stay on Plan 2, because Plan 5 is England-only.",
     ],
     interestParagraphs: [
-      `Plan 2 interest is charged on a sliding scale. While you are studying, and on income up to ${p2YearGBP}, you pay RPI (${rpiPct}). Between ${formatGBP(plan2InterestLower)} and ${formatGBP(plan2InterestUpper)} the rate rises linearly, reaching RPI + 3% (${plan2HighPct}) once you earn ${formatGBP(plan2InterestUpper)} or more.`,
-      `That RPI + 3% ceiling is the single biggest reason Plan 2 is so expensive: the balance can grow faster than a typical borrower repays it, so it keeps compounding for years.`,
+      `Plan 2 interest is charged on a sliding scale. While you are studying, and on income up to ${p2YearGBP}, you pay RPI (${rpiPct}). Between ${formatGBP(plan2InterestLower)} and ${formatGBP(plan2InterestUpper)} the rate rises linearly, reaching RPI + 3%, capped at ${capPct}, once you earn ${formatGBP(plan2InterestUpper)} or more.`,
+      `That ceiling is still the single biggest reason Plan 2 is so expensive: the balance can grow faster than a typical borrower repays it, so it keeps compounding for years.`,
     ],
-    compareParagraph: `Plan 2 has a higher threshold than Plan 1 (${p1YearGBP}) or Plan 5 (${p5YearGBP}), so you repay less each month at the same salary. But its RPI + 3% interest ceiling makes it the most expensive plan for middle earners, more than offsetting the shorter ${p2WriteOff}-year term versus Plan 5's ${p5WriteOff} years.`,
-    middleEarner: `Plan 2 is the clearest example of the middle-earner trap. Low earners repay little and reach the ${p2WriteOff}-year write-off with plenty written off; high earners pay off the balance fast before much interest builds. It is the middle (graduates earning enough to make real repayments, but not enough to outrun RPI + 3% interest) who repay the most in total, often far more than they originally borrowed.`,
+    compareParagraph: `Plan 2 has a higher threshold than Plan 1 (${p1YearGBP}) or Plan 5 (${p5YearGBP}), so you repay less each month at the same salary. But its ${plan2HighPct} interest ceiling makes it the most expensive plan for middle earners, more than offsetting the shorter ${p2WriteOff}-year term versus Plan 5's ${p5WriteOff} years.`,
+    middleEarner: `Plan 2 is the clearest example of the middle-earner trap. Low earners repay little and reach the ${p2WriteOff}-year write-off with plenty written off; high earners pay off the balance fast before much interest builds. It is the middle (graduates earning enough to make real repayments, but not enough to outrun the capped interest ceiling) who repay the most in total, often far more than they originally borrowed.`,
     faqs: [
       {
         question: "What is a Plan 2 student loan?",
-        answer: `Plan 2 is a UK undergraduate loan for English and Welsh students who started between September 2012 and July 2023. You repay ${p1Rate} of income above ${p2YearGBP} a year, interest runs from RPI (${rpiPct}) up to RPI + 3% (${plan2HighPct}) depending on income, and any balance is written off after ${p2WriteOff} years.`,
+        answer: `Plan 2 is a UK undergraduate loan for English and Welsh students who started between September 2012 and July 2023. You repay ${p1Rate} of income above ${p2YearGBP} a year, interest runs on a sliding scale from RPI (${rpiPct}) up to a capped ${plan2HighPct} depending on income, and any balance is written off after ${p2WriteOff} years.`,
       },
       {
         question: "What is the Plan 2 repayment threshold?",
@@ -273,11 +275,11 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
       },
       {
         question: "What is the Plan 2 interest rate?",
-        answer: `Plan 2 interest follows a sliding scale, from RPI (${rpiPct}) at or below ${formatGBP(plan2InterestLower)} up to RPI + 3% (${plan2HighPct}) at ${formatGBP(plan2InterestUpper)} or more, interpolated in between. A separate cap can lower the headline rate when market rates are low.`,
+        answer: `Plan 2 interest follows a sliding scale, from RPI (${rpiPct}) at or below ${formatGBP(plan2InterestLower)} up to RPI + 3% at ${formatGBP(plan2InterestUpper)} or more, interpolated in between. A cap currently holds the top of that scale to ${capPct}, so anyone at or above ${formatGBP(plan2InterestUpper)} pays ${plan2HighPct} rather than the full RPI + 3%.`,
       },
       {
         question: "Why do Plan 2 middle earners repay the most?",
-        answer: `Because Plan 2 interest reaches RPI + 3%, middle earners repay steadily but not fast enough to stop the balance compounding, and they earn too much for the ${p2WriteOff}-year write-off to help. High earners pay off the loan quickly; low earners have it written off. The middle pays the most in total.`,
+        answer: `Because Plan 2 interest reaches its capped ceiling of ${plan2HighPct}, middle earners repay steadily but not fast enough to stop the balance compounding, and they earn too much for the ${p2WriteOff}-year write-off to help. High earners pay off the loan quickly; low earners have it written off. The middle pays the most in total.`,
       },
     ],
   },
@@ -376,7 +378,7 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
       `Plan 5 interest is charged at RPI only, currently ${rpiPct}, with no sliding scale. That makes it the simplest interest of any plan to understand and forecast.`,
       `Lower, simpler interest sounds cheaper, but the ${p5WriteOff}-year write-off means most borrowers keep repaying for far longer, so many end up paying more in total than they would have on the shorter Plan 2.`,
     ],
-    compareParagraph: `Plan 5's ${p5YearGBP} threshold is lower than Plan 2 (${p2YearGBP}), so you start repaying sooner and pay more each month at the same salary. Its RPI-only interest is gentler than Plan 2's RPI + 3%, but the ${p5WriteOff}-year term (versus ${p2WriteOff} for Plan 2) is longer than any other plan.`,
+    compareParagraph: `Plan 5's ${p5YearGBP} threshold is lower than Plan 2 (${p2YearGBP}), so you start repaying sooner and pay more each month at the same salary. Its RPI-only interest is gentler than Plan 2's capped ${plan2HighPct} ceiling, but the ${p5WriteOff}-year term (versus ${p2WriteOff} for Plan 2) is longer than any other plan.`,
     middleEarner: `Plan 5's ${p5WriteOff}-year term turns the middle-earner trap into a marathon. Lower earners can pay for four decades and still have a balance written off; high earners pay it off early. Middle earners repay steadily for most of their working life, often paying back far more than they borrowed before the write-off ever arrives.`,
     faqs: [
       {
@@ -389,7 +391,7 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
       },
       {
         question: "What is the Plan 5 student loan interest rate?",
-        answer: `Plan 5 interest is charged at RPI only, currently ${rpiPct}, with no sliding scale. That is simpler and lower than Plan 2's RPI + 3% ceiling, but the ${p5WriteOff}-year write-off can make Plan 5 more expensive overall.`,
+        answer: `Plan 5 interest is charged at RPI only, currently ${rpiPct}, with no sliding scale. That is simpler and lower than Plan 2's capped ${plan2HighPct} ceiling, but the ${p5WriteOff}-year write-off can make Plan 5 more expensive overall.`,
       },
       {
         question: "When is a Plan 5 loan written off?",
@@ -412,7 +414,7 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
     interestCurrent: postgradPct,
     metaTitle:
       "What Is a Postgraduate Loan? Threshold, Interest & Write-Off (2026)",
-    metaDescription: `Postgraduate Master's & Doctoral loans: ${pgYearGBP} threshold, ${pgRatePct} rate, RPI + 3% interest (${postgradPct} now) and a ${pgWriteOff}-year write-off. How it stacks alongside your undergraduate loan.`,
+    metaDescription: `Postgraduate Master's & Doctoral loans: ${pgYearGBP} threshold, ${pgRatePct} rate, RPI + 3% interest capped at ${postgradPct}, and a ${pgWriteOff}-year write-off. How it stacks alongside your undergraduate loan.`,
     keywords: [
       "what is a postgraduate loan",
       "postgraduate student loan",
@@ -421,7 +423,7 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
       "masters loan repayment",
       "postgraduate loan write off",
     ],
-    heroIntro: `The Postgraduate Loan funds Master's and Doctoral study across the UK. It works differently from the undergraduate plans: you repay ${pgRatePct} (not 9%) of income above ${pgYearGBP} a year, interest is a flat RPI + 3%, and the balance is written off after ${pgWriteOff} years.`,
+    heroIntro: `The Postgraduate Loan funds Master's and Doctoral study across the UK. It works differently from the undergraduate plans: you repay ${pgRatePct} (not 9%) of income above ${pgYearGBP} a year, interest is a flat RPI + 3%, capped at ${postgradPct}, and the balance is written off after ${pgWriteOff} years.`,
     whatItIs: [
       `A Postgraduate Loan is repaid at ${pgRatePct} of income above ${pgYearGBP} a year (${pgMonthlyGBP} a month). The threshold is the lowest of any plan, and interest is a flat RPI + 3% regardless of your salary.`,
       `A Postgraduate Loan is repaid alongside any undergraduate loan, not instead of it. If you hold both, the deductions stack, so a graduate on Plan 2 plus a Postgraduate Loan can face two repayments at once.`,
@@ -431,15 +433,15 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
       "It sits on top of any undergraduate plan you already have. Your undergraduate loan keeps its own threshold, rate and write-off, and the Postgraduate Loan is calculated separately.",
     ],
     interestParagraphs: [
-      `Postgraduate Loan interest is a flat RPI + 3%, currently ${postgradPct}, for everyone, whatever you earn. There is no sliding scale like Plan 2 and no cap like Plan 1 or Plan 4.`,
+      `Postgraduate Loan interest is a flat RPI + 3%, capped at ${postgradPct}, for everyone, whatever you earn. There is no sliding scale like Plan 2, and unlike Plan 1 or Plan 4 it isn't linked to the Bank of England base rate, only to the interest cap.`,
       `That makes it one of the higher interest rates in the system, so the balance grows quickly. Combined with the ${pgWriteOff}-year term, many postgraduate borrowers repay well beyond what they originally borrowed.`,
     ],
-    compareParagraph: `The Postgraduate Loan has the lowest threshold (${pgYearGBP}) but the lowest repayment rate (${pgRatePct} versus 9%). Its flat RPI + 3% interest matches Plan 2's ceiling, and because it stacks on top of an undergraduate loan, the combined deductions can be heavier than any single plan.`,
-    middleEarner: `Postgraduate borrowers feel the middle-earner squeeze twice over: the ${pgRatePct} postgraduate deduction stacks on top of a 9% undergraduate deduction, while RPI + 3% interest keeps both balances growing. Middle earners with two loans running at once can lose a meaningful slice of every pay rise. Model the combined effect to see it clearly.`,
+    compareParagraph: `The Postgraduate Loan has the lowest threshold (${pgYearGBP}) but the lowest repayment rate (${pgRatePct} versus 9%). Its flat interest matches Plan 2's capped ${plan2HighPct} ceiling, and because it stacks on top of an undergraduate loan, the combined deductions can be heavier than any single plan.`,
+    middleEarner: `Postgraduate borrowers feel the middle-earner squeeze twice over: the ${pgRatePct} postgraduate deduction stacks on top of a 9% undergraduate deduction, while the postgraduate loan's capped interest keeps both balances growing. Middle earners with two loans running at once can lose a meaningful slice of every pay rise. Model the combined effect to see it clearly.`,
     faqs: [
       {
         question: "What is a Postgraduate Loan?",
-        answer: `A Postgraduate Loan funds Master's and Doctoral study in the UK. You repay ${pgRatePct} of income above ${pgYearGBP} a year, interest is a flat RPI + 3% (currently ${postgradPct}), and the balance is written off after ${pgWriteOff} years. It is repaid alongside any undergraduate loan.`,
+        answer: `A Postgraduate Loan funds Master's and Doctoral study in the UK. You repay ${pgRatePct} of income above ${pgYearGBP} a year, interest is a flat RPI + 3%, capped at ${postgradPct}, and the balance is written off after ${pgWriteOff} years. It is repaid alongside any undergraduate loan.`,
       },
       {
         question: "What is the Postgraduate Loan threshold?",
@@ -447,7 +449,7 @@ export const PLAN_PAGES: Record<PlanPageKey, PlanPageContent> = {
       },
       {
         question: "What is the Postgraduate Loan interest rate?",
-        answer: `Postgraduate Loan interest is a flat RPI + 3% for everyone, currently ${postgradPct}. Unlike Plan 2 there is no sliding scale, and unlike Plan 1 and Plan 4 there is no low-rate cap.`,
+        answer: `Postgraduate Loan interest is a flat RPI + 3%, capped at ${postgradPct}, for everyone. Unlike Plan 2 there is no sliding scale, and unlike Plan 1 and Plan 4 it isn't linked to the Bank of England base rate, only the interest cap.`,
       },
       {
         question:

--- a/src/test/environment.test.ts
+++ b/src/test/environment.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+describe("test environment web storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it("round-trips a value through localStorage", () => {
+    localStorage.setItem("key", "value");
+
+    expect(localStorage.getItem("key")).toBe("value");
+  });
+
+  it("empties localStorage on clear", () => {
+    localStorage.setItem("key", "value");
+
+    localStorage.clear();
+
+    expect(localStorage.getItem("key")).toBeNull();
+  });
+
+  it("round-trips a value through sessionStorage", () => {
+    sessionStorage.setItem("key", "value");
+
+    expect(sessionStorage.getItem("key")).toBe("value");
+  });
+
+  it("empties sessionStorage on clear", () => {
+    sessionStorage.setItem("key", "value");
+
+    sessionStorage.clear();
+
+    expect(sessionStorage.getItem("key")).toBeNull();
+  });
+});

--- a/src/test/environment.ts
+++ b/src/test/environment.ts
@@ -1,0 +1,21 @@
+import { builtinEnvironments, type Environment } from "vitest/runtime";
+
+const jsdom = builtinEnvironments.jsdom;
+
+/**
+ * The jsdom environment, without the empty web-storage globals of Node 26.
+ * Vitest skips a jsdom key that the global scope already holds, so those
+ * globals hide `localStorage` and `sessionStorage`. Delete them first.
+ */
+const jsdomWebStorage: Environment = {
+  ...jsdom,
+  name: "jsdom-web-storage",
+  setup(global, options) {
+    Reflect.deleteProperty(globalThis, "localStorage");
+    Reflect.deleteProperty(globalThis, "sessionStorage");
+    return jsdom.setup(global, options);
+  },
+};
+
+// Vitest loads a custom environment by its default export.
+export default jsdomWebStorage;

--- a/src/utils/loanCalculations.test.ts
+++ b/src/utils/loanCalculations.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import type { Loan } from "@/lib/loans/types";
 import { MIN_SALARY, MAX_SALARY, SALARY_STEP } from "../constants";
 import {
+  findPeakSalary,
   generateSalaryDataSeries,
   generateSalaryDataSeriesPV,
   generateBalanceTimeSeries,
@@ -191,5 +192,59 @@ describe("generateBalanceTimeSeries", () => {
     expect(resultLowRpi.data[1].balance).not.toBe(
       resultHighRpi.data[1].balance,
     );
+  });
+});
+
+describe("findPeakSalary", () => {
+  it("returns the salary of the highest point", () => {
+    const peak = findPeakSalary([
+      { salary: 25_000, value: 10_000 },
+      { salary: 45_000, value: 90_000 },
+      { salary: 65_000, value: 40_000 },
+    ]);
+
+    expect(peak).toBe(45_000);
+  });
+
+  it("returns the lowest salary when two points tie for the peak", () => {
+    const peak = findPeakSalary([
+      { salary: 25_000, value: 10_000 },
+      { salary: 45_000, value: 90_000 },
+      { salary: 46_000, value: 90_000 },
+    ]);
+
+    expect(peak).toBe(45_000);
+  });
+
+  it("finds a peak at either end of the series", () => {
+    expect(
+      findPeakSalary([
+        { salary: 25_000, value: 90_000 },
+        { salary: 45_000, value: 10_000 },
+      ]),
+    ).toBe(25_000);
+    expect(
+      findPeakSalary([
+        { salary: 25_000, value: 10_000 },
+        { salary: 45_000, value: 90_000 },
+      ]),
+    ).toBe(45_000);
+  });
+
+  it("throws for an empty series", () => {
+    expect(() => findPeakSalary([])).toThrow(
+      "Cannot find a peak salary in an empty series",
+    );
+  });
+
+  it("finds the peak of a real salary series", () => {
+    const data = generateSalaryDataSeries([
+      { planType: "PLAN_2", balance: 45_000 },
+    ]);
+    const peak = findPeakSalary(data);
+    const peakPoint = data.find((p) => p.salary === peak);
+
+    expect(peakPoint).toBeDefined();
+    expect(Math.max(...data.map((p) => p.value))).toBe(peakPoint?.value);
   });
 });

--- a/src/utils/loanCalculations.ts
+++ b/src/utils/loanCalculations.ts
@@ -18,6 +18,7 @@ import { pvTotal } from "@/utils/presentValue";
  * @param rpiRate - Optional RPI rate override
  * @param salaryGrowthRate - Annual salary growth rate (default 0)
  * @param thresholdGrowthRate - Annual threshold growth rate (default 0)
+ * @param interestCap - Interest cap override (default CURRENT_RATES.interestCap)
  * @returns Array of [salary, value] data points
  */
 export function generateSalaryDataSeries(
@@ -27,6 +28,7 @@ export function generateSalaryDataSeries(
   thresholdGrowthRate = 0,
   boeBaseRate: number = CURRENT_RATES.boeBaseRate,
   plan2ThresholdSchedule?: number[],
+  interestCap?: number,
 ): DataPoint[] {
   const data: DataPoint[] = [];
 
@@ -40,6 +42,7 @@ export function generateSalaryDataSeries(
       thresholdGrowthRate,
       boeBaseRate,
       plan2ThresholdSchedule,
+      interestCap,
     });
 
     data.push({ salary, value: timeSeries.summary.totalPaid });
@@ -60,6 +63,7 @@ export function generateSalaryDataSeries(
  * @param salaryGrowthRate - Annual salary growth rate (default 0)
  * @param thresholdGrowthRate - Annual threshold growth rate (default 0)
  * @param boeBaseRate - BoE base rate override
+ * @param interestCap - Interest cap override (default CURRENT_RATES.interestCap)
  * @returns Array of [salary, value] data points with PV-adjusted values
  */
 export function generateSalaryDataSeriesPV(
@@ -70,6 +74,7 @@ export function generateSalaryDataSeriesPV(
   thresholdGrowthRate = 0,
   boeBaseRate: number = CURRENT_RATES.boeBaseRate,
   plan2ThresholdSchedule?: number[],
+  interestCap?: number,
 ): DataPoint[] {
   const data: DataPoint[] = [];
 
@@ -83,6 +88,7 @@ export function generateSalaryDataSeriesPV(
       thresholdGrowthRate,
       boeBaseRate,
       plan2ThresholdSchedule,
+      interestCap,
     });
 
     const total = pvTotal(
@@ -118,6 +124,7 @@ export interface BalanceTimeSeriesResult {
  * @param rpiRate - Optional RPI rate override
  * @param salaryGrowthRate - Annual salary growth rate (default 0)
  * @param thresholdGrowthRate - Annual threshold growth rate (default 0)
+ * @param interestCap - Interest cap override (default CURRENT_RATES.interestCap)
  * @returns Balance data points and write-off month if applicable
  */
 export function generateBalanceTimeSeries(
@@ -128,6 +135,7 @@ export function generateBalanceTimeSeries(
   thresholdGrowthRate = 0,
   boeBaseRate: number = CURRENT_RATES.boeBaseRate,
   plan2ThresholdSchedule?: number[],
+  interestCap?: number,
 ): BalanceTimeSeriesResult {
   if (loans.length === 0 || loans.every((loan) => loan.balance <= 0)) {
     return { data: [], writeOffMonth: null };
@@ -142,6 +150,7 @@ export function generateBalanceTimeSeries(
     thresholdGrowthRate,
     boeBaseRate,
     plan2ThresholdSchedule,
+    interestCap,
   });
 
   const data: BalanceDataPoint[] = [];
@@ -179,4 +188,28 @@ export function generateBalanceTimeSeries(
   const writeOffMonth = hasWriteOff ? timeSeries.summary.monthsToPayoff : null;
 
   return { data, writeOffMonth };
+}
+
+/**
+ * Finds the salary at the centre of the peak repayment zone: the point in a
+ * salary series where total repaid is highest.
+ *
+ * A tie resolves to the lowest salary that reaches the maximum.
+ *
+ * @param data - Salary series, as produced by generateSalaryDataSeries
+ * @returns The salary of the highest data point
+ */
+export function findPeakSalary(data: DataPoint[]): number {
+  if (data.length === 0) {
+    throw new Error("Cannot find a peak salary in an empty series");
+  }
+
+  let peak = data[0];
+  for (const point of data) {
+    if (point.value > peak.value) {
+      peak = point;
+    }
+  }
+
+  return peak.salary;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
     },
   },
   test: {
-    environment: "jsdom",
+    environment: "./src/test/environment.ts",
     setupFiles: [resolvedWebWorker, "./src/test/setup.ts"],
     // Extend (don't replace) the defaults: losing **/node_modules/** made
     // vitest crawl dependency test suites inside .claude/worktrees/*/node_modules.


### PR DESCRIPTION
GOV.UK raised RPI from 3.2% to 4.1% for the loan year that starts in September 2026. The daily figure check has seen the new figure since 1 September and regenerated the files each day, but it could not open its own pull request because two unit tests failed against the new figure, so it reported to #626 instead. Review of the first version of this change asked for three more things: model the interest cap GOV.UK now states, make the suite pass on Node 26, and have the codegen keep the default salary on the repayment peak.

**Every interest calculation now runs on 4.1% RPI, held by the 6% interest cap.** GOV.UK's Plan 2 section reads "RPI plus up to 3%, but there's currently a limit (or 'cap') of 6%", and its table ends "£52,885 or more: 6%". The scraper reads that sentence into `CURRENT_RATES.interestCap` beside RPI, the BoE base rate and CPI, and every plan's rate is held to it in the model. A Plan 2 borrower earning above about £44,300 now accrues at 6% rather than climbing to 7.1%, and Postgraduate borrowers pay 6% rather than 7.1%. Copy that printed RPI + 3% as the ceiling now prints the capped figure, and the interest rate cap guide describes the cap as in force rather than announced. The glossary in `CONTEXT.md` gains an "Interest cap" entry. A cap move of up to two points auto-merges like the other market rates.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/QingqiShi/uk-student-loan-study/pr-assets/fix/update-rpi-to-4-1/before.png" width="450"> | <img src="https://raw.githubusercontent.com/QingqiShi/uk-student-loan-study/pr-assets/fix/update-rpi-to-4-1/after.png" width="450"> |

**The default salary is now derived from the repayment peak instead of being typed in.** The home page marks the selected salary on the total repaid curve, and the default is meant to sit on the peak, but nothing computed that. The codegen now runs the same salary sweep the home page draws, with the default preset and the default assumptions, and writes the peak into `DEFAULT_SALARY` in the generated plans file. A move of up to 15% auto-merges. At today's figures the peak is £45,000: the cap holds the top of the Plan 2 scale, and that pulls the peak back from the £48,000 it would be without the cap.

**The two tests that pinned 3.2% now take the figure from the code.** The wizard test asserts that every entry of `RPI_OPTIONS` renders, and the sparkline test uses a borrower who pays down at any plausible RPI. The next annual RPI change can auto-merge without stopping at these tests.

**The suite passes on Node 26 as well as Node 24.** Node 26 adds `localStorage` and `sessionStorage` as globals, but leaves them `undefined` unless the process starts with `--localstorage-file`. Vitest builds the jsdom environment by copying jsdom's globals onto the global scope and skips any key the scope already holds, so on Node 26 the two empty Node globals stood in front of jsdom's real web storage and it was never installed. Node 24, which CI uses, has no such global, so CI never saw the failure. The suite now runs a jsdom environment that removes those two globals before jsdom populates the scope, the same fix as shiqingqi.com PR 2613.

Closes #626
